### PR TITLE
feat(transport): add Plivo, Telnyx, and Exotel telephony serializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+- **Telephony serializers for Plivo, Telnyx, and Exotel.** Three new
+  `wsserver.Serializer` implementations alongside the existing Twilio one:
+  Plivo (`transport/wsserver/plivo`, μ-law with REST auto-hang-up), Telnyx
+  (`transport/wsserver/telnyx`, μ-law **and** A-law, receive encoding learned
+  from the stream, REST auto-hang-up), and Exotel (`transport/wsserver/exotel`,
+  raw 16-bit PCM). Each learns its stream/call identifiers from the inbound
+  `start` message and emits a barge-in clear on interruption.
+- **G.711 A-law codec** (`audio/g711`): `EncodeALaw`/`DecodeALaw` join the
+  existing μ-law pair, for PSTN audio outside North America (Telnyx PCMA).
+
 ## [0.0.4] - 2026-07-12
 
 ### Added

--- a/audio/g711/alaw.go
+++ b/audio/g711/alaw.go
@@ -1,0 +1,107 @@
+package g711
+
+const (
+	// alawQuantMask selects the quantization bits of an A-law byte.
+	alawQuantMask = 0x0F
+	// alawSegMask selects the segment bits; alawSegShift positions them.
+	alawSegMask  = 0x70
+	alawSegShift = 4
+	// alawEvenBits toggles the even bits, the A-law even-bit inversion applied on
+	// both encode and decode.
+	alawEvenBits = 0x55
+)
+
+// alawSegEnd holds the upper bound of each of the eight A-law segments.
+//
+//nolint:gochecknoglobals // immutable codec table
+var alawSegEnd = [8]int16{0x1F, 0x3F, 0x7F, 0xFF, 0x1FF, 0x3FF, 0x7FF, 0xFFF}
+
+// alawDecodeTable expands each A-law byte to its 16-bit PCM sample.
+//
+//nolint:gochecknoglobals // immutable codec table, built once
+var alawDecodeTable = buildALawDecodeTable()
+
+// EncodeALaw encodes 16-bit signed little-endian PCM to A-law (G.711 PCMA),
+// returning one byte per sample. A trailing odd byte is ignored. A-law is the
+// PSTN companding used outside North America (Telnyx's PCMA encoding).
+func EncodeALaw(pcm []byte) []byte {
+	out := make([]byte, len(pcm)/2)
+	for i := 0; i+1 < len(pcm); i += 2 {
+		sample := int16(uint16(pcm[i]) | uint16(pcm[i+1])<<8)
+		out[i/2] = linearToALaw(sample)
+	}
+	return out
+}
+
+// DecodeALaw decodes A-law bytes to 16-bit signed little-endian PCM, returning
+// two bytes per input byte.
+func DecodeALaw(alaw []byte) []byte {
+	out := make([]byte, len(alaw)*2)
+	for i, a := range alaw {
+		s := uint16(alawDecodeTable[a])
+		out[i*2] = byte(s)
+		out[i*2+1] = byte(s >> 8)
+	}
+	return out
+}
+
+func linearToALaw(pcm int16) byte {
+	v := pcm >> 3 // scale 16-bit to the codec's 13-bit range
+	var mask int16
+	if v >= 0 {
+		mask = 0xD5
+	} else {
+		v = -v - 1
+		mask = alawEvenBits
+	}
+
+	seg := alawSegment(v)
+	if seg >= 8 {
+		return byte(0x7F ^ mask)
+	}
+	aval := int16(seg << alawSegShift)
+	if seg < 2 {
+		aval |= (v >> 1) & alawQuantMask
+	} else {
+		aval |= (v >> uint(seg)) & alawQuantMask
+	}
+	return byte(aval ^ mask)
+}
+
+// alawSegment returns the index of the segment v falls in, or 8 if it exceeds
+// the last segment.
+func alawSegment(v int16) int {
+	for i, end := range alawSegEnd {
+		if v <= end {
+			return i
+		}
+	}
+	return 8
+}
+
+func alawToLinear(a byte) int16 {
+	a ^= alawEvenBits
+	t := int16(a&alawQuantMask) << 4
+	seg := (int(a) & alawSegMask) >> alawSegShift
+	switch seg {
+	case 0:
+		t += 8
+	case 1:
+		t += 0x108
+	default:
+		t += 0x108
+		t <<= uint(seg - 1)
+	}
+	if a&0x80 != 0 {
+		return t
+	}
+	return -t
+}
+
+func buildALawDecodeTable() [256]int16 {
+	var t [256]int16
+	for i := range 256 {
+		t[i] = alawToLinear(byte(i))
+	}
+	return t
+}

