### PR TITLE
feat(transport): add pure-Go local-audio transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   transforms; attach it with the new `(*tts.Base).SetTextFilters`, promoted to
   every TTS service. English number spelling follows the `num2words` "en"
   conventions and needs no external dependency.
+- **Local-audio transport** (`transport/localaudio`): capture from the local
+  microphone and play back through the local speaker, for running a bot on the
+  same machine with no browser or telephony leg. It speaks the PulseAudio native
+  protocol through the pure-Go [`github.com/jfreymuth/pulse`](https://github.com/jfreymuth/pulse)
+  client, so the default build stays cgo-free; it needs a running PulseAudio or
+  PipeWire (pulse-compatible) server. See `examples/localaudio` for a no-keys
+  microphone-to-speaker echo.
 
 ## [0.0.4] - 2026-07-12
 

--- a/examples/localaudio/main.go
+++ b/examples/localaudio/main.go
@@ -1,0 +1,76 @@
+// Command localaudio echoes the local microphone straight back to the local
+// speaker using jargo's pure-Go local-audio transport. It needs no API keys and
+// no browser — just a running PulseAudio or PipeWire server — so it is a quick
+// way to check that capture and playback work. Wear headphones: echoing the mic
+// to the speaker will otherwise feed back.
+//
+// Run with: go run ./examples/localaudio   (Ctrl-C to stop)
+package main
+
+import (
+	"context"
+	"errors"
+	"log"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/gojargo/jargo/frames"
+	"github.com/gojargo/jargo/pipeline"
+	"github.com/gojargo/jargo/processor"
+	"github.com/gojargo/jargo/transport"
+	"github.com/gojargo/jargo/transport/localaudio"
+)
+
+const sampleRate = 24000
+
+func main() {
+	params := transport.DefaultParams()
+	params.AudioInSampleRate = sampleRate
+	params.AudioOutSampleRate = sampleRate
+
+	t, err := localaudio.New(localaudio.Config{AppName: "jargo-echo", Params: params})
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer t.Close()
+
+	pipe := pipeline.New(t.Input(), newEcho(), t.Output())
+	task := pipeline.NewTask(pipe, pipeline.TaskParams{
+		AudioInSampleRate:  sampleRate,
+		AudioOutSampleRate: sampleRate,
+	})
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	slog.Info("local echo started; speak into the mic (Ctrl-C to stop)")
+	if err := task.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
+		slog.Error("pipeline ended", "err", err)
+	}
+	slog.Info("local echo stopped")
+}
+
+// echoProcessor turns each captured audio frame into an outgoing audio frame,
+// so the pipeline plays the microphone straight back.
+type echoProcessor struct {
+	*processor.Base
+}
+
+func newEcho() *echoProcessor {
+	e := &echoProcessor{}
+	e.Base = processor.New("Echo", e)
+	return e
+}
+
+func (e *echoProcessor) ProcessFrame(ctx context.Context, f frames.Frame, dir processor.Direction) error {
+	if err := e.Base.ProcessFrame(ctx, f, dir); err != nil {
+		return err
+	}
+	if in, ok := f.(*frames.InputAudioRawFrame); ok {
+		out := frames.NewOutputAudioRawFrame(in.Audio, in.SampleRate, in.NumChannels)
+		return e.PushFrame(ctx, out, processor.Downstream)
+	}
+	return e.PushFrame(ctx, f, dir)
+}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/go-playground/validator/v10 v10.30.3
 	github.com/gojargo/go-resample v1.0.0
 	github.com/google/uuid v1.6.0
+	github.com/jfreymuth/pulse v0.1.2
 	github.com/livekit/server-sdk-go/v2 v2.17.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/pion/opus v0.1.1-0.20260706164138-4d863e517a7a

--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF2
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/invopop/jsonschema v0.14.0 h1:MHQqLhvpNUZfw+hM3AZDYK7jxO8FZoQeQM77g8iyZjg=
 github.com/invopop/jsonschema v0.14.0/go.mod h1:ygm6C2EaVNMBDPpaPlnOA2pFAxBnxGjFlMZABxm9n2I=
