### PR TITLE
chore(release): sign release checksums with keyless cosign

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
     # GoReleaser creates the GitHub Release and uploads the built artifacts.
     permissions:
       contents: write
+      id-token: write # OIDC token for keyless cosign signing
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -21,6 +22,8 @@ jobs:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: go.mod
+      # cosign, used by GoReleaser's signs step to keyless-sign the checksums.
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
         with:
           version: latest

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -40,6 +40,25 @@ archives:
 checksum:
   name_template: "checksums.txt"
 
+# Sign the checksums file with cosign keyless (Sigstore/OIDC in CI), which
+# transitively covers every release artifact. Produces checksums.txt.sig and
+# checksums.txt.pem release assets, satisfying OSSF Scorecard's Signed-Releases
+# check. Verify with:
+#   cosign verify-blob --certificate checksums.txt.pem \
+#     --signature checksums.txt.sig checksums.txt
+signs:
+  - cmd: cosign
+    signature: "${artifact}.sig"
+    certificate: "${artifact}.pem"
+    args:
+      - sign-blob
+      - "--output-signature=${signature}"
+      - "--output-certificate=${certificate}"
+      - "${artifact}"
+      - "--yes"
+    artifacts: checksum
+    output: true
+
 changelog:
   use: github
   sort: asc

--- a/.plumber.yaml
+++ b/.plumber.yaml
@@ -32,6 +32,8 @@ github:
         # Security scanners in the security workflow, pinned by commit SHA there.
         - snyk/actions
         - trufflesecurity/trufflehog
+        # Release signing (release.yml), pinned by commit SHA there.
+        - sigstore/cosign-installer
         # Docker's official actions that build and publish the base images
         # (docker.yml), pinned by commit SHA there.
         - docker/setup-buildx-action


### PR DESCRIPTION
Signs `checksums.txt` with **cosign keyless** (Sigstore/OIDC) in the release pipeline, producing `checksums.txt.sig` + `checksums.txt.pem` release assets that transitively cover every artifact — satisfying [OSSF Scorecard's Signed-Releases](https://github.com/ossf/scorecard/blob/main/docs/checks.md#signed-releases) check.

- `.goreleaser.yaml`: add a `signs` block (cosign `sign-blob`, artifacts: checksum). Validated with `goreleaser check`.
- `release.yml`: add `id-token: write` (OIDC) and a SHA-pinned `sigstore/cosign-installer` step.
- `.plumber.yaml`: trust `sigstore/cosign-installer`.

No signing secrets to manage. Takes effect on the next tagged release; verify with `cosign verify-blob --certificate checksums.txt.pem --signature checksums.txt.sig checksums.txt`.