--- a/audio/g711/alaw_test.go
+++ b/audio/g711/alaw_test.go
@@ -1,0 +1,59 @@
+package g711
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// TestALawDomainIdempotent mirrors the μ-law idempotency check: decoding an
+// A-law byte yields a canonical reconstruction level, so re-encoding it must
+// return the same byte.
+func TestALawDomainIdempotent(t *testing.T) {
+	for a := range 256 {
+		pcm := DecodeALaw([]byte{byte(a)})
+		re := EncodeALaw(pcm)[0]
+		if re != byte(a) {
+			sample := int16(binary.LittleEndian.Uint16(pcm))
+			t.Fatalf("re-encode A-law 0x%02X: decoded %d re-encoded 0x%02X", a, sample, re)
+		}
+	}
+}
+
+// TestALawLinearRoundTripRelative sweeps the 16-bit range and checks the
+// round-trip error stays within A-law's companded resolution.
+func TestALawLinearRoundTripRelative(t *testing.T) {
+	for s := -32768; s <= 32767; s += 7 {
+		var b [2]byte
+		binary.LittleEndian.PutUint16(b[:], uint16(int16(s)))
+		out := int16(binary.LittleEndian.Uint16(DecodeALaw(EncodeALaw(b[:]))))
+		bound := abs(s)/8 + 256
+		if d := abs(s - int(out)); d > bound {
+			t.Fatalf("sample %d round-tripped to %d (diff %d > %d)", s, out, d, bound)
+		}
+	}
+}
+
+// TestALawEncodeLengths verifies the byte ratios and that an odd trailing byte
+// is ignored rather than panicking.
+func TestALawEncodeLengths(t *testing.T) {
+	if got := len(EncodeALaw(make([]byte, 320))); got != 160 {
+		t.Fatalf("encode 320 PCM bytes: got %d A-law bytes want 160", got)
+	}
+	if got := len(DecodeALaw(make([]byte, 160))); got != 320 {
+		t.Fatalf("decode 160 A-law bytes: got %d PCM bytes want 320", got)
+	}
+	if got := len(EncodeALaw(make([]byte, 5))); got != 2 {
+		t.Fatalf("odd trailing byte: got %d want 2", got)
+	}
+}
+
+// TestALawSilenceRoundTrip checks that digital silence stays quiet through the
+// A-law round trip (A-law has no exact zero, so a small residual is expected).
+func TestALawSilenceRoundTrip(t *testing.T) {
+	decoded := DecodeALaw(EncodeALaw(make([]byte, 160)))
+	for i := 0; i < len(decoded); i += 2 {
+		if v := int16(binary.LittleEndian.Uint16(decoded[i:])); v < -8 || v > 8 {
+			t.Fatalf("silence sample %d decoded to %d", i/2, v)
+		}
+	}
+}

