### PR TITLE
fix: green CI (atomic.Int64 in probe, wget for librnnoise build)

### DIFF
--- a/audio/turn/onnxprobe_test.go
+++ b/audio/turn/onnxprobe_test.go
@@ -110,7 +110,7 @@ func TestSmartTurnSchedulerProbe(t *testing.T) {
 func probeOnce(
 	sessions []*onnxrt.Session, in []onnxrt.Tensor, dur time.Duration,
 ) (p50, p99, mx time.Duration, runsPerSec float64) {
-	var runs int64
+	var runs atomic.Int64
 	stop := make(chan struct{})
 	var wg sync.WaitGroup
 	for _, s := range sessions {
@@ -126,7 +126,7 @@ func probeOnce(
 				if _, err := s.Run(in); err != nil {
 					return
 				}
-				atomic.AddInt64(&runs, 1)
+				runs.Add(1)
 			}
 		}(s)
 	}
@@ -146,7 +146,7 @@ func probeOnce(
 
 	slices.Sort(delays)
 	return pct(delays, 50), pct(delays, 99), delays[len(delays)-1],
-		float64(atomic.LoadInt64(&runs)) / elapsed.Seconds()
+		float64(runs.Load()) / elapsed.Seconds()
 }
 
 func pct(sorted []time.Duration, p int) time.Duration {

--- a/docker/runtime.Dockerfile
+++ b/docker/runtime.Dockerfile
@@ -22,7 +22,7 @@ ARG ORT_VERSION=1.26.0
 ARG TARGETARCH=amd64
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        ca-certificates curl libsoxr0 libopus0 \
+        ca-certificates curl wget libsoxr0 libopus0 \
         git build-essential autoconf automake libtool \
     && rm -rf /var/lib/apt/lists/*
 RUN set -eux; \


### PR DESCRIPTION
Two CI failures from #15:

- **CI lint**: `onnxprobe_test.go` used a plain `int64` with `atomic.AddInt64`; CI's golangci-lint `modernize/atomictypes` wants `atomic.Int64`.
- **Docker (exit 127)**: the runtime image's librnnoise build ran RNNoise's `autogen.sh`, which downloads the model with `wget` — not installed. Reproduced and fixed with a local `docker build`.