### PR TITLE
chore: disable commit/PR attribution via project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  }
+}


### PR DESCRIPTION
Adds `.claude/settings.json` with an `attribution` key whose `commit` and `pr` templates are empty strings, so no automated authorship line is added to commits or pull requests.