--- a/audio/g711/g711.go
+++ b/audio/g711/g711.go
@@ -1,8 +1,9 @@
-// Package g711 implements the ITU-T G.711 μ-law companding codec used by
-// telephony media streams (Twilio, Telnyx, Plivo and the wider PSTN). It
-// converts between 16-bit signed little-endian PCM and 8-bit μ-law, one byte per
-// sample, mono. The algorithm is the canonical Sun reference implementation, so
-// it round-trips with audioop.lin2ulaw/ulaw2lin and the like.
+// Package g711 implements the ITU-T G.711 companding codecs used by telephony
+// media streams (Twilio, Telnyx, Plivo and the wider PSTN): μ-law (PCMU), the
+// North American variant, and A-law (PCMA), used elsewhere. Both convert between
+// 16-bit signed little-endian PCM and 8-bit companded samples, one byte per
+// sample, mono. The algorithms are the canonical Sun reference implementations,
+// so they round-trip with audioop.lin2ulaw/ulaw2lin and lin2alaw/alaw2lin.
 package g711
 
 const (

--- a/transport/wsserver/exotel/exotel.go
+++ b/transport/wsserver/exotel/exotel.go
@@ -1,0 +1,145 @@
+// Package exotel is the wsserver.Serializer for Exotel Media Streaming (the
+// Voicebot applet). Unlike the μ-law telephony providers, Exotel streams raw
+// 16-bit signed little-endian PCM (base64-encoded) at 8 kHz mono; this
+// serializer base64-codes it to and from jargo audio frames and emits a "clear"
+// message on barge-in. Exotel provides no media-stream hang-up API, so ending
+// the call is left to the applet flow.
+package exotel
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"sync"
+
+	"github.com/gojargo/jargo/frames"
+	"github.com/gojargo/jargo/transport/wsserver"
+)
+
+// Serializer implements wsserver.Serializer.
+var _ wsserver.Serializer = (*Serializer)(nil)
+
+// defaultSampleRate is Exotel's default stream rate. Exotel also supports 16 kHz;
+// set Config.SampleRate to match and run the pipeline at the same rate.
+const defaultSampleRate = 8000
+
+// Config configures the Exotel serializer.
+type Config struct {
+	// SampleRate is the PCM rate of the Exotel stream in Hz; 0 defaults to 8000.
+	// The pipeline must run at this rate, since the serializer does not resample.
+	SampleRate int
+}
+
+// Serializer implements wsserver.Serializer for Exotel. The stream SID is
+// learned from the inbound "start" message.
+type Serializer struct {
+	rate int
+
+	mu        sync.Mutex
+	streamSID string
+}
+
+// New builds an Exotel serializer.
+func New(cfg Config) *Serializer {
+	rate := cfg.SampleRate
+	if rate == 0 {
+		rate = defaultSampleRate
+	}
+	return &Serializer{rate: rate}
+}
+
+// Setup is a no-op: the stream rate is fixed by Config.
+func (s *Serializer) Setup(*frames.StartFrame) error { return nil }
+
+// Serialize converts an outbound frame to an Exotel message.
+func (s *Serializer) Serialize(f frames.Frame) ([]byte, error) {
+	switch fr := f.(type) {
+	case *frames.TTSAudioRawFrame:
+		return s.media(fr.Audio)
+	case *frames.OutputAudioRawFrame:
+		return s.media(fr.Audio)
+	case *frames.InterruptionFrame:
+		return s.clear()
+	default:
+		return nil, nil //nolint:nilnil // frame not sent to Exotel
+	}
+}
+
+// Deserialize converts an Exotel message to a frame.
+func (s *Serializer) Deserialize(data []byte) (frames.Frame, error) {
+	var m inbound
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, err
+	}
+	switch m.Event {
+	case "media":
+		pcm, err := base64.StdEncoding.DecodeString(m.Media.Payload)
+		if err != nil {
+			return nil, err
+		}
+		return frames.NewInputAudioRawFrame(pcm, s.rate, 1), nil
+	case "start":
+		s.mu.Lock()
+		s.streamSID = m.Start.StreamSID
+		s.mu.Unlock()
+		return nil, nil //nolint:nilnil // handshake message carries no frame
+	case "dtmf":
+		if m.DTMF.Digit == "" {
+			return nil, nil //nolint:nilnil // empty keypress
+		}
+		return frames.NewInputDTMFFrame(frames.KeypadEntry(m.DTMF.Digit)), nil
+	default: // connected, mark, stop
+		return nil, nil //nolint:nilnil // message carries no frame
+	}
+}
+
+func (s *Serializer) media(pcm []byte) ([]byte, error) {
+	s.mu.Lock()
+	sid := s.streamSID
+	s.mu.Unlock()
+	if sid == "" {
+		return nil, nil //nolint:nilnil // stream not started yet; drop until "start" arrives
+	}
+	out := mediaOut{Event: "media", StreamSID: sid}
+	out.Media.Payload = base64.StdEncoding.EncodeToString(pcm)
+	return json.Marshal(out)
+}
+
+func (s *Serializer) clear() ([]byte, error) {
+	s.mu.Lock()
+	sid := s.streamSID
+	s.mu.Unlock()
+	if sid == "" {
+		return nil, nil //nolint:nilnil // stream not started yet; nothing to clear
+	}
+	return json.Marshal(clearOut{Event: "clear", StreamSID: sid})
+}
+
+// The JSON field names below are Exotel's wire protocol (camelCase for the
+// outbound streamSid), so the snake_case house style does not apply.
+
+type mediaOut struct {
+	Event     string `json:"event"`
+	StreamSID string `json:"streamSid"` //nolint:tagliatelle // Exotel wire field
+	Media     struct {
+		Payload string `json:"payload"`
+	} `json:"media"`
+}
+
+type clearOut struct {
+	Event     string `json:"event"`
+	StreamSID string `json:"streamSid"` //nolint:tagliatelle // Exotel wire field
+}
+
+type inbound struct {
+	Event string `json:"event"`
+	Media struct {
+		Payload string `json:"payload"`
+	} `json:"media"`
+	Start struct {
+		StreamSID string `json:"stream_sid"`
+		CallSID   string `json:"call_sid"`
+	} `json:"start"`
+	DTMF struct {
+		Digit string `json:"digit"`
+	} `json:"dtmf"`
+}

