### PR TITLE
feat(text): add TTS text-normalization layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   `start` message and emits a barge-in clear on interruption.
 - **G.711 A-law codec** (`audio/g711`): `EncodeALaw`/`DecodeALaw` join the
   existing μ-law pair, for PSTN audio outside North America (Telnyx PCMA).
+- **TTS text normalization** (`utils/text/`): a pluggable `text.Filter` layer that
+  rewrites written text into a more speakable form before synthesis — strips
+  Markdown, spells out numbers, currency, percentages, dates, and units, spaces
+  out phone-number digits and acronyms, and reads email addresses aloud. A
+  `text.VoiceFormatter` bundles a configurable, ordered pipeline of these
+  transforms; attach it with the new `(*tts.Base).SetTextFilters`, promoted to
+  every TTS service. English number spelling follows the `num2words` "en"
+  conventions and needs no external dependency.
 
 ## [0.0.4] - 2026-07-12
 

--- a/service/tts/tts.go
+++ b/service/tts/tts.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gojargo/jargo/processor"
 	"github.com/gojargo/jargo/telemetry/metrics"
 	"github.com/gojargo/jargo/telemetry/tracing"
+	ttstext "github.com/gojargo/jargo/utils/text"
 	"go.opentelemetry.io/otel/attribute"
 )
 
@@ -47,6 +48,7 @@ type Base struct {
 	*processor.Base
 	syn         Synthesizer
 	aggregation string
+	filters     []ttstext.Filter
 }
 
 // New builds a TTS Base named name driven by syn. The concrete service passes
@@ -55,6 +57,15 @@ func New(name string, syn Synthesizer) *Base {
 	b := &Base{syn: syn}
 	b.Base = processor.New(name, b)
 	return b
+}
+
+// SetTextFilters sets the text-normalization filters applied to each sentence
+// just before synthesis — for example a text.VoiceFormatter that strips
+// Markdown and spells out numbers, currency and dates. Filters run in order.
+// Call this before the pipeline starts; the filter set is not safe to change
+// while it is running.
+func (b *Base) SetTextFilters(filters ...ttstext.Filter) {
+	b.filters = filters
 }
 
 // ProcessFrame aggregates text into sentences and synthesizes them.
