### PR TITLE
chore(security): clear fixable code-scanning findings

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -37,6 +37,9 @@ jobs:
           scan-type: fs
           scanners: vuln,secret,misconfig
           severity: CRITICAL,HIGH
+          # Documented, path-scoped suppressions for base-image and unused-dep
+          # findings that do not apply. See .trivyignore.yaml for the rationale.
+          trivyignores: .trivyignore.yaml
           format: sarif
           output: trivy.sarif
           # Report findings (in the Security tab) without failing the build yet;

--- a/.plumber.yaml
+++ b/.plumber.yaml
@@ -29,6 +29,12 @@ github:
         - getplumber/plumber
         - ossf/scorecard-action
         - codecov/codecov-action
+        # Docker's official actions that build and publish the base images
+        # (docker.yml), pinned by commit SHA there.
+        - docker/setup-buildx-action
+        - docker/login-action
+        - docker/metadata-action
+        - docker/build-push-action
     actionsMustNotBeArchived:
       enabled: true
     actionsMustNotCarryKnownCVEs:

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,28 @@
+# Trivy suppressions for the Security workflow (.github/workflows/security.yml).
+# Each entry records why the finding does not apply; delete one to re-surface it.
+
+misconfigurations:
+  # Build base: FROM'd to compile a bot, so the downstream COPY/`go build` and
+  # any apt install need root, like the upstream golang image it derives from.
+  # The runtime base sets a non-root USER; the final app image is the one that
+  # runs, so root here is not the attack surface.
+  - id: AVD-DS-0002
+    paths:
+      - "docker/build.Dockerfile"
+    statement: "Build toolchain base runs as root by design; the runtime/app image runs non-root."
+
+  # Both files are base images, not runnable services: the build base only
+  # compiles, and the runtime base has no ENTRYPOINT (downstream adds one).
+  # HEALTHCHECK belongs on the concrete application image.
+  - id: AVD-DS-0026
+    paths:
+      - "docker/build.Dockerfile"
+      - "docker/runtime.Dockerfile"
+    statement: "Base images have no long-running process to health-check; the app image defines HEALTHCHECK."
+
+vulnerabilities:
+  # golang.org/x/crypto is an indirect dependency; the flagged openpgp
+  # subpackage is not imported (`go mod why` reports it is not needed), and the
+  # advisory has no fixed version because the package is frozen upstream.
+  - id: GO-2026-5932
+    statement: "Unused indirect dependency: openpgp is not imported and has no fixed version upstream."

--- a/docker/runtime.Dockerfile
+++ b/docker/runtime.Dockerfile
@@ -47,5 +47,9 @@ COPY --from=libs /usr/lib/x86_64-linux-gnu/libopus.so.0* /usr/lib/x86_64-linux-g
 COPY --from=libs /usr/local/lib/libonnxruntime.so /usr/local/lib/libonnxruntime.so
 ENV JARGO_ONNXRUNTIME_LIB=/usr/local/lib/libonnxruntime.so
 
+# The distroless base already defaults to the non-root user; state it
+# explicitly so it is enforced and visible to scanners.
+USER nonroot
+
 # jargo example bots serve on :8080 (informational; downstream can override).
 EXPOSE 8080


### PR DESCRIPTION
## What

Clears the code-fixable alerts on the **Security** tab. Each finding is either
fixed properly or suppressed with a documented, path-scoped reason.

| Finding (source) | Change |
|---|---|
| `AVD-DS-0002` root user — `runtime.Dockerfile` (Trivy, HIGH) | **Fixed** — explicit `USER nonroot`. The distroless base is already the `:nonroot` variant; this makes it visible to the scanner and enforced. |
| `ISSUE-713` action from unauthorized source ×4 (Plumber, HIGH) | **Fixed** — added the official `docker/*` actions used by `docker.yml` to `githubActionMustComeFromAuthorizedSources.trustedGithubActions`. They are already SHA-pinned in the workflow. |
| `AVD-DS-0002` root — `build.Dockerfile` (Trivy, HIGH) | **Documented ignore** — build toolchain base runs as root like the upstream `golang` image it derives from; the runtime/app image runs non-root. |
| `AVD-DS-0026` no HEALTHCHECK — both Dockerfiles (Trivy, LOW) | **Documented ignore** — base images with no long-running process; the concrete app image defines `HEALTHCHECK`. |
| `GO-2026-5932` openpgp unmaintained (note) | **Documented ignore** — `golang.org/x/crypto` is indirect and `openpgp` is not imported (`go mod why` confirms), with no fixed version upstream. |

Suppressions live in a new `.trivyignore.yaml` (path-scoped, each with a
`statement:`) and are wired via the trivy step's `trivyignores` input.

## Not included

OpenSSF Scorecard items — `Code-Review`, `Maintained`, `CII-Best-Practices`,
`SAST`, `CI-Tests`, `Vulnerabilities` — are repo settings / process (branch
protection, badge enrolment), not code changes.

## Notes

- No behaviour change to the scans beyond the documented suppressions; all other
  Plumber controls and Trivy scanners are untouched.
- Alerts close once the Security workflow re-runs on this branch/PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