--- a/transport/wsserver/exotel/exotel_test.go
+++ b/transport/wsserver/exotel/exotel_test.go
@@ -1,0 +1,94 @@
+package exotel
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/gojargo/jargo/frames"
+)
+
+func pcm() []byte {
+	b := make([]byte, 160*2)
+	for i := range b {
+		b[i] = byte(i)
+	}
+	return b
+}
+
+func TestDeserializeMediaIsRawPCM(t *testing.T) {
+	s := New(Config{})
+	payload := base64.StdEncoding.EncodeToString(pcm())
+	f, err := s.Deserialize([]byte(`{"event":"media","media":{"payload":"` + payload + `"}}`))
+	if err != nil {
+		t.Fatalf("deserialize media: %v", err)
+	}
+	af, ok := f.(*frames.InputAudioRawFrame)
+	if !ok {
+		t.Fatalf("media frame type = %T", f)
+	}
+	if af.SampleRate != defaultSampleRate {
+		t.Fatalf("sample rate = %d, want %d", af.SampleRate, defaultSampleRate)
+	}
+	// Exotel is raw PCM: the decoded bytes must match the input exactly.
+	if !bytes.Equal(af.Audio, pcm()) {
+		t.Fatalf("decoded audio does not round-trip raw PCM")
+	}
+}
+
+func TestSerializeAudioAfterStart(t *testing.T) {
+	s := New(Config{})
+	start := `{"event":"start","start":{"stream_sid":"stream-1","call_sid":"call-1"}}`
+	if _, err := s.Deserialize([]byte(start)); err != nil {
+		t.Fatalf("deserialize start: %v", err)
+	}
+	msg, err := s.Serialize(frames.NewTTSAudioRawFrame(pcm(), defaultSampleRate, 1))
+	if err != nil {
+		t.Fatalf("serialize audio: %v", err)
+	}
+	var out mediaOut
+	if err := json.Unmarshal(msg, &out); err != nil {
+		t.Fatalf("unmarshal media: %v", err)
+	}
+	if out.Event != "media" || out.StreamSID != "stream-1" {
+		t.Fatalf("media = %+v", out)
+	}
+	raw, err := base64.StdEncoding.DecodeString(out.Media.Payload)
+	if err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	// Raw PCM out: no companding, so bytes are unchanged.
+	if !bytes.Equal(raw, pcm()) {
+		t.Fatalf("payload is not raw PCM")
+	}
+}
+
+func TestSerializeAudioDroppedBeforeStart(t *testing.T) {
+	s := New(Config{})
+	msg, err := s.Serialize(frames.NewTTSAudioRawFrame(pcm(), defaultSampleRate, 1))
+	if err != nil {
+		t.Fatalf("serialize audio: %v", err)
+	}
+	if msg != nil {
+		t.Fatalf("audio before start should be dropped, got %q", msg)
+	}
+}
+
+func TestSerializeInterruption(t *testing.T) {
+	s := New(Config{})
+	if _, err := s.Deserialize([]byte(`{"event":"start","start":{"stream_sid":"stream-1"}}`)); err != nil {
+		t.Fatalf("deserialize start: %v", err)
+	}
+	msg, err := s.Serialize(frames.NewInterruptionFrame())
+	if err != nil {
+		t.Fatalf("serialize interruption: %v", err)
+	}
+	var out clearOut
+	if err := json.Unmarshal(msg, &out); err != nil {
+		t.Fatalf("unmarshal clear: %v", err)
+	}
+	if out.Event != "clear" || out.StreamSID != "stream-1" {
+		t.Fatalf("clear = %+v", out)
+	}
+}