@@ -119,6 +130,9 @@ func (b *Base) flush(ctx context.Context) error {
 
 // synthesize requests speech for text and streams it downstream as audio.
 func (b *Base) synthesize(ctx context.Context, text string) error {
+	for _, f := range b.filters {
+		text = f.Filter(text)
+	}
 	if strings.TrimSpace(text) == "" {
 		return nil
 	}

--- a/utils/text/formatter.go
+++ b/utils/text/formatter.go
@@ -1,0 +1,109 @@
+package text
+
+// FormatterOptions configures which transforms a VoiceFormatter applies. The
+// zero value enables nothing; use DefaultFormatterOptions for the recommended
+// set and toggle individual fields from there.
+type FormatterOptions struct {
+	// StripMarkdown removes Markdown formatting symbols.
+	StripMarkdown bool
+	// EmailToSpeech spells email addresses ("a@b.com" → "a at b dot com").
+	EmailToSpeech bool
+	// ExpandPhoneNumbers spaces out phone-number digits.
+	ExpandPhoneNumbers bool
+	// NormalizeDates expands ISO and US dates into spoken form.
+	NormalizeDates bool
+	// ExpandCurrency expands currency amounts ("$5" → "five dollars").
+	ExpandCurrency bool
+	// ExpandPercentages expands percentages ("50%" → "fifty percent").
+	ExpandPercentages bool
+	// ExpandUnits expands unit abbreviations ("5km" → "5 kilometers").
+	ExpandUnits bool
+	// NormalizeAcronyms letter-spaces all-caps acronyms ("API" → "A P I").
+	NormalizeAcronyms bool
+	// ExpandNumbers spells numeric digits as words. Off by default, since many
+	// numbers (versions, codes, IDs) read better as digits.
+	ExpandNumbers bool
+	// NumberDigitCutoff is passed to ExpandNumbers when it is enabled: numbers
+	// above it are read digit-by-digit. Zero or less spells every number.
+	NumberDigitCutoff int
+	// CustomReplacements are {pattern, replacement} regex rules applied last.
+	CustomReplacements [][2]string
+}
+
+// DefaultFormatterOptions returns the recommended set: every transform except
+// ExpandNumbers (which can mangle numbers better left as digits).
+func DefaultFormatterOptions() FormatterOptions {
+	return FormatterOptions{
+		StripMarkdown:      true,
+		EmailToSpeech:      true,
+		ExpandPhoneNumbers: true,
+		NormalizeDates:     true,
+		ExpandCurrency:     true,
+		ExpandPercentages:  true,
+		ExpandUnits:        true,
+		NormalizeAcronyms:  true,
+		ExpandNumbers:      false,
+	}
+}
+
+// VoiceFormatter applies an ordered pipeline of text transforms, implementing
+// Filter. Build one with NewVoiceFormatter.
+type VoiceFormatter struct {
+	transforms []Transform
+}
+
+// NewVoiceFormatter builds a VoiceFormatter from opts. The transforms run in a
+// deliberate order — structural cleanup, then language expansions, then user
+// replacements — chosen so earlier steps do not hide patterns later ones match
+// (email before phone and acronyms; units before acronyms). It returns an error
+// only if a CustomReplacements pattern fails to compile.
+func NewVoiceFormatter(opts FormatterOptions) (*VoiceFormatter, error) {
+	var ts []Transform
+	if opts.StripMarkdown {
+		ts = append(ts, StripMarkdown)
+	}
+	// Email must run before phone (its digit-only domains match the phone
+	// pattern) and before acronyms (all-caps local parts would be letter-spaced).
+	if opts.EmailToSpeech {
+		ts = append(ts, EmailToSpeech)
+	}
+	if opts.ExpandPhoneNumbers {
+		ts = append(ts, ExpandPhoneNumbers)
+	}
+	if opts.NormalizeDates {
+		ts = append(ts, NormalizeDates)
+	}
+	if opts.ExpandCurrency {
+		ts = append(ts, ExpandCurrency)
+	}
+	if opts.ExpandPercentages {
+		ts = append(ts, ExpandPercentages)
+	}
+	// Units before acronyms: uppercase abbreviations like "MB" or "MPH" would
+	// otherwise be letter-spaced and no longer recognized.
+	if opts.ExpandUnits {
+		ts = append(ts, ExpandUnits)
+	}
+	if opts.NormalizeAcronyms {
+		ts = append(ts, NormalizeAcronyms)
+	}
+	if opts.ExpandNumbers {
+		ts = append(ts, ExpandNumbers(opts.NumberDigitCutoff))
+	}
+	if len(opts.CustomReplacements) > 0 {
+		r, err := ReplaceText(opts.CustomReplacements)
+		if err != nil {
+			return nil, err
+		}
+		ts = append(ts, r)
+	}
+	return &VoiceFormatter{transforms: ts}, nil
+}
+
+// Filter applies every configured transform to text in order.
+func (f *VoiceFormatter) Filter(text string) string {
+	for _, t := range f.transforms {
+		text = t(text)
+	}
+	return text
+}

--- a/utils/text/numbers.go
+++ b/utils/text/numbers.go
@@ -1,0 +1,158 @@
+package text
+
+import (
+	"strconv"
+	"strings"
+)
+
+// English cardinal-number spelling, matching the num2words "en" conventions the
+// upstream transforms rely on: hyphenated tens ("forty-two"), an "and" before a
+// sub-hundred remainder ("one hundred and one"), and magnitude groups joined by
+// ", " with a final sub-hundred group joined by " and " ("one thousand and
+// five", "one million, two hundred and thirty-four thousand, five hundred and
+// sixty-seven").
+
+//nolint:gochecknoglobals // immutable spelling tables
+var (
+	onesWords = []string{
+		"zero", "one", "two", "three", "four", "five", "six", "seven", "eight",
+		"nine", "ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen",
+		"sixteen", "seventeen", "eighteen", "nineteen",
+	}
+	tensWords = []string{
+		"", "", "twenty", "thirty", "forty", "fifty", "sixty", "seventy",
+		"eighty", "ninety",
+	}
+	scaleWords = []string{
+		"", "thousand", "million", "billion", "trillion", "quadrillion",
+		"quintillion",
+	}
+)
+
+// cardinal spells a non-negative integer in English. Values beyond the scale
+// table (>= 10^21) fall back to their decimal digits.
+func cardinal(n int64) string {
+	if n == 0 {
+		return "zero"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+
+	// Split into groups of three digits, least significant first.
+	var groups []int64
+	for n > 0 {
+		groups = append(groups, n%1000)
+		n /= 1000
+	}
+	if len(groups) > len(scaleWords) {
+		return decimalDigits(strconv.FormatInt(orig(neg, groups), 10))
+	}
+
+	type part struct {
+		text  string
+		scale int
+		val   int64
+	}
+	var parts []part
+	for i := len(groups) - 1; i >= 0; i-- {
+		g := groups[i]
+		if g == 0 {
+			continue
+		}
+		t := threeDigitWords(g)
+		if i > 0 {
+			t += " " + scaleWords[i]
+		}
+		parts = append(parts, part{t, i, g})
+	}
+
+	result := parts[0].text
+	for k := 1; k < len(parts); k++ {
+		sep := ", "
+		// num2words joins a final sub-hundred units group with " and " rather
+		// than a comma ("one thousand and five").
+		if k == len(parts)-1 && parts[k].scale == 0 && parts[k].val < 100 {
+			sep = " and "
+		}
+		result += sep + parts[k].text
+	}
+	if neg {
+		return "minus " + result
+	}
+	return result
+}
+
+// orig reassembles the signed integer from its digit groups, used only for the
+// out-of-range fallback.
+func orig(neg bool, groups []int64) int64 {
+	var n int64
+	for i := len(groups) - 1; i >= 0; i-- {
+		n = n*1000 + groups[i]
+	}
+	if neg {
+		return -n
+	}
+	return n
+}
+
+// threeDigitWords spells 1..999.
+func threeDigitWords(n int64) string {
+	h := n / 100
+	r := n % 100
+	if h > 0 {
+		s := onesWords[h] + " hundred"
+		if r > 0 {
+			s += " and " + twoDigitWords(r)
+		}
+		return s
+	}
+	return twoDigitWords(r)
+}
+
+// twoDigitWords spells 0..99.
+func twoDigitWords(n int64) string {
+	if n < 20 {
+		return onesWords[n]
+	}
+	w := tensWords[n/10]
+	if n%10 > 0 {
+		w += "-" + onesWords[n%10]
+	}
+	return w
+}
+
+// floatToWords spells a decimal string the way num2words spells a float: the
+// integer part as a cardinal, then " point " and the remaining fractional digits
+// read individually, with trailing zeros dropped ("42.50" → "forty-two point
+// five", "42.0" → "forty-two", "0.25" → "zero point two five").
+func floatToWords(s string) string {
+	intPart, fracPart, hasDot := strings.Cut(s, ".")
+	if intPart == "" {
+		intPart = "0"
+	}
+	n, err := strconv.ParseInt(intPart, 10, 64)
+	if err != nil {
+		return s
+	}
+	words := cardinal(n)
+	if !hasDot {
+		return words
+	}
+	frac := strings.TrimRight(fracPart, "0")
+	if frac == "" {
+		return words
+	}
+	digits := make([]string, len(frac))
+	for i := range frac {
+		digits[i] = onesWords[frac[i]-'0']
+	}
+	return words + " point " + strings.Join(digits, " ")
+}
+
+// decimalDigits spaces out the characters of a digit string ("2026" → "2 0 2
+// 6") so a synthesizer reads them one by one.
+func decimalDigits(s string) string {
+	return strings.Join(strings.Split(s, ""), " ")
+}

--- a/utils/text/numbers_test.go
+++ b/utils/text/numbers_test.go
@@ -1,0 +1,58 @@
+package text
+
+import "testing"
+
+// The expected spellings are the verified num2words(lang="en") outputs.
+func TestCardinal(t *testing.T) {
+	cases := map[int64]string{
+		0:       "zero",
+		1:       "one",
+		15:      "fifteen",
+		20:      "twenty",
+		21:      "twenty-one",
+		42:      "forty-two",
+		70:      "seventy",
+		99:      "ninety-nine",
+		100:     "one hundred",
+		101:     "one hundred and one",
+		123:     "one hundred and twenty-three",
+		200:     "two hundred",
+		999:     "nine hundred and ninety-nine",
+		1000:    "one thousand",
+		1005:    "one thousand and five",
+		1023:    "one thousand and twenty-three",
+		1234:    "one thousand, two hundred and thirty-four",
+		2000:    "two thousand",
+		2023:    "two thousand and twenty-three",
+		2100:    "two thousand, one hundred",
+		2123:    "two thousand, one hundred and twenty-three",
+		1000000: "one million",
+		1000023: "one million and twenty-three",
+		1234567: "one million, two hundred and thirty-four thousand, five hundred and sixty-seven",
+	}
+	for n, want := range cases {
+		if got := cardinal(n); got != want {
+			t.Errorf("cardinal(%d) = %q, want %q", n, got, want)
+		}
+	}
+	if got := cardinal(-42); got != "minus forty-two" {
+		t.Errorf("cardinal(-42) = %q, want %q", got, "minus forty-two")
+	}
+}
+
+func TestFloatToWords(t *testing.T) {
+	cases := map[string]string{
+		"50":    "fifty",
+		"42.5":  "forty-two point five",
+		"42.50": "forty-two point five",
+		"0.25":  "zero point two five",
+		"3.14":  "three point one four",
+		"42.05": "forty-two point zero five",
+		"42.00": "forty-two",
+	}
+	for in, want := range cases {
+		if got := floatToWords(in); got != want {
+			t.Errorf("floatToWords(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/utils/text/text.go
+++ b/utils/text/text.go
@@ -1,0 +1,24 @@
+// Package text normalizes written text into a form better suited to
+// text-to-speech: it strips Markdown, expands numbers, currency, percentages,
+// dates, units and acronyms into spoken words, spaces out phone-number digits,
+// and spells email addresses. The transforms are plain string functions; a
+// VoiceFormatter bundles a configurable ordered pipeline of them behind the
+// Filter interface, which the TTS base applies to each sentence before synthesis.
+//
+// The expansions target English (the num2words "en" conventions): most TTS
+// providers already normalize other languages server-side.
+package text
+
+// Filter transforms text before it is handed to a speech synthesizer. The TTS
+// base calls Filter on each complete sentence just before synthesizing it.
+type Filter interface {
+	Filter(text string) string
+}
+
+// Transform is a single text-normalization step. All the package's transforms
+// have this shape, so they compose directly and a VoiceFormatter is just an
+// ordered list of them.
+type Transform func(text string) string
+
+// Filter lets a bare Transform satisfy the Filter interface.
+func (t Transform) Filter(text string) string { return t(text) }

--- a/utils/text/transforms.go
+++ b/utils/text/transforms.go
@@ -1,0 +1,396 @@
+package text
+
+import (
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// replaceAllSubmatch rewrites every match of re, passing the replacer the full
+// match (groups[0]) and its capture groups (groups[1:]); a group that did not
+// participate is the empty string. It is the group-aware counterpart to
+// regexp.ReplaceAllStringFunc.
+func replaceAllSubmatch(re *regexp.Regexp, text string, repl func(groups []string) string) string {
+	matches := re.FindAllStringSubmatchIndex(text, -1)
+	if matches == nil {
+		return text
+	}
+	var b strings.Builder
+	last := 0
+	for _, idx := range matches {
+		b.WriteString(text[last:idx[0]])
+		groups := make([]string, len(idx)/2)
+		for g := range groups {
+			if idx[2*g] >= 0 {
+				groups[g] = text[idx[2*g]:idx[2*g+1]]
+			}
+		}
+		b.WriteString(repl(groups))
+		last = idx[1]
+	}
+	b.WriteString(text[last:])
+	return b.String()
+}
+
+//
+// Markdown
+//
+
+//nolint:gochecknoglobals // compiled once, immutable
+var (
+	mdFence1     = regexp.MustCompile("```[\\s\\S]*?```")
+	mdFence2     = regexp.MustCompile(`~~~[\s\S]*?~~~`)
+	mdInlineCode = regexp.MustCompile("`([^`]+)`")
+	mdBoldItalic = regexp.MustCompile(`\*{3}(.+?)\*{3}`)
+	mdBoldItalU  = regexp.MustCompile(`_{3}(.+?)_{3}`)
+	mdBold       = regexp.MustCompile(`\*{2}(.+?)\*{2}`)
+	mdBoldU      = regexp.MustCompile(`_{2}(.+?)_{2}`)
+	mdItalic     = regexp.MustCompile(`\*(.+?)\*`)
+	mdItalicU    = regexp.MustCompile(`\b_(.+?)_\b`)
+	mdHeader     = regexp.MustCompile(`(?m)^#{1,6}\s+`)
+	mdQuote      = regexp.MustCompile(`(?m)^>\s?`)
+	mdRule       = regexp.MustCompile(`(?m)^\s*[-*_]{3,}\s*$`)
+)
+
+// StripMarkdown removes Markdown formatting symbols that have no spoken
+// equivalent: fenced and inline code, bold/italic markers, ATX headers,
+// blockquote markers and horizontal rules. Link and image syntax is left
+// intact, since the label text is meaningful.
+func StripMarkdown(text string) string {
+	text = mdFence1.ReplaceAllString(text, "")
+	text = mdFence2.ReplaceAllString(text, "")
+	text = mdInlineCode.ReplaceAllString(text, "$1")
+	text = mdBoldItalic.ReplaceAllString(text, "$1")
+	text = mdBoldItalU.ReplaceAllString(text, "$1")
+	text = mdBold.ReplaceAllString(text, "$1")
+	text = mdBoldU.ReplaceAllString(text, "$1")
+	text = mdItalic.ReplaceAllString(text, "$1")
+	text = mdItalicU.ReplaceAllString(text, "$1")
+	text = mdHeader.ReplaceAllString(text, "")
+	text = mdQuote.ReplaceAllString(text, "")
+	text = mdRule.ReplaceAllString(text, "")
+	return text
+}
+
+//
+// Email
+//
+
+//nolint:gochecknoglobals // compiled once, immutable
+var emailRE = regexp.MustCompile(`[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}`)
+
+// EmailToSpeech rewrites email addresses into a spoken form, e.g.
+// "user@example.com" → "user at example dot com".
+func EmailToSpeech(text string) string {
+	return emailRE.ReplaceAllStringFunc(text, func(email string) string {
+		local, domain, _ := strings.Cut(email, "@")
+		local = strings.NewReplacer(
+			".", " dot ", "_", " underscore ", "-", " dash ", "+", " plus ",
+		).Replace(local)
+		domain = strings.NewReplacer(".", " dot ", "-", " dash ").Replace(domain)
+		return local + " at " + domain
+	})
+}
+
+//
+// Phone numbers
+//
+
+//nolint:gochecknoglobals // compiled once, immutable
+var (
+	phoneRE    = regexp.MustCompile(`(\+?1[\s.\-]?)?(\(?\d{3}\)?[\s.\-]?)(\d{3}[\s.\-]?)(\d{4})`)
+	nonDigitRE = regexp.MustCompile(`\D`)
+)
+
+// ExpandPhoneNumbers spaces out phone-number digits so a synthesizer reads them
+// one by one, e.g. "123-456-7890" → "1 2 3 4 5 6 7 8 9 0". A run bordered by
+// another digit is left alone, so digits inside a longer number are not split.
+func ExpandPhoneNumbers(text string) string {
+	matches := phoneRE.FindAllStringIndex(text, -1)
+	if matches == nil {
+		return text
+	}
+	var b strings.Builder
+	last := 0
+	for _, m := range matches {
+		start, end := m[0], m[1]
+		// Reproduce the upstream (?<!\d) / (?!\d) guards: skip a match that
+		// abuts another digit, so it is not a fragment of a longer number.
+		if (start > 0 && isDigit(text[start-1])) || (end < len(text) && isDigit(text[end])) {
+			continue
+		}
+		b.WriteString(text[last:start])
+		digits := nonDigitRE.ReplaceAllString(text[start:end], "")
+		b.WriteString(strings.Join(strings.Split(digits, ""), " "))
+		last = end
+	}
+	b.WriteString(text[last:])
+	return b.String()
+}
+
+func isDigit(c byte) bool { return c >= '0' && c <= '9' }
+
+//
+// Acronyms
+//
+
+// Two or more consecutive uppercase letters standing as a whole word. The
+// trailing \b excludes the uppercase prefix of a CamelCase word ("IPhone") and a
+// trailing lowercase plural ("APIs"), matching the upstream (?![a-z]) guard.
+//
+//nolint:gochecknoglobals // compiled once, immutable
+var acronymRE = regexp.MustCompile(`\b[A-Z]{2,}\b`)
+
+// NormalizeAcronyms spaces out the letters of an all-caps acronym so each is
+// pronounced individually, e.g. "API" → "A P I".
+func NormalizeAcronyms(text string) string {
+	return acronymRE.ReplaceAllStringFunc(text, func(a string) string {
+		return strings.Join(strings.Split(a, ""), " ")
+	})
+}
+
+//
+// Dates
+//
+
+//nolint:gochecknoglobals // compiled once, immutable
+var (
+	isoDateRE  = regexp.MustCompile(`\b(\d{4})-(\d{2})-(\d{2})\b`)
+	usDateRE   = regexp.MustCompile(`\b(\d{1,2})[/\-](\d{1,2})[/\-](\d{4})\b`)
+	monthNames = []string{
+		"January", "February", "March", "April", "May", "June", "July",
+		"August", "September", "October", "November", "December",
+	}
+)
+
+// NormalizeDates expands ISO (YYYY-MM-DD) and US (MM/DD/YYYY or MM-DD-YYYY)
+// dates into spoken form, e.g. "2023-05-10" → "May 10th, two thousand and
+// twenty-three". A string that parses to no valid calendar date is left unchanged.
+func NormalizeDates(text string) string {
+	text = replaceAllSubmatch(isoDateRE, text, func(g []string) string {
+		return spokenDate(atoi(g[1]), atoi(g[2]), atoi(g[3]), g[0])
+	})
+	text = replaceAllSubmatch(usDateRE, text, func(g []string) string {
+		return spokenDate(atoi(g[3]), atoi(g[1]), atoi(g[2]), g[0])
+	})
+	return text
+}
+
+func spokenDate(year, month, day int, original string) string {
+	if month < 1 || month > 12 || day < 1 {
+		return original
+	}
+	t := time.Date(year, time.Month(month), day, 0, 0, 0, 0, time.UTC)
+	if t.Year() != year || int(t.Month()) != month || t.Day() != day {
+		return original
+	}
+	return monthNames[month-1] + " " + ordinal(day) + ", " + cardinal(int64(year))
+}
+
+func ordinal(n int) string {
+	suffix := "th"
+	if r := n % 100; r < 11 || r > 13 {
+		switch n % 10 {
+		case 1:
+			suffix = "st"
+		case 2:
+			suffix = "nd"
+		case 3:
+			suffix = "rd"
+		}
+	}
+	return strconv.Itoa(n) + suffix
+}
+
+//
+// Currency
+//
+
+//nolint:gochecknoglobals // compiled once, immutable
+var (
+	currencyRE = regexp.MustCompile(`([€£¥₹$])\s*(\d{1,3}(?:,\d{3})*|\d+)\b(?:\.(\d{1,2}))?`)
+
+	currencyMap = map[string]struct {
+		singular, plural, centSingular, centPlural string
+	}{
+		"$": {"dollar", "dollars", "cent", "cents"},
+		"€": {"euro", "euros", "cent", "cents"},
+		"£": {"pound", "pounds", "penny", "pence"},
+		"¥": {"yen", "yen", "", ""},
+		"₹": {"rupee", "rupees", "paisa", "paise"},
+	}
+)
+
+// ExpandCurrency expands currency amounts into spoken form, e.g. "$42.50" →
+// "forty-two dollars and fifty cents".
+func ExpandCurrency(text string) string {
+	return replaceAllSubmatch(currencyRE, text, func(g []string) string {
+		cur, ok := currencyMap[g[1]]
+		if !ok {
+			return g[0]
+		}
+		whole, _ := strconv.ParseInt(strings.ReplaceAll(g[2], ",", ""), 10, 64)
+		result := amountWords(whole, cur.singular, cur.plural)
+		if g[3] != "" && cur.centSingular != "" {
+			cents, _ := strconv.ParseInt(padRight(g[3], 2, '0'), 10, 64)
+			if cents > 0 {
+				result += " and " + amountWords(cents, cur.centSingular, cur.centPlural)
+			}
+		}
+		return result
+	})
+}
+
+func amountWords(n int64, singular, plural string) string {
+	unit := plural
+	if n == 1 {
+		unit = singular
+	}
+	return cardinal(n) + " " + unit
+}
+
+func padRight(s string, width int, pad byte) string {
+	for len(s) < width {
+		s += string(pad)
+	}
+	return s
+}
+
+//
+// Percentages
+//
+
+//nolint:gochecknoglobals // compiled once, immutable
+var percentRE = regexp.MustCompile(`(\d+(?:\.\d+)?)\s*%`)
+
+// ExpandPercentages expands percentage expressions into spoken form, e.g. "50%"
+// → "fifty percent".
+func ExpandPercentages(text string) string {
+	return replaceAllSubmatch(percentRE, text, func(g []string) string {
+		return floatToWords(g[1]) + " percent"
+	})
+}
+
+//
+// Numbers
+//
+
+//nolint:gochecknoglobals // compiled once, immutable
+var numberRE = regexp.MustCompile(`\b(\d{1,3}(?:,\d{3})*|\d+)(?:\.(\d+))?\b`)
+
+// ExpandNumbers returns a transform that expands numbers into spoken form. A
+// number whose whole part exceeds digitCutoff is read digit-by-digit ("2026" →
+// "2 0 2 6"); at or below the cutoff it is spelled as a quantity ("42" →
+// "forty-two"). A digitCutoff of zero or less disables the cutoff, so every
+// number is spelled as a quantity.
+func ExpandNumbers(digitCutoff int) Transform {
+	return func(text string) string {
+		return replaceAllSubmatch(numberRE, text, func(g []string) string {
+			wholeStr := strings.ReplaceAll(g[1], ",", "")
+			frac := g[2]
+			whole, err := strconv.ParseInt(wholeStr, 10, 64)
+			if err != nil {
+				return g[0]
+			}
+			if digitCutoff > 0 && whole > int64(digitCutoff) {
+				out := decimalDigits(wholeStr)
+				if frac != "" {
+					out += " point " + decimalDigits(frac)
+				}
+				return out
+			}
+			if frac != "" {
+				return floatToWords(wholeStr + "." + frac)
+			}
+			return cardinal(whole)
+		})
+	}
+}
+
+//
+// Units
+//
+
+//nolint:gochecknoglobals // compiled once, immutable
+var (
+	unitMap = map[string]string{
+		"km": "kilometers", "m": "meters", "cm": "centimeters", "mm": "millimeters",
+		"mi": "miles", "ft": "feet", "in": "inches", "yd": "yards",
+		"kg": "kilograms", "g": "grams", "mg": "milligrams", "lb": "pounds", "oz": "ounces",
+		"l": "liters", "ml": "milliliters",
+		"mph": "miles per hour", "kph": "kilometers per hour", "kmh": "kilometers per hour",
+		"gb": "gigabytes", "mb": "megabytes", "kb": "kilobytes", "tb": "terabytes",
+		"hz": "hertz", "khz": "kilohertz", "mhz": "megahertz", "ghz": "gigahertz",
+	}
+	// Single-letter units that are also common English words: expand only when
+	// they immediately follow a digit with no space ("5m", not "1 m people").
+	ambiguousUnits = map[string]bool{"in": true, "m": true, "g": true, "l": true}
+
+	// Unambiguous units allow optional whitespace; ambiguous ones do not.
+	unitRE          = regexp.MustCompile(`(?i)(\d+(?:\.\d+)?)\s*(` + unitAlternation(false) + `)\b`)
+	ambiguousUnitRE = regexp.MustCompile(`(?i)(\d+(?:\.\d+)?)(` + unitAlternation(true) + `)\b`)
+)
+
+// unitAlternation builds a regex alternation of the ambiguous or unambiguous
+// unit abbreviations, longest first so a longer unit wins over a prefix of it
+// ("mph" before "mi").
+func unitAlternation(ambiguous bool) string {
+	var units []string
+	for u := range unitMap {
+		if ambiguousUnits[u] == ambiguous {
+			units = append(units, u)
+		}
+	}
+	sort.Slice(units, func(i, j int) bool {
+		if len(units[i]) != len(units[j]) {
+			return len(units[i]) > len(units[j])
+		}
+		return units[i] < units[j]
+	})
+	return strings.Join(units, "|")
+}
+
+// ExpandUnits expands unit abbreviations after a number into their spoken form,
+// e.g. "5km" → "5 kilometers", "100kph" → "100 kilometers per hour".
+func ExpandUnits(text string) string {
+	expand := func(g []string) string {
+		return g[1] + " " + unitMap[strings.ToLower(g[2])]
+	}
+	text = replaceAllSubmatch(unitRE, text, expand)
+	return replaceAllSubmatch(ambiguousUnitRE, text, expand)
+}
+
+//
+// Custom replacements
+//
+
+// ReplaceText returns a transform that applies a list of {pattern, replacement}
+// rules in order. Patterns are regular expressions compiled up front, so an
+// invalid pattern returns an error here rather than failing during synthesis.
+func ReplaceText(rules [][2]string) (Transform, error) {
+	type rule struct {
+		re   *regexp.Regexp
+		with string
+	}
+	compiled := make([]rule, len(rules))
+	for i, r := range rules {
+		re, err := regexp.Compile(r[0])
+		if err != nil {
+			return nil, err
+		}
+		compiled[i] = rule{re, r[1]}
+	}
+	return func(text string) string {
+		for _, r := range compiled {
+			text = r.re.ReplaceAllString(text, r.with)
+		}
+		return text
+	}, nil
+}
+
+func atoi(s string) int {
+	n, _ := strconv.Atoi(s)
+	return n
+}

--- a/utils/text/transforms_test.go
+++ b/utils/text/transforms_test.go
@@ -1,0 +1,148 @@
+package text
+
+import "testing"
+
+func TestStripMarkdown(t *testing.T) {
+	cases := map[string]string{
+		"**Hello** and _world_":    "Hello and world",
+		"***bold italic***":        "bold italic",
+		"`code` span":              "code span",
+		"# Heading":                "Heading",
+		"> quoted":                 "quoted",
+		"plain text":               "plain text",
+		"see [the docs](x) please": "see [the docs](x) please",
+	}
+	for in, want := range cases {
+		if got := StripMarkdown(in); got != want {
+			t.Errorf("StripMarkdown(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestEmailToSpeech(t *testing.T) {
+	got := EmailToSpeech("Contact user_1@example.com today")
+	want := "Contact user underscore 1 at example dot com today"
+	if got != want {
+		t.Errorf("EmailToSpeech = %q, want %q", got, want)
+	}
+}
+
+func TestExpandPhoneNumbers(t *testing.T) {
+	got := ExpandPhoneNumbers("Call 123-456-7890 now")
+	want := "Call 1 2 3 4 5 6 7 8 9 0 now"
+	if got != want {
+		t.Errorf("ExpandPhoneNumbers = %q, want %q", got, want)
+	}
+	// A 14-digit blob is not a phone number: bordered by digits, it is skipped.
+	if got := ExpandPhoneNumbers("12345678901234"); got != "12345678901234" {
+		t.Errorf("long digit run should be untouched, got %q", got)
+	}
+}
+
+func TestNormalizeAcronyms(t *testing.T) {
+	got := NormalizeAcronyms("Use the API or HTTP endpoint")
+	want := "Use the A P I or H T T P endpoint"
+	if got != want {
+		t.Errorf("NormalizeAcronyms = %q, want %q", got, want)
+	}
+	// CamelCase and plural acronyms are left alone.
+	if got := NormalizeAcronyms("IPhone APIs"); got != "IPhone APIs" {
+		t.Errorf("NormalizeAcronyms(camel/plural) = %q, want unchanged", got)
+	}
+}
+
+func TestNormalizeDates(t *testing.T) {
+	cases := map[string]string{
+		"Meeting on 2023-05-10": "Meeting on May 10th, two thousand and twenty-three",
+		"Due 05/10/2023":        "Due May 10th, two thousand and twenty-three",
+		"Not 2023-13-40":        "Not 2023-13-40", // invalid date left as-is
+	}
+	for in, want := range cases {
+		if got := NormalizeDates(in); got != want {
+			t.Errorf("NormalizeDates(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestExpandCurrency(t *testing.T) {
+	cases := map[string]string{
+		"Your balance is $42.50": "Your balance is forty-two dollars and fifty cents",
+		"It costs $1":            "It costs one dollar",
+		"Paid £3.01":             "Paid three pounds and one penny",
+		"Total ¥100":             "Total one hundred yen",
+	}
+	for in, want := range cases {
+		if got := ExpandCurrency(in); got != want {
+			t.Errorf("ExpandCurrency(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestExpandPercentages(t *testing.T) {
+	cases := map[string]string{
+		"50% off":    "fifty percent off",
+		"12.5% rate": "twelve point five percent rate",
+	}
+	for in, want := range cases {
+		if got := ExpandPercentages(in); got != want {
+			t.Errorf("ExpandPercentages(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestExpandUnits(t *testing.T) {
+	cases := map[string]string{
+		"Run 5km at 100kph": "Run 5 kilometers at 100 kilometers per hour",
+		"Weighs 5kg":        "Weighs 5 kilograms",
+		"5m tall":           "5 meters tall", // ambiguous unit, no space → expand
+		"1 m people":        "1 m people",    // ambiguous unit with space → keep
+	}
+	for in, want := range cases {
+		if got := ExpandUnits(in); got != want {
+			t.Errorf("ExpandUnits(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestExpandNumbers(t *testing.T) {
+	expand := ExpandNumbers(2025)
+	cases := map[string]string{
+		"Room 42":       "Room forty-two",
+		"opens in 2026": "opens in 2 0 2 6", // above cutoff → digit-by-digit
+		"pi is 3.14":    "pi is three point one four",
+	}
+	for in, want := range cases {
+		if got := expand(in); got != want {
+			t.Errorf("ExpandNumbers(%q) = %q, want %q", in, got, want)
+		}
+	}
+	// No cutoff spells everything.
+	if got := ExpandNumbers(0)("year 2026"); got != "year two thousand and twenty-six" {
+		t.Errorf("ExpandNumbers(0) = %q", got)
+	}
+}
+
+func TestReplaceText(t *testing.T) {
+	tr, err := ReplaceText([][2]string{{`\bDr\.`, "Doctor"}, {`\bvs\b`, "versus"}})
+	if err != nil {
+		t.Fatalf("ReplaceText: %v", err)
+	}
+	if got := tr("Dr. Smith vs Jones"); got != "Doctor Smith versus Jones" {
+		t.Errorf("ReplaceText = %q", got)
+	}
+	if _, err := ReplaceText([][2]string{{`(`, "x"}}); err == nil {
+		t.Error("ReplaceText should reject an invalid pattern")
+	}
+}
+
+func TestVoiceFormatter(t *testing.T) {
+	f, err := NewVoiceFormatter(DefaultFormatterOptions())
+	if err != nil {
+		t.Fatalf("NewVoiceFormatter: %v", err)
+	}
+	got := f.Filter("**Total:** $42.50 for the API, 50% done")
+	want := "Total: forty-two dollars and fifty cents for the A P I, fifty percent done"
+	if got != want {
+		t.Errorf("VoiceFormatter.Filter = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Adds a `utils/text` package that rewrites written text into a more speakable
form before synthesis, behind a small `text.Filter` interface:

- StripMarkdown, EmailToSpeech, ExpandPhoneNumbers, NormalizeAcronyms
- ExpandCurrency, ExpandPercentages, ExpandNumbers, ExpandUnits, NormalizeDates
- ReplaceText for user-defined find/replace rules
- `VoiceFormatter` bundles a configurable, ordered pipeline of the above

English number spelling is a self-contained cardinal/float speller (hyphenated
tens, "and" before a sub-hundred remainder, ", " between magnitude groups), so
there is no external dependency.

Wired into the TTS base via `SetTextFilters`, applied to each complete sentence
just before synthesis; the method is promoted through the embedded base, so
every TTS provider gets it. Unit tests validate the spellings and each
transform. Build, vet, and lint pass.