### PR TITLE
fix(lint): satisfy goconst and modernize checks

### DIFF
--- a/transport/wsserver/exotel/exotel.go
+++ b/transport/wsserver/exotel/exotel.go
@@ -18,9 +18,14 @@ import (
 // Serializer implements wsserver.Serializer.
 var _ wsserver.Serializer = (*Serializer)(nil)
 
-// defaultSampleRate is Exotel's default stream rate. Exotel also supports 16 kHz;
-// set Config.SampleRate to match and run the pipeline at the same rate.
-const defaultSampleRate = 8000
+const (
+	// defaultSampleRate is Exotel's default stream rate. Exotel also supports 16 kHz;
+	// set Config.SampleRate to match and run the pipeline at the same rate.
+	defaultSampleRate = 8000
+
+	// eventMedia is the Exotel message event carrying base64 PCM audio.
+	eventMedia = "media"
+)
 
 // Config configures the Exotel serializer.
 type Config struct {
@@ -71,7 +76,7 @@ func (s *Serializer) Deserialize(data []byte) (frames.Frame, error) {
 		return nil, err
 	}
 	switch m.Event {
-	case "media":
+	case eventMedia:
 		pcm, err := base64.StdEncoding.DecodeString(m.Media.Payload)
 		if err != nil {
 			return nil, err
@@ -99,7 +104,7 @@ func (s *Serializer) media(pcm []byte) ([]byte, error) {
 	if sid == "" {
 		return nil, nil //nolint:nilnil // stream not started yet; drop until "start" arrives
 	}
-	out := mediaOut{Event: "media", StreamSID: sid}
+	out := mediaOut{Event: eventMedia, StreamSID: sid}
 	out.Media.Payload = base64.StdEncoding.EncodeToString(pcm)
 	return json.Marshal(out)
 }

--- a/transport/wsserver/telnyx/telnyx.go
+++ b/transport/wsserver/telnyx/telnyx.go
@@ -27,6 +27,9 @@ const (
 	sampleRate = 8000
 	hangupURL  = "https://api.telnyx.com/v2/calls/%s/actions/hangup"
 
+	// eventMedia is the Telnyx message event carrying base64 audio.
+	eventMedia = "media"
+
 	// EncodingPCMU selects G.711 μ-law; EncodingPCMA selects G.711 A-law. These
 	// are Telnyx's media_format.encoding values.
 	EncodingPCMU = "PCMU"
@@ -103,7 +106,7 @@ func (s *Serializer) Deserialize(data []byte) (frames.Frame, error) {
 		return nil, err
 	}
 	switch m.Event {
-	case "media":
+	case eventMedia:
 		payload, err := base64.StdEncoding.DecodeString(m.Media.Payload)
 		if err != nil {
 			return nil, err
@@ -132,7 +135,7 @@ func (s *Serializer) Deserialize(data []byte) (frames.Frame, error) {
 }
 
 func (s *Serializer) media(pcm []byte) ([]byte, error) {
-	out := mediaOut{Event: "media"}
+	out := mediaOut{Event: eventMedia}
 	out.Media.Payload = base64.StdEncoding.EncodeToString(encode(s.send, pcm))
 	return json.Marshal(out)
 }

--- a/utils/text/numbers.go
+++ b/utils/text/numbers.go
@@ -1,6 +1,7 @@
 package text
 
 import (
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -33,7 +34,7 @@ var (
 // table (>= 10^21) fall back to their decimal digits.
 func cardinal(n int64) string {
 	if n == 0 {
-		return "zero"
+		return onesWords[0]
 	}
 	neg := n < 0
 	if neg {
@@ -56,8 +57,7 @@ func cardinal(n int64) string {
 		val   int64
 	}
 	var parts []part
-	for i := len(groups) - 1; i >= 0; i-- {
-		g := groups[i]
+	for i, g := range slices.Backward(groups) {
 		if g == 0 {
 			continue
 		}
@@ -68,7 +68,8 @@ func cardinal(n int64) string {
 		parts = append(parts, part{t, i, g})
 	}
 
-	result := parts[0].text
+	var b strings.Builder
+	b.WriteString(parts[0].text)
 	for k := 1; k < len(parts); k++ {
 		sep := ", "
 		// num2words joins a final sub-hundred units group with " and " rather
@@ -76,8 +77,10 @@ func cardinal(n int64) string {
 		if k == len(parts)-1 && parts[k].scale == 0 && parts[k].val < 100 {
 			sep = " and "
 		}
-		result += sep + parts[k].text
+		b.WriteString(sep)
+		b.WriteString(parts[k].text)
 	}
+	result := b.String()
 	if neg {
 		return "minus " + result
 	}
@@ -88,8 +91,8 @@ func cardinal(n int64) string {
 // out-of-range fallback.
 func orig(neg bool, groups []int64) int64 {
 	var n int64
-	for i := len(groups) - 1; i >= 0; i-- {
-		n = n*1000 + groups[i]
+	for _, g := range slices.Backward(groups) {
+		n = n*1000 + g
 	}
 	if neg {
 		return -n


### PR DESCRIPTION
## What

Fixes the failing `lint` job (`golangci-lint`, `version: latest`). Six findings across three files:

| File | Finding | Fix |
|------|---------|-----|
| `utils/text/numbers.go` | `modernize` slicesbackward (×2) | `for i, g := range slices.Backward(groups)` |
| `utils/text/numbers.go` | `modernize` stringsbuilder (`+=` in loop) | build the joined result with `strings.Builder` |
| `utils/text/numbers.go` | `goconst` `"zero"` ×3 | return `onesWords[0]` for the zero case |
| `transport/wsserver/telnyx/telnyx.go` | `goconst` `"media"` ×3 | shared `eventMedia` constant |
| `transport/wsserver/exotel/exotel.go` | `goconst` `"media"` ×3 | shared `eventMedia` constant |

No behavior change — the number speller and the Telnyx/Exotel serializers produce identical output.

## Verification

Reproduced CI's `version: latest` with the official **golangci-lint v2.12.2** release binary and the repo config:

- Before: the same 6 findings.
- After: `0 issues`.

Also `go build ./...`, `go test` on the affected packages, and `golangci-lint fmt --diff` all pass.

## Side effect

This also recovers the OpenSSF Scorecard `CI-Tests` alert (Security tab): it only counts CI that runs **successfully**, and the last two merged PRs merged with a red lint job (2/4). Green CI on merged PRs restores the score.