--- a/transport/wsserver/plivo/plivo.go
+++ b/transport/wsserver/plivo/plivo.go
@@ -1,0 +1,201 @@
+// Package plivo is the wsserver.Serializer for Plivo Audio Streaming. Plivo
+// streams call audio as base64 μ-law 8 kHz mono in JSON text messages; this
+// serializer converts those to and from jargo audio frames, emits a "clearAudio"
+// message on barge-in, and optionally hangs the call up over Plivo's REST API
+// when the pipeline ends.
+package plivo
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sync"
+
+	"github.com/gojargo/jargo/audio/g711"
+	"github.com/gojargo/jargo/frames"
+	"github.com/gojargo/jargo/transport/wsserver"
+)
+
+// Serializer implements wsserver.Serializer.
+var _ wsserver.Serializer = (*Serializer)(nil)
+
+const (
+	// sampleRate is Plivo Audio Streaming's fixed rate: 8 kHz mono μ-law.
+	sampleRate = 8000
+	hangupURL  = "https://api.plivo.com/v1/Account/%s/Call/%s/"
+)
+
+// Config configures the Plivo serializer.
+type Config struct {
+	// AuthID and AuthToken authorize the REST hang-up call. They are only needed
+	// when AutoHangUp is set.
+	AuthID    string
+	AuthToken string
+	// AutoHangUp ends the Plivo call over the REST API when the pipeline sends an
+	// EndFrame or CancelFrame.
+	AutoHangUp bool
+	// HTTPClient is used for the hang-up request; nil uses http.DefaultClient.
+	HTTPClient *http.Client
+}
+
+// Serializer implements wsserver.Serializer for Plivo. The stream and call IDs
+// are learned from the inbound "start" message.
+type Serializer struct {
+	cfg  Config
+	http *http.Client
+
+	mu       sync.Mutex
+	streamID string
+	callID   string
+	hungUp   bool
+}
+
+// New builds a Plivo serializer.
+func New(cfg Config) *Serializer {
+	h := cfg.HTTPClient
+	if h == nil {
+		h = http.DefaultClient
+	}
+	return &Serializer{cfg: cfg, http: h}
+}
+
+// Setup is a no-op: Plivo audio is always 8 kHz.
+func (s *Serializer) Setup(*frames.StartFrame) error { return nil }
+
+// Serialize converts an outbound frame to a Plivo message.
+func (s *Serializer) Serialize(f frames.Frame) ([]byte, error) {
+	switch fr := f.(type) {
+	case *frames.TTSAudioRawFrame:
+		return s.media(fr.Audio)
+	case *frames.OutputAudioRawFrame:
+		return s.media(fr.Audio)
+	case *frames.InterruptionFrame:
+		return s.clear()
+	case *frames.EndFrame, *frames.CancelFrame:
+		s.hangup()
+		return nil, nil //nolint:nilnil // hang-up is a side effect; no wire message
+	default:
+		return nil, nil //nolint:nilnil // frame not sent to Plivo
+	}
+}
+
+// Deserialize converts a Plivo message to a frame.
+func (s *Serializer) Deserialize(data []byte) (frames.Frame, error) {
+	var m inbound
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, err
+	}
+	switch m.Event {
+	case "media":
+		ulaw, err := base64.StdEncoding.DecodeString(m.Media.Payload)
+		if err != nil {
+			return nil, err
+		}
+		return frames.NewInputAudioRawFrame(g711.DecodeULaw(ulaw), sampleRate, 1), nil
+	case "start":
+		s.mu.Lock()
+		s.streamID = m.Start.StreamID
+		s.callID = m.Start.CallID
+		s.mu.Unlock()
+		return nil, nil //nolint:nilnil // handshake message carries no frame
+	case "dtmf":
+		if m.DTMF.Digit == "" {
+			return nil, nil //nolint:nilnil // empty keypress
+		}
+		return frames.NewInputDTMFFrame(frames.KeypadEntry(m.DTMF.Digit)), nil
+	default: // connected, checkpoint, clearedAudio
+		return nil, nil //nolint:nilnil // message carries no frame
+	}
+}
+
+func (s *Serializer) media(pcm []byte) ([]byte, error) {
+	s.mu.Lock()
+	id := s.streamID
+	s.mu.Unlock()
+	if id == "" {
+		return nil, nil //nolint:nilnil // stream not started yet; drop until "start" arrives
+	}
+	out := playAudio{Event: "playAudio", StreamID: id}
+	out.Media.ContentType = "audio/x-mulaw"
+	out.Media.SampleRate = sampleRate
+	out.Media.Payload = base64.StdEncoding.EncodeToString(g711.EncodeULaw(pcm))
+	return json.Marshal(out)
+}
+
+func (s *Serializer) clear() ([]byte, error) {
+	s.mu.Lock()
+	id := s.streamID
+	s.mu.Unlock()
+	if id == "" {
+		return nil, nil //nolint:nilnil // stream not started yet; nothing to clear
+	}
+	return json.Marshal(clearAudio{Event: "clearAudio", StreamID: id})
+}
+
+func (s *Serializer) hangup() {
+	if !s.cfg.AutoHangUp {
+		return
+	}
+	s.mu.Lock()
+	ready := !s.hungUp && s.callID != "" && s.cfg.AuthID != "" && s.cfg.AuthToken != ""
+	if ready {
+		s.hungUp = true
+	}
+	callID := s.callID
+	s.mu.Unlock()
+	if !ready {
+		return
+	}
+	go s.doHangup(callID)
+}
+
+func (s *Serializer) doHangup(callID string) {
+	endpoint := fmt.Sprintf(hangupURL, s.cfg.AuthID, callID)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodDelete, endpoint, nil)
+	if err != nil {
+		slog.Warn("plivo: build hang-up request", "err", err)
+		return
+	}
+	req.SetBasicAuth(s.cfg.AuthID, s.cfg.AuthToken)
+	resp, err := s.http.Do(req)
+	if err != nil {
+		slog.Warn("plivo: hang-up call", "err", err)
+		return
+	}
+	_ = resp.Body.Close()
+}
+
+// The JSON field names below are Plivo's wire protocol (camelCase), so the
+// snake_case house style does not apply.
+
+type playAudio struct {
+	Event string `json:"event"`
+	Media struct {
+		ContentType string `json:"contentType"` //nolint:tagliatelle // Plivo wire field
+		SampleRate  int    `json:"sampleRate"`  //nolint:tagliatelle // Plivo wire field
+		Payload     string `json:"payload"`
+	} `json:"media"`
+	StreamID string `json:"streamId"` //nolint:tagliatelle // Plivo wire field
+}
+
+type clearAudio struct {
+	Event    string `json:"event"`
+	StreamID string `json:"streamId"` //nolint:tagliatelle // Plivo wire field
+}
+
+type inbound struct {
+	Event string `json:"event"`
+	Media struct {
+		Payload string `json:"payload"`
+	} `json:"media"`
+	Start struct {
+		StreamID string `json:"streamId"` //nolint:tagliatelle // Plivo wire field
+		CallID   string `json:"callId"`   //nolint:tagliatelle // Plivo wire field
+	} `json:"start"`
+	DTMF struct {
+		Digit string `json:"digit"`
+	} `json:"dtmf"`
+}