+github.com/jfreymuth/pulse v0.1.2 h1:t4+ItUuWLlQnulVDOL2eAotKk+utKJzK8ol0iybYAmQ=
+github.com/jfreymuth/pulse v0.1.2/go.mod h1:cpYspI6YljhkUf1WLXLLDmeaaPFc3CnGLjDZf9dZ4no=
 github.com/jxskiss/base62 v1.1.0 h1:A5zbF8v8WXx2xixnAKD2w+abC+sIzYJX+nxmhA6HWFw=
 github.com/jxskiss/base62 v1.1.0/go.mod h1:HhWAlUXvxKThfOlZbcuFzsqwtF5TcqS9ru3y5GfjWAc=
 github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=

--- a/transport/localaudio/localaudio.go
+++ b/transport/localaudio/localaudio.go
@@ -1,0 +1,284 @@
+// Package localaudio is a transport that captures from the local microphone and
+// plays back through the local speaker, for running a bot on the same machine
+// with no browser or telephony leg. It speaks the PulseAudio native protocol
+// through the pure-Go github.com/jfreymuth/pulse client, so it stays cgo-free;
+// it needs a running PulseAudio or PipeWire (pulse-compatible) server, which is
+// the default on Linux desktops.
+//
+// Audio is 16-bit signed mono PCM. Capture runs at the pipeline's input rate and
+// playback at its output rate; PulseAudio resamples to and from the device, so
+// the pipeline can run at whatever rate its STT and TTS want.
+package localaudio
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"sync"
+
+	"github.com/gojargo/jargo/frames"
+	"github.com/gojargo/jargo/processor"
+	"github.com/gojargo/jargo/transport"
+	"github.com/jfreymuth/pulse"
+	"github.com/jfreymuth/pulse/proto"
+)
+
+// Interface checks.
+var (
+	_ transport.Transport    = (*Transport)(nil)
+	_ transport.InputDriver  = (*inputTransport)(nil)
+	_ transport.OutputDriver = (*outputTransport)(nil)
+)
+
+// Default sample rates used when the StartFrame does not carry one.
+const (
+	defaultInRate  = 16000
+	defaultOutRate = 24000
+	// maxBufferSeconds bounds the playback backlog, so a stalled speaker cannot
+	// grow the output buffer without limit.
+	maxBufferSeconds = 10
+)
+
+// monoMap is a single-channel (mono) PulseAudio channel map.
+//
+//nolint:gochecknoglobals // immutable
+var monoMap = proto.ChannelMap{proto.ChannelMono}
+
+// Config configures the local-audio transport.
+type Config struct {
+	// AppName is the client name PulseAudio shows for the streams; "" uses "jargo".
+	AppName string
+	// Params configures audio input and output; see transport.DefaultParams.
+	Params transport.Params
+}
+
+// Transport captures from the microphone and plays to the speaker over a single
+// PulseAudio client connection.
+type Transport struct {
+	client *pulse.Client
+	in     *inputTransport
+	out    *outputTransport
+}
+
+// New connects to the local PulseAudio server and builds the transport. It
+// returns an error if no server is reachable.
+func New(cfg Config) (*Transport, error) {
+	name := cfg.AppName
+	if name == "" {
+		name = "jargo"
+	}
+	client, err := pulse.NewClient(pulse.ClientApplicationName(name))
+	if err != nil {
+		return nil, fmt.Errorf("localaudio: connect to PulseAudio: %w", err)
+	}
+	return &Transport{
+		client: client,
+		in:     newInput(client, cfg.Params),
+		out:    newOutput(client, cfg.Params),
+	}, nil
+}
+
+// Input returns the input processor.
+func (t *Transport) Input() processor.Processor { return t.in }
+
+// Output returns the output processor.
+func (t *Transport) Output() processor.Processor { return t.out }
+
+// Close closes the PulseAudio connection. Call it after the pipeline stops.
+func (t *Transport) Close() { t.client.Close() }
+
+//
+// Input: microphone capture
+//
+
+type inputTransport struct {
+	*transport.BaseInput
+	client *pulse.Client
+
+	mu     sync.Mutex
+	stream *pulse.RecordStream
+	ctx    context.Context
+}
+
+func newInput(client *pulse.Client, params transport.Params) *inputTransport {
+	in := &inputTransport{client: client}
+	in.BaseInput = transport.NewBaseInput("LocalAudioInput", params, in)
+	return in
+}
+
+// StartReading opens the capture stream at the input sample rate and starts it.
+func (in *inputTransport) StartReading(ctx context.Context) error {
+	rate := in.SampleRate()
+	if rate == 0 {
+		rate = defaultInRate
+	}
+	in.mu.Lock()
+	in.ctx = ctx
+	in.mu.Unlock()
+
+	stream, err := in.client.NewRecord(
+		pulse.Int16Writer(in.onSamples),
+		pulse.RecordSampleRate(rate),
+		pulse.RecordChannels(monoMap),
+	)
+	if err != nil {
+		return fmt.Errorf("localaudio: open capture stream: %w", err)
+	}
+	in.mu.Lock()
+	in.stream = stream
+	in.mu.Unlock()
+	stream.Start()
+	return nil
+}
+
+// onSamples receives captured mono S16 samples from PulseAudio and pushes them
+// downstream as an input audio frame.
+func (in *inputTransport) onSamples(samples []int16) (int, error) {
+	in.mu.Lock()
+	ctx := in.ctx
+	in.mu.Unlock()
+	if ctx == nil || len(samples) == 0 {
+		return len(samples), nil
+	}
+	rate := in.SampleRate()
+	if rate == 0 {
+		rate = defaultInRate
+	}
+	pcm := int16ToPCM(samples)
+	in.PushAudioFrame(ctx, frames.NewInputAudioRawFrame(pcm, rate, 1))
+	return len(samples), nil
+}
+
+// StopReading stops and closes the capture stream.
+func (in *inputTransport) StopReading(context.Context) error {
+	in.mu.Lock()
+	stream := in.stream
+	in.stream = nil
+	in.mu.Unlock()
+	if stream != nil {
+		stream.Stop()
+		stream.Close()
+	}
+	return nil
+}
+
+//
+// Output: speaker playback
+//
+
+type outputTransport struct {
+	*transport.BaseOutput
+	client *pulse.Client
+
+	mu     sync.Mutex
+	stream *pulse.PlaybackStream
+	buf    []byte
+}
+
+func newOutput(client *pulse.Client, params transport.Params) *outputTransport {
+	out := &outputTransport{client: client}
+	out.BaseOutput = transport.NewBaseOutput("LocalAudioOutput", params, out)
+	return out
+}
+
+// ProcessFrame drives the playback stream's lifecycle around the base output:
+// open it on start, drop buffered audio on a barge-in, and close it on end.
+func (out *outputTransport) ProcessFrame(ctx context.Context, f frames.Frame, dir processor.Direction) error {
+	if err := out.BaseOutput.ProcessFrame(ctx, f, dir); err != nil {
+		return err
+	}
+	if dir != processor.Downstream {
+		return nil
+	}
+	switch f.(type) {
+	case *frames.StartFrame:
+		return out.openStream()
+	case *frames.InterruptionFrame:
+		out.mu.Lock()
+		out.buf = nil
+		out.mu.Unlock()
+	case *frames.EndFrame, *frames.CancelFrame:
+		out.closeStream()
+	}
+	return nil
+}
+
+func (out *outputTransport) openStream() error {
+	rate := out.SampleRate()
+	if rate == 0 {
+		rate = defaultOutRate
+	}
+	stream, err := out.client.NewPlayback(
+		pulse.Int16Reader(out.fill),
+		pulse.PlaybackSampleRate(rate),
+		pulse.PlaybackChannels(monoMap),
+	)
+	if err != nil {
+		return fmt.Errorf("localaudio: open playback stream: %w", err)
+	}
+	out.mu.Lock()
+	out.stream = stream
+	out.mu.Unlock()
+	stream.Start()
+	return nil
+}
+
+// WriteAudio queues one chunk of S16 PCM for playback. PulseAudio pulls it back
+// out through fill at the device's pace.
+func (out *outputTransport) WriteAudio(_ context.Context, pcm []byte) error {
+	out.mu.Lock()
+	out.buf = append(out.buf, pcm...)
+	if limit := maxBufferBytes(out.SampleRate()); len(out.buf) > limit {
+		out.buf = out.buf[len(out.buf)-limit:]
+	}
+	out.mu.Unlock()
+	return nil
+}
+
+// SendMessage is a no-op: the local transport has no client data channel.
+func (out *outputTransport) SendMessage(context.Context, []byte) error { return nil }
+
+// fill supplies the next samples to PulseAudio, draining the queued PCM and
+// padding any shortfall with silence so the stream keeps flowing.
+func (out *outputTransport) fill(samples []int16) (int, error) {
+	out.mu.Lock()
+	n := 0
+	for n < len(samples) && len(out.buf) >= 2 {
+		samples[n] = int16(binary.LittleEndian.Uint16(out.buf))
+		out.buf = out.buf[2:]
+		n++
+	}
+	out.mu.Unlock()
+	for i := n; i < len(samples); i++ {
+		samples[i] = 0
+	}
+	return len(samples), nil
+}
+
+func (out *outputTransport) closeStream() {
+	out.mu.Lock()
+	stream := out.stream
+	out.stream = nil
+	out.buf = nil
+	out.mu.Unlock()
+	if stream != nil {
+		stream.Stop()
+		stream.Close()
+	}
+}
+
+// int16ToPCM packs native S16 samples into S16LE bytes, jargo's PCM layout.
+func int16ToPCM(samples []int16) []byte {
+	pcm := make([]byte, len(samples)*2)
+	for i, s := range samples {
+		binary.LittleEndian.PutUint16(pcm[2*i:], uint16(s))
+	}
+	return pcm
+}
+
+func maxBufferBytes(rate int) int {
+	if rate == 0 {
+		rate = defaultOutRate
+	}
+	return rate * 2 * maxBufferSeconds
+}

