### PR TITLE
fix(release): pin cosign to 2.4.x for classic .sig/.pem signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,12 @@ jobs:
         with:
           go-version-file: go.mod
       # cosign, used by GoReleaser's signs step to keyless-sign the checksums.
+      # Pinned to 2.4.x: cosign 2.5+ defaults to the new bundle format, which
+      # deprecates --output-signature/--output-certificate and would stop
+      # producing the .sig/.pem assets the Signed-Releases check looks for.
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: "v2.4.3"
       - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
         with:
           version: latest


### PR DESCRIPTION
The v0.0.4 release job failed at the signing step: cosign 2.5+ defaults to the new bundle format and ignores `--output-signature`/`--output-certificate`, so GoReleaser errored with `create bundle file: open : no such file`.

Pins the cosign binary to **v2.4.3** (via cosign-installer's `cosign-release`), which still emits `checksums.txt.sig` + `checksums.txt.pem` — the assets OSSF Scorecard's Signed-Releases check looks for. Then the v0.0.4 tag will be re-cut on the fixed commit.