--- a/transport/wsserver/plivo/plivo_test.go
+++ b/transport/wsserver/plivo/plivo_test.go
@@ -1,0 +1,115 @@
+package plivo
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/gojargo/jargo/audio/g711"
+	"github.com/gojargo/jargo/frames"
+)
+
+// silence is 20 ms of 8 kHz mono PCM (160 samples).
+func silence() []byte { return make([]byte, 160*2) }
+
+func TestDeserializeStartThenMedia(t *testing.T) {
+	s := New(Config{})
+
+	start := `{"event":"start","start":{"streamId":"stream-1","callId":"call-1"}}`
+	f, err := s.Deserialize([]byte(start))
+	if err != nil {
+		t.Fatalf("deserialize start: %v", err)
+	}
+	if f != nil {
+		t.Fatalf("start should carry no frame, got %T", f)
+	}
+
+	payload := base64.StdEncoding.EncodeToString(g711.EncodeULaw(silence()))
+	media := `{"event":"media","media":{"payload":"` + payload + `"}}`
+	f, err = s.Deserialize([]byte(media))
+	if err != nil {
+		t.Fatalf("deserialize media: %v", err)
+	}
+	af, ok := f.(*frames.InputAudioRawFrame)
+	if !ok {
+		t.Fatalf("media frame type = %T, want *InputAudioRawFrame", f)
+	}
+	if af.SampleRate != sampleRate || af.NumChannels != 1 {
+		t.Fatalf("media frame = %d Hz/%d ch, want %d/1", af.SampleRate, af.NumChannels, sampleRate)
+	}
+	if len(af.Audio) != len(silence()) {
+		t.Fatalf("decoded audio len = %d, want %d", len(af.Audio), len(silence()))
+	}
+}
+
+func TestDeserializeDTMF(t *testing.T) {
+	s := New(Config{})
+	f, err := s.Deserialize([]byte(`{"event":"dtmf","dtmf":{"digit":"5"}}`))
+	if err != nil {
+		t.Fatalf("deserialize dtmf: %v", err)
+	}
+	d, ok := f.(*frames.InputDTMFFrame)
+	if !ok {
+		t.Fatalf("dtmf frame type = %T, want *InputDTMFFrame", f)
+	}
+	if d.Button != frames.KeypadFive {
+		t.Fatalf("dtmf button = %q, want 5", d.Button)
+	}
+}
+
+func TestSerializeAudioDroppedBeforeStart(t *testing.T) {
+	s := New(Config{})
+	msg, err := s.Serialize(frames.NewTTSAudioRawFrame(silence(), sampleRate, 1))
+	if err != nil {
+		t.Fatalf("serialize audio: %v", err)
+	}
+	if msg != nil {
+		t.Fatalf("audio before start should be dropped, got %q", msg)
+	}
+}
+
+func TestSerializeAudioAfterStart(t *testing.T) {
+	s := New(Config{})
+	if _, err := s.Deserialize([]byte(`{"event":"start","start":{"streamId":"stream-1"}}`)); err != nil {
+		t.Fatalf("deserialize start: %v", err)
+	}
+	msg, err := s.Serialize(frames.NewTTSAudioRawFrame(silence(), sampleRate, 1))
+	if err != nil {
+		t.Fatalf("serialize audio: %v", err)
+	}
+	var out playAudio
+	if err := json.Unmarshal(msg, &out); err != nil {
+		t.Fatalf("unmarshal playAudio: %v", err)
+	}
+	if out.Event != "playAudio" || out.StreamID != "stream-1" {
+		t.Fatalf("playAudio = %+v, want event playAudio / stream-1", out)
+	}
+	if out.Media.ContentType != "audio/x-mulaw" || out.Media.SampleRate != sampleRate {
+		t.Fatalf("media header = %+v", out.Media)
+	}
+	raw, err := base64.StdEncoding.DecodeString(out.Media.Payload)
+	if err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if len(raw) != len(silence())/2 {
+		t.Fatalf("μ-law payload len = %d, want %d", len(raw), len(silence())/2)
+	}
+}
+
+func TestSerializeInterruption(t *testing.T) {
+	s := New(Config{})
+	if _, err := s.Deserialize([]byte(`{"event":"start","start":{"streamId":"stream-1"}}`)); err != nil {
+		t.Fatalf("deserialize start: %v", err)
+	}
+	msg, err := s.Serialize(frames.NewInterruptionFrame())
+	if err != nil {
+		t.Fatalf("serialize interruption: %v", err)
+	}
+	var out clearAudio
+	if err := json.Unmarshal(msg, &out); err != nil {
+		t.Fatalf("unmarshal clearAudio: %v", err)
+	}
+	if out.Event != "clearAudio" || out.StreamID != "stream-1" {
+		t.Fatalf("clearAudio = %+v", out)
+	}
+}