--- a/transport/localaudio/localaudio_test.go
+++ b/transport/localaudio/localaudio_test.go
@@ -1,0 +1,71 @@
+package localaudio
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/gojargo/jargo/transport"
+)
+
+func TestInt16ToPCMRoundTrip(t *testing.T) {
+	samples := []int16{0, 1, -1, 32767, -32768, 1234}
+	pcm := int16ToPCM(samples)
+	if len(pcm) != len(samples)*2 {
+		t.Fatalf("pcm len = %d, want %d", len(pcm), len(samples)*2)
+	}
+	for i, s := range samples {
+		if got := int16(binary.LittleEndian.Uint16(pcm[2*i:])); got != s {
+			t.Fatalf("sample %d = %d, want %d", i, got, s)
+		}
+	}
+}
+
+// TestFillDrainsThenPads checks that fill drains queued PCM in order and pads the
+// remainder with silence, always filling the whole request so the stream keeps
+// running.
+func TestFillDrainsThenPads(t *testing.T) {
+	out := newOutput(nil, transport.DefaultParams())
+	if err := out.WriteAudio(context.Background(), int16ToPCM([]int16{100, -200})); err != nil {
+		t.Fatalf("WriteAudio: %v", err)
+	}
+
+	got := make([]int16, 4) // ask for more than is queued
+	n, err := out.fill(got)
+	if err != nil {
+		t.Fatalf("fill: %v", err)
+	}
+	if n != 4 {
+		t.Fatalf("fill returned %d, want the full 4 (silence-padded)", n)
+	}
+	want := []int16{100, -200, 0, 0}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("sample %d = %d, want %d", i, got[i], want[i])
+		}
+	}
+
+	// The queue is now empty: the next fill is pure silence.
+	next := make([]int16, 3)
+	if _, err := out.fill(next); err != nil {
+		t.Fatalf("fill: %v", err)
+	}
+	for i, s := range next {
+		if s != 0 {
+			t.Fatalf("silence sample %d = %d, want 0", i, s)
+		}
+	}
+}
+
+// TestWriteAudioCapsBacklog checks the playback backlog is bounded so a stalled
+// speaker cannot grow the buffer without limit.
+func TestWriteAudioCapsBacklog(t *testing.T) {
+	out := newOutput(nil, transport.DefaultParams())
+	capacity := maxBufferBytes(0)
+	if err := out.WriteAudio(context.Background(), make([]byte, capacity+4096)); err != nil {
+		t.Fatalf("WriteAudio: %v", err)
+	}
+	if len(out.buf) > capacity {
+		t.Fatalf("buffer len = %d, want <= %d", len(out.buf), capacity)
+	}
+}


### PR DESCRIPTION
Adds `transport/localaudio`: a microphone-in, speaker-out transport for running
a bot on the same machine with no browser or telephony leg.

It speaks the PulseAudio native protocol through the pure-Go
`github.com/jfreymuth/pulse` client, so the default build stays cgo-free
(`CGO_ENABLED=0 go build ./...` still works); it needs a running PulseAudio or
PipeWire (pulse-compatible) server.

Capture runs at the pipeline input rate and playback at the output rate, with
PulseAudio resampling to and from the device. Playback is pull-based: the output
buffers PCM and fills the device callback on demand, padding underruns with
silence, dropping the backlog on barge-in, and bounding it against a stalled
speaker. `examples/localaudio` is a no-keys mic-to-speaker echo.

Unit tests cover the PCM/int16 conversion and the playback buffering. Build,
vet, and lint pass.