### PR TITLE
chore(ci): pin golangci-lint to v2.12.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,9 @@ jobs:
           go-version-file: go.mod
       - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
-          version: latest
+          # Pinned so a new golangci-lint release can't break CI by adding
+          # findings out from under a green tree; bump this deliberately.
+          version: v2.12.2
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Pins the lint job to `golangci-lint` **v2.12.2** instead of `version: latest`.

## Why

The `lint` job resolved `latest` at run time, so a new golangci-lint release could introduce `goconst`/`modernize` (or other) findings and turn CI red with **no code change** — which is what happened and required the fix in #29. Pinning makes lint results reproducible; the version is bumped deliberately in its own PR.

`v2.12.2` is the release CI was already resolving `latest` to, so this is a no-op for current results — the follow-up run should stay green.