--- a/transport/wsserver/telnyx/telnyx.go
+++ b/transport/wsserver/telnyx/telnyx.go
@@ -1,0 +1,215 @@
+// Package telnyx is the wsserver.Serializer for Telnyx Media Streaming. Telnyx
+// streams call audio as base64 companded 8 kHz mono (μ-law or A-law) in JSON
+// text messages; this serializer converts those to and from jargo audio frames,
+// emits a "clear" message on barge-in, and optionally hangs the call up over
+// Telnyx's REST API when the pipeline ends.
+package telnyx
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sync"
+
+	"github.com/gojargo/jargo/audio/g711"
+	"github.com/gojargo/jargo/frames"
+	"github.com/gojargo/jargo/transport/wsserver"
+)
+
+// Serializer implements wsserver.Serializer.
+var _ wsserver.Serializer = (*Serializer)(nil)
+
+const (
+	// sampleRate is Telnyx Media Streaming's fixed rate: 8 kHz mono.
+	sampleRate = 8000
+	hangupURL  = "https://api.telnyx.com/v2/calls/%s/actions/hangup"
+
+	// EncodingPCMU selects G.711 μ-law; EncodingPCMA selects G.711 A-law. These
+	// are Telnyx's media_format.encoding values.
+	EncodingPCMU = "PCMU"
+	EncodingPCMA = "PCMA"
+)
+
+// Config configures the Telnyx serializer.
+type Config struct {
+	// APIKey authorizes the REST hang-up call (Bearer token). Only needed when
+	// AutoHangUp is set.
+	APIKey string
+	// AutoHangUp ends the Telnyx call over the REST API when the pipeline sends an
+	// EndFrame or CancelFrame.
+	AutoHangUp bool
+	// SendEncoding is the companding used for audio sent to Telnyx (PCMU or
+	// PCMA); empty defaults to PCMU. The receive encoding is learned from the
+	// "start" message's media_format, falling back to this value.
+	SendEncoding string
+	// HTTPClient is used for the hang-up request; nil uses http.DefaultClient.
+	HTTPClient *http.Client
+}
+
+// Serializer implements wsserver.Serializer for Telnyx. The stream ID, call
+// control ID and receive encoding are learned from the inbound "start" message.
+type Serializer struct {
+	cfg  Config
+	http *http.Client
+	send string
+
+	mu       sync.Mutex
+	streamID string
+	callCtrl string
+	recv     string
+	hungUp   bool
+}
+
+// New builds a Telnyx serializer.
+func New(cfg Config) *Serializer {
+	h := cfg.HTTPClient
+	if h == nil {
+		h = http.DefaultClient
+	}
+	send := cfg.SendEncoding
+	if send == "" {
+		send = EncodingPCMU
+	}
+	return &Serializer{cfg: cfg, http: h, send: send, recv: send}
+}
+
+// Setup is a no-op: Telnyx audio is always 8 kHz.
+func (s *Serializer) Setup(*frames.StartFrame) error { return nil }
+
+// Serialize converts an outbound frame to a Telnyx message.
+func (s *Serializer) Serialize(f frames.Frame) ([]byte, error) {
+	switch fr := f.(type) {
+	case *frames.TTSAudioRawFrame:
+		return s.media(fr.Audio)
+	case *frames.OutputAudioRawFrame:
+		return s.media(fr.Audio)
+	case *frames.InterruptionFrame:
+		return json.Marshal(event{Event: "clear"})
+	case *frames.EndFrame, *frames.CancelFrame:
+		s.hangup()
+		return nil, nil //nolint:nilnil // hang-up is a side effect; no wire message
+	default:
+		return nil, nil //nolint:nilnil // frame not sent to Telnyx
+	}
+}
+
+// Deserialize converts a Telnyx message to a frame.
+func (s *Serializer) Deserialize(data []byte) (frames.Frame, error) {
+	var m inbound
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, err
+	}
+	switch m.Event {
+	case "media":
+		payload, err := base64.StdEncoding.DecodeString(m.Media.Payload)
+		if err != nil {
+			return nil, err
+		}
+		s.mu.Lock()
+		enc := s.recv
+		s.mu.Unlock()
+		return frames.NewInputAudioRawFrame(decode(enc, payload), sampleRate, 1), nil
+	case "start":
+		s.mu.Lock()
+		s.streamID = m.StreamID
+		s.callCtrl = m.Start.CallControlID
+		if enc := m.Start.MediaFormat.Encoding; enc != "" {
+			s.recv = enc
+		}
+		s.mu.Unlock()
+		return nil, nil //nolint:nilnil // handshake message carries no frame
+	case "dtmf":
+		if m.DTMF.Digit == "" {
+			return nil, nil //nolint:nilnil // empty keypress
+		}
+		return frames.NewInputDTMFFrame(frames.KeypadEntry(m.DTMF.Digit)), nil
+	default: // connected, mark, stop
+		return nil, nil //nolint:nilnil // message carries no frame
+	}
+}
+
+func (s *Serializer) media(pcm []byte) ([]byte, error) {
+	out := mediaOut{Event: "media"}
+	out.Media.Payload = base64.StdEncoding.EncodeToString(encode(s.send, pcm))
+	return json.Marshal(out)
+}
+
+func (s *Serializer) hangup() {
+	if !s.cfg.AutoHangUp {
+		return
+	}
+	s.mu.Lock()
+	ready := !s.hungUp && s.callCtrl != "" && s.cfg.APIKey != ""
+	if ready {
+		s.hungUp = true
+	}
+	callCtrl := s.callCtrl
+	s.mu.Unlock()
+	if !ready {
+		return
+	}
+	go s.doHangup(callCtrl)
+}
+
+func (s *Serializer) doHangup(callCtrl string) {
+	endpoint := fmt.Sprintf(hangupURL, callCtrl)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, endpoint, nil)
+	if err != nil {
+		slog.Warn("telnyx: build hang-up request", "err", err)
+		return
+	}
+	req.Header.Set("Authorization", "Bearer "+s.cfg.APIKey)
+	resp, err := s.http.Do(req)
+	if err != nil {
+		slog.Warn("telnyx: hang-up call", "err", err)
+		return
+	}
+	_ = resp.Body.Close()
+}
+
+// encode companded bytes from PCM per the given encoding, defaulting to μ-law.
+func encode(enc string, pcm []byte) []byte {
+	if enc == EncodingPCMA {
+		return g711.EncodeALaw(pcm)
+	}
+	return g711.EncodeULaw(pcm)
+}
+
+// decode PCM from companded bytes per the given encoding, defaulting to μ-law.
+func decode(enc string, companded []byte) []byte {
+	if enc == EncodingPCMA {
+		return g711.DecodeALaw(companded)
+	}
+	return g711.DecodeULaw(companded)
+}
+
+type event struct {
+	Event string `json:"event"`
+}
+
+type mediaOut struct {
+	Event string `json:"event"`
+	Media struct {
+		Payload string `json:"payload"`
+	} `json:"media"`
+}
+
+type inbound struct {
+	Event    string `json:"event"`
+	StreamID string `json:"stream_id"`
+	Media    struct {
+		Payload string `json:"payload"`
+	} `json:"media"`
+	Start struct {
+		CallControlID string `json:"call_control_id"`
+		MediaFormat   struct {
+			Encoding string `json:"encoding"`
+		} `json:"media_format"`
+	} `json:"start"`
+	DTMF struct {
+		Digit string `json:"digit"`
+	} `json:"dtmf"`
+}

