### PR TITLE
Update Plumber to v0.3.86 (security fix)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -58,7 +58,7 @@ jobs:
       # (action pinning, overbroad permissions, curl|bash, risky triggers). It
       # uploads its SARIF to the Security tab itself (upload-sarif defaults true).
       - name: Plumber pipeline scan
-        uses: getplumber/plumber@fec66e6efa296d4e09b0399c6bff981a90d2bb74 # v0.3.73
+        uses: getplumber/plumber@a697e9c316b058d279861719c73b87093fb5a60f # v0.3.86
         with:
           # Gate below the action's default of 100 so CI stays green while the
           # findings still surface in the Security tab. Raise it as the pipelines


### PR DESCRIPTION
Hi 👋

I'm from the Plumber team. This repo pins the `getplumber/plumber` action in CI, and the version here is affected by a security issue we've just fixed (everything `<= 0.3.85`).

This PR bumps the pinned action to **v0.3.86** (SHA-pinned), which contains the fix.

We're not sharing the details publicly yet, a full advisory will be published soon. In the meantime we'd recommend updating promptly. Happy to answer anything.

Thanks! 🙏