--- a/transport/wsserver/telnyx/telnyx_test.go
+++ b/transport/wsserver/telnyx/telnyx_test.go
@@ -1,0 +1,89 @@
+package telnyx
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/gojargo/jargo/audio/g711"
+	"github.com/gojargo/jargo/frames"
+)
+
+func silence() []byte { return make([]byte, 160*2) }
+
+func TestDeserializeStartLearnsEncoding(t *testing.T) {
+	s := New(Config{})
+
+	start := `{"event":"start","stream_id":"stream-1",` +
+		`"start":{"call_control_id":"cc-1","media_format":{"encoding":"PCMA"}}}`
+	if _, err := s.Deserialize([]byte(start)); err != nil {
+		t.Fatalf("deserialize start: %v", err)
+	}
+
+	// After a PCMA start, inbound media must be decoded as A-law.
+	payload := base64.StdEncoding.EncodeToString(g711.EncodeALaw(silence()))
+	f, err := s.Deserialize([]byte(`{"event":"media","media":{"payload":"` + payload + `"}}`))
+	if err != nil {
+		t.Fatalf("deserialize media: %v", err)
+	}
+	af, ok := f.(*frames.InputAudioRawFrame)
+	if !ok {
+		t.Fatalf("media frame type = %T", f)
+	}
+	if af.SampleRate != sampleRate || len(af.Audio) != len(silence()) {
+		t.Fatalf("media frame = %d Hz, %d bytes", af.SampleRate, len(af.Audio))
+	}
+}
+
+func TestSerializeAudioDefaultPCMU(t *testing.T) {
+	s := New(Config{})
+	msg, err := s.Serialize(frames.NewTTSAudioRawFrame(silence(), sampleRate, 1))
+	if err != nil {
+		t.Fatalf("serialize audio: %v", err)
+	}
+	var out mediaOut
+	if err := json.Unmarshal(msg, &out); err != nil {
+		t.Fatalf("unmarshal media: %v", err)
+	}
+	if out.Event != "media" {
+		t.Fatalf("event = %q, want media", out.Event)
+	}
+	raw, err := base64.StdEncoding.DecodeString(out.Media.Payload)
+	if err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if len(raw) != len(silence())/2 {
+		t.Fatalf("companded payload len = %d, want %d", len(raw), len(silence())/2)
+	}
+}
+
+func TestSerializeSendEncodingPCMA(t *testing.T) {
+	s := New(Config{SendEncoding: EncodingPCMA})
+	// A non-silent sample so μ-law and A-law encodings differ.
+	pcm := make([]byte, 4)
+	pcm[0], pcm[1] = 0x00, 0x40 // 0x4000
+	msg, _ := s.Serialize(frames.NewTTSAudioRawFrame(pcm, sampleRate, 1))
+	var out mediaOut
+	if err := json.Unmarshal(msg, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	raw, _ := base64.StdEncoding.DecodeString(out.Media.Payload)
+	if got, want := raw, g711.EncodeALaw(pcm); string(got) != string(want) {
+		t.Fatalf("payload = % x, want A-law % x", got, want)
+	}
+}
+
+func TestSerializeInterruptionClear(t *testing.T) {
+	s := New(Config{})
+	msg, err := s.Serialize(frames.NewInterruptionFrame())
+	if err != nil {
+		t.Fatalf("serialize interruption: %v", err)
+	}
+	var out event
+	if err := json.Unmarshal(msg, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Event != "clear" {
+		t.Fatalf("event = %q, want clear", out.Event)
+	}
+}


### PR DESCRIPTION
Three new `wsserver.Serializer` implementations alongside the existing Twilio one:

- **plivo** — base64 μ-law 8 kHz, `playAudio`/`clearAudio` events, DELETE-based REST auto-hang-up.
- **telnyx** — base64 μ-law **or** A-law; receive encoding learned from the stream's `media_format`, send encoding configurable; POST-based REST auto-hang-up.
- **exotel** — raw 16-bit PCM (no companding), configurable stream rate.

Each learns its stream/call identifiers from the inbound `start` message and
emits a barge-in clear on `InterruptionFrame`, matching the Twilio serializer.

Also adds a G.711 **A-law** codec (`EncodeALaw`/`DecodeALaw`) to `audio/g711`
for Telnyx PCMA, mirroring the μ-law implementation.

Unit tests cover each serializer's start/media/dtmf handling and the A-law
round-trip. `CGO_ENABLED=0 go build ./...`, `go vet`, and `golangci-lint` pass.