### PR TITLE
feat(eval): behavioral eval harness, jargo CLI, audio mode and suite runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,8 @@
 *.so
 *.dylib
 
-# Built example binaries (from `go build ./examples/...`)
+# Built binaries (from `go build ./cmd/...` or `go build ./examples/...`)
+/jargo
 /echo
 /voicebot
 /twiliobot

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -110,6 +110,7 @@ linters:
       case:
         rules:
           json: snake
+          yaml: snake
     gomodguard:
       blocked:
         modules:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   the command line against a running bot with `jargo eval run <scenario.yaml>
   --bot-url ws://…`. This first iteration covers text-mode scenarios — each user
   turn is delivered as RTVI `send-text`, and expectations match `llm_started`,
-  `llm_response` (`text_contains` or an optional LLM `judge`), and `function_call`
-  events in order, each within a `within_ms` latency budget.
+  `llm_response` (`text_contains` or an LLM `judge`), and `function_call`
+  events in order, each within a `within_ms` latency budget. A `judge:` criterion
+  is graded by an LLM judge (`eval.NewLLMJudge`, backed by any jargo LLM service;
+  `jargo eval run --judge-model …` for the CLI), with verdicts cached per
+  (criterion, reply).
 - **RTVI text input and richer event surface** (`processor/rtvi`): the processor
   now handles an inbound `send-text` message (appending a user turn and running
   the LLM), and emits `bot-llm-started`/`bot-llm-stopped`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   events in order, each within a `within_ms` latency budget. A `judge:` criterion
   is graded by an LLM judge (`eval.NewLLMJudge`, backed by any jargo LLM service;
   `jargo eval run --judge-model …` for the CLI), with verdicts cached per
-  (criterion, reply).
+  (criterion, reply). **Audio mode** (`Options.UserTTS`) synthesizes each user
+  turn and streams it to the bot as microphone audio at real-time cadence, so the
+  bot's real VAD, turn detection and STT run — unlocking `user_started_speaking`,
+  `user_stopped_speaking` and `user_transcription` assertions. **`jargo eval
+  suite <manifest.yaml>`** runs many scenarios across bots concurrently and prints
+  an aggregate summary.
 - **RTVI text input and richer event surface** (`processor/rtvi`): the processor
   now handles an inbound `send-text` message (appending a user turn and running
   the LLM), and emits `bot-llm-started`/`bot-llm-stopped`,
@@ -34,8 +39,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   `llm-function-call-result` server messages — so RTVI clients see the full
   response lifecycle and tool calls.
 - **RTVI-over-WebSocket serializer** (`transport/wsserver/rtviws`): a
-  `wsserver.Serializer` that carries the RTVI control, event, and text channel
-  over a plain WebSocket, so a client can drive a bot without WebRTC.
+  `wsserver.Serializer` that carries the RTVI control, event, and text channel —
+  plus inbound microphone audio (`raw-audio` → `InputAudioRawFrame`) — over a
+  plain WebSocket, so a client can drive a bot without WebRTC.
 - **NVIDIA Riva streaming STT** (`provider/nvidia`): `NewSTT` adds a gRPC
   streaming speech-to-text service that talks to NVIDIA's hosted ASR endpoint
   or a locally deployed Riva/NIM model (such as parakeet), selected through

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,25 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- **Behavioral eval harness** (`eval`) and a **`jargo` CLI** (`cmd/jargo`). The
+  harness drives a real bot over RTVI, plays scripted conversation turns from a
+  YAML scenario, and asserts on the semantic events the bot emits. Scenarios run
+  two ways off one core: in-process from a Go test with `eval.Run(t, path,
+  buildBot)` (the bot hosted on a loopback WebSocket via `eval.Handler`), or from
+  the command line against a running bot with `jargo eval run <scenario.yaml>
+  --bot-url ws://…`. This first iteration covers text-mode scenarios — each user
+  turn is delivered as RTVI `send-text`, and expectations match `llm_started`,
+  `llm_response` (`text_contains` or an optional LLM `judge`), and `function_call`
+  events in order, each within a `within_ms` latency budget.
+- **RTVI text input and richer event surface** (`processor/rtvi`): the processor
+  now handles an inbound `send-text` message (appending a user turn and running
+  the LLM), and emits `bot-llm-started`/`bot-llm-stopped`,
+  `bot-tts-started`/`bot-tts-stopped`, `llm-function-call-in-progress`, and
+  `llm-function-call-result` server messages — so RTVI clients see the full
+  response lifecycle and tool calls.
+- **RTVI-over-WebSocket serializer** (`transport/wsserver/rtviws`): a
+  `wsserver.Serializer` that carries the RTVI control, event, and text channel
+  over a plain WebSocket, so a client can drive a bot without WebRTC.
 - **NVIDIA Riva streaming STT** (`provider/nvidia`): `NewSTT` adds a gRPC
   streaming speech-to-text service that talks to NVIDIA's hosted ASR endpoint
   or a locally deployed Riva/NIM model (such as parakeet), selected through

--- a/cmd/jargo/eval.go
+++ b/cmd/jargo/eval.go
@@ -4,10 +4,12 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/gojargo/jargo/eval"
 	"github.com/gojargo/jargo/provider/openai"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 // CLI errors.
@@ -24,18 +26,13 @@ func evalCmd() *cobra.Command {
 		Use:   "eval",
 		Short: "Run behavioral eval scenarios against a jargo bot",
 	}
-	cmd.AddCommand(evalRunCmd())
+	cmd.AddCommand(evalRunCmd(), evalSuiteCmd())
 	return cmd
 }
 
 // evalRunCmd is `jargo eval run` — play scenarios against a running bot.
 func evalRunCmd() *cobra.Command {
-	var (
-		botURL     string
-		judgeModel string
-		judgeURL   string
-		judgeKey   string
-	)
+	var botURL string
 	cmd := &cobra.Command{
 		Use:   "run <scenario.yaml>...",
 		Short: "Play one or more scenarios against a running bot's RTVI WebSocket endpoint",
@@ -44,39 +41,99 @@ func evalRunCmd() *cobra.Command {
 			"scenario's result is printed; the command exits non-zero if any fail.\n\n" +
 			"Scenarios that use judge: need an LLM judge — enable one with --judge-model.",
 		Args: cobra.MinimumNArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if botURL == "" {
-				return errBotURLRequired
-			}
-			judge := buildJudge(judgeModel, judgeURL, judgeKey)
-			out := cmd.OutOrStdout()
-			failed := 0
-			for _, path := range args {
-				scenario, err := eval.Load(path)
-				if err != nil {
-					return err
-				}
-				res, err := eval.RunURL(cmd.Context(), scenario, botURL, judge)
-				if err != nil {
-					return fmt.Errorf("%s: %w", scenario.Name, err)
-				}
-				_, _ = fmt.Fprintln(out, res.String())
-				if !res.Passed() {
-					failed++
-				}
-			}
-			if failed > 0 {
-				return fmt.Errorf("%w: %d of %d", errScenariosFailed, failed, len(args))
-			}
-			return nil
-		},
 	}
-	f := cmd.Flags()
-	f.StringVar(&botURL, "bot-url", "", "RTVI WebSocket URL of the running bot (ws:// or wss://)")
-	f.StringVar(&judgeModel, "judge-model", "", "enable the LLM judge with this model id (for scenarios using judge:)")
-	f.StringVar(&judgeURL, "judge-url", "", "OpenAI-compatible base URL for the judge (e.g. a local Ollama)")
-	f.StringVar(&judgeKey, "judge-key", "", "API key for the judge endpoint (falls back to $OPENAI_API_KEY)")
+	getJudge := addJudgeFlags(cmd.Flags())
+	cmd.Flags().StringVar(&botURL, "bot-url", "", "RTVI WebSocket URL of the running bot (ws:// or wss://)")
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		if botURL == "" {
+			return errBotURLRequired
+		}
+		judge := getJudge()
+		out := cmd.OutOrStdout()
+		failed := 0
+		for _, path := range args {
+			scenario, err := eval.Load(path)
+			if err != nil {
+				return err
+			}
+			res, err := eval.RunURL(cmd.Context(), scenario, botURL, judge)
+			if err != nil {
+				return fmt.Errorf("%s: %w", scenario.Name, err)
+			}
+			_, _ = fmt.Fprintln(out, res.String())
+			if !res.Passed() {
+				failed++
+			}
+		}
+		if failed > 0 {
+			return fmt.Errorf("%w: %d of %d", errScenariosFailed, failed, len(args))
+		}
+		return nil
+	}
 	return cmd
+}
+
+// evalSuiteCmd is `jargo eval suite` — run a manifest of scenarios concurrently.
+func evalSuiteCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "suite <manifest.yaml>",
+		Short: "Run a manifest of scenarios against one or more bots, concurrently",
+		Args:  cobra.ExactArgs(1),
+	}
+	getJudge := addJudgeFlags(cmd.Flags())
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		m, err := eval.LoadManifest(args[0])
+		if err != nil {
+			return err
+		}
+		results := eval.RunSuite(cmd.Context(), m, getJudge())
+		out := cmd.OutOrStdout()
+		p := func(format string, a ...any) { _, _ = fmt.Fprintf(out, format, a...) }
+
+		failed := 0
+		for _, r := range results {
+			p("%-5s %s (%s)\n", suiteStatus(r), filepath.Base(r.Scenario), r.BotURL)
+			if r.Err != nil {
+				p("  %v\n", r.Err)
+			}
+			for _, f := range r.Result.Failures {
+				p("  - %s\n", f)
+			}
+			if !r.Passed() {
+				failed++
+			}
+		}
+		p("\n%d/%d scenarios passed\n", len(results)-failed, len(results))
+		if failed > 0 {
+			return fmt.Errorf("%w: %d of %d", errScenariosFailed, failed, len(results))
+		}
+		return nil
+	}
+	return cmd
+}
+
+// suiteStatus is the one-word status for a suite result.
+func suiteStatus(r eval.SuiteResult) string {
+	switch {
+	case r.Err != nil:
+		return "ERROR"
+	case !r.Result.Passed():
+		return "FAIL"
+	default:
+		return "PASS"
+	}
+}
+
+// addJudgeFlags registers the --judge-* flags on f and returns a getter that
+// builds the configured judge (nil when no --judge-model is set).
+func addJudgeFlags(f *pflag.FlagSet) func() eval.Judge {
+	var model, baseURL, key string
+	f.StringVar(&model, "judge-model", "", "enable the LLM judge with this model id (for scenarios using judge:)")
+	f.StringVar(&baseURL, "judge-url", "", "OpenAI-compatible base URL for the judge (e.g. a local Ollama)")
+	f.StringVar(&key, "judge-key", "", "API key for the judge endpoint (falls back to $OPENAI_API_KEY)")
+	return func() eval.Judge { return buildJudge(model, baseURL, key) }
 }
 
 // buildJudge constructs an LLM judge from the flags, or nil when no judge model

--- a/cmd/jargo/eval.go
+++ b/cmd/jargo/eval.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/gojargo/jargo/eval"
+	"github.com/spf13/cobra"
+)
+
+// CLI errors.
+//
+//nolint:gochecknoglobals // sentinel errors
+var (
+	errBotURLRequired  = errors.New("--bot-url is required")
+	errScenariosFailed = errors.New("scenarios failed")
+)
+
+// evalCmd is the `jargo eval` command group.
+func evalCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "eval",
+		Short: "Run behavioral eval scenarios against a jargo bot",
+	}
+	cmd.AddCommand(evalRunCmd())
+	return cmd
+}
+
+// evalRunCmd is `jargo eval run` — play scenarios against a running bot.
+func evalRunCmd() *cobra.Command {
+	var botURL string
+	cmd := &cobra.Command{
+		Use:   "run <scenario.yaml>...",
+		Short: "Play one or more scenarios against a running bot's RTVI WebSocket endpoint",
+		Long: "Play one or more scenarios against a running bot.\n\n" +
+			"The bot must expose an RTVI WebSocket endpoint (see eval.Handler). Each\n" +
+			"scenario's result is printed; the command exits non-zero if any fail.",
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if botURL == "" {
+				return errBotURLRequired
+			}
+			out := cmd.OutOrStdout()
+			failed := 0
+			for _, path := range args {
+				scenario, err := eval.Load(path)
+				if err != nil {
+					return err
+				}
+				res, err := eval.RunURL(cmd.Context(), scenario, botURL, nil)
+				if err != nil {
+					return fmt.Errorf("%s: %w", scenario.Name, err)
+				}
+				_, _ = fmt.Fprintln(out, res.String())
+				if !res.Passed() {
+					failed++
+				}
+			}
+			if failed > 0 {
+				return fmt.Errorf("%w: %d of %d", errScenariosFailed, failed, len(args))
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&botURL, "bot-url", "", "RTVI WebSocket URL of the running bot (ws:// or wss://)")
+	return cmd
+}

--- a/cmd/jargo/eval.go
+++ b/cmd/jargo/eval.go
@@ -3,8 +3,10 @@ package main
 import (
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/gojargo/jargo/eval"
+	"github.com/gojargo/jargo/provider/openai"
 	"github.com/spf13/cobra"
 )
 
@@ -28,18 +30,25 @@ func evalCmd() *cobra.Command {
 
 // evalRunCmd is `jargo eval run` — play scenarios against a running bot.
 func evalRunCmd() *cobra.Command {
-	var botURL string
+	var (
+		botURL     string
+		judgeModel string
+		judgeURL   string
+		judgeKey   string
+	)
 	cmd := &cobra.Command{
 		Use:   "run <scenario.yaml>...",
 		Short: "Play one or more scenarios against a running bot's RTVI WebSocket endpoint",
 		Long: "Play one or more scenarios against a running bot.\n\n" +
 			"The bot must expose an RTVI WebSocket endpoint (see eval.Handler). Each\n" +
-			"scenario's result is printed; the command exits non-zero if any fail.",
+			"scenario's result is printed; the command exits non-zero if any fail.\n\n" +
+			"Scenarios that use judge: need an LLM judge — enable one with --judge-model.",
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if botURL == "" {
 				return errBotURLRequired
 			}
+			judge := buildJudge(judgeModel, judgeURL, judgeKey)
 			out := cmd.OutOrStdout()
 			failed := 0
 			for _, path := range args {
@@ -47,7 +56,7 @@ func evalRunCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				res, err := eval.RunURL(cmd.Context(), scenario, botURL, nil)
+				res, err := eval.RunURL(cmd.Context(), scenario, botURL, judge)
 				if err != nil {
 					return fmt.Errorf("%s: %w", scenario.Name, err)
 				}
@@ -62,6 +71,27 @@ func evalRunCmd() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&botURL, "bot-url", "", "RTVI WebSocket URL of the running bot (ws:// or wss://)")
+	f := cmd.Flags()
+	f.StringVar(&botURL, "bot-url", "", "RTVI WebSocket URL of the running bot (ws:// or wss://)")
+	f.StringVar(&judgeModel, "judge-model", "", "enable the LLM judge with this model id (for scenarios using judge:)")
+	f.StringVar(&judgeURL, "judge-url", "", "OpenAI-compatible base URL for the judge (e.g. a local Ollama)")
+	f.StringVar(&judgeKey, "judge-key", "", "API key for the judge endpoint (falls back to $OPENAI_API_KEY)")
 	return cmd
+}
+
+// buildJudge constructs an LLM judge from the flags, or nil when no judge model
+// is set. It targets any OpenAI-compatible endpoint (OpenAI, a local Ollama via
+// --judge-url, etc.).
+func buildJudge(model, baseURL, key string) eval.Judge {
+	if model == "" {
+		return nil
+	}
+	if key == "" {
+		key = os.Getenv("OPENAI_API_KEY")
+	}
+	return eval.NewLLMJudge(openai.NewLLM(openai.LLMConfig{
+		BaseURL: baseURL,
+		Model:   model,
+		APIKey:  key,
+	}))
 }

--- a/cmd/jargo/eval_test.go
+++ b/cmd/jargo/eval_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"context"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gojargo/jargo/eval"
+	"github.com/gojargo/jargo/frames"
+	"github.com/gojargo/jargo/pipeline"
+	"github.com/gojargo/jargo/processor"
+	"github.com/gojargo/jargo/processor/aggregators"
+	"github.com/gojargo/jargo/processor/rtvi"
+)
+
+// echoLLM answers each turn by echoing the user's last message, so the CLI can
+// be tested against a real (if trivial) bot.
+type echoLLM struct{ *processor.Base }
+
+func newEchoLLM() *echoLLM {
+	e := &echoLLM{}
+	e.Base = processor.New("EchoLLM", e)
+	return e
+}
+
+func (e *echoLLM) ProcessFrame(ctx context.Context, f frames.Frame, dir processor.Direction) error {
+	if err := e.Base.ProcessFrame(ctx, f, dir); err != nil {
+		return err
+	}
+	cf, ok := f.(*frames.LLMContextFrame)
+	if !ok {
+		return e.PushFrame(ctx, f, dir)
+	}
+	msgs := cf.Context.Messages()
+	last := ""
+	if len(msgs) > 0 {
+		last = msgs[len(msgs)-1].Text
+	}
+	_ = e.PushFrame(ctx, frames.NewLLMFullResponseStartFrame(), processor.Downstream)
+	_ = e.PushFrame(ctx, frames.NewLLMTextFrame("echo: "+last), processor.Downstream)
+	return e.PushFrame(ctx, frames.NewLLMFullResponseEndFrame(), processor.Downstream)
+}
+
+func echoBot(in, out processor.Processor) *pipeline.Task {
+	agg := aggregators.New(frames.NewLLMContext("test"))
+	return pipeline.NewTask(pipeline.New(
+		in, agg.User(), newEchoLLM(), rtvi.NewProcessor(), out, agg.Assistant(),
+	), pipeline.TaskParams{})
+}
+
+func writeScenario(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "scenario.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestEvalRunAgainstBot(t *testing.T) {
+	srv := httptest.NewServer(eval.Handler(echoBot))
+	defer srv.Close()
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+
+	path := writeScenario(t, `
+name: cli
+turns:
+  - user: "ping"
+    expect:
+      - event: llm_response
+        text_contains: "echo: ping"
+`)
+
+	var out strings.Builder
+	cmd := rootCmd()
+	cmd.SetArgs([]string{"eval", "run", path, "--bot-url", wsURL})
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("eval run failed: %v\noutput:\n%s", err, out.String())
+	}
+	if !strings.Contains(out.String(), "PASS cli") {
+		t.Fatalf("expected PASS in output, got:\n%s", out.String())
+	}
+}
+
+func TestEvalRunRequiresBotURL(t *testing.T) {
+	path := writeScenario(t, "name: x\nturns:\n  - user: hi\n    expect:\n      - event: llm_started\n")
+
+	var out strings.Builder
+	cmd := rootCmd()
+	cmd.SetArgs([]string{"eval", "run", path})
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected an error when --bot-url is missing")
+	}
+}

--- a/cmd/jargo/eval_test.go
+++ b/cmd/jargo/eval_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -85,6 +86,42 @@ turns:
 	}
 	if !strings.Contains(out.String(), "PASS cli") {
 		t.Fatalf("expected PASS in output, got:\n%s", out.String())
+	}
+}
+
+func TestEvalSuiteAgainstBots(t *testing.T) {
+	srv := httptest.NewServer(eval.Handler(echoBot))
+	defer srv.Close()
+	ws := "ws" + strings.TrimPrefix(srv.URL, "http")
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "s.yaml"), []byte(`name: s
+turns:
+  - user: "ping"
+    expect:
+      - event: llm_response
+        text_contains: "echo: ping"
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "m.yaml"), fmt.Appendf(nil, `suite:
+  - bot_url: %s
+    scenarios: [s.yaml]
+`, ws), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var out strings.Builder
+	cmd := rootCmd()
+	cmd.SetArgs([]string{"eval", "suite", filepath.Join(dir, "m.yaml")})
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("eval suite failed: %v\noutput:\n%s", err, out.String())
+	}
+	if !strings.Contains(out.String(), "1/1 scenarios passed") {
+		t.Fatalf("expected summary in output, got:\n%s", out.String())
 	}
 }
 

--- a/cmd/jargo/eval_test.go
+++ b/cmd/jargo/eval_test.go
@@ -88,6 +88,15 @@ turns:
 	}
 }
 
+func TestBuildJudge(t *testing.T) {
+	if buildJudge("", "", "") != nil {
+		t.Fatal("no --judge-model should yield no judge")
+	}
+	if buildJudge("gpt-4o-mini", "", "") == nil {
+		t.Fatal("a --judge-model should yield a judge")
+	}
+}
+
 func TestEvalRunRequiresBotURL(t *testing.T) {
 	path := writeScenario(t, "name: x\nturns:\n  - user: hi\n    expect:\n      - event: llm_started\n")
 

--- a/cmd/jargo/main.go
+++ b/cmd/jargo/main.go
@@ -1,0 +1,41 @@
+// Command jargo is the command-line entry point for jargo tooling. Today it
+// hosts the behavioral eval runner (jargo eval run); the subcommand tree leaves
+// room for more as the toolchain grows.
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+
+	"github.com/spf13/cobra"
+)
+
+func main() {
+	os.Exit(run())
+}
+
+// run executes the CLI and returns a process exit code, so main's deferred
+// cleanup (signal reset) runs before the process exits.
+func run() int {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	if err := rootCmd().ExecuteContext(ctx); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, "error:", err)
+		return 1
+	}
+	return 0
+}
+
+// rootCmd builds the top-level jargo command.
+func rootCmd() *cobra.Command {
+	root := &cobra.Command{
+		Use:          "jargo",
+		Short:        "Tooling for building and testing jargo voice agents",
+		SilenceUsage: true,
+	}
+	root.AddCommand(evalCmd())
+	return root
+}

--- a/eval/audio.go
+++ b/eval/audio.go
@@ -1,0 +1,113 @@
+package eval
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/gojargo/jargo/frames"
+	"github.com/gojargo/jargo/pipeline"
+	"github.com/gojargo/jargo/service/tts"
+	"github.com/gojargo/jargo/transport/wsserver/rtviws"
+)
+
+const (
+	// audioChunkMS is the size of each streamed mic frame — the granularity a live
+	// transport delivers, and what VAD and turn models consume.
+	audioChunkMS = 20
+	// silenceTailMS is how much trailing silence follows a user turn's speech, so
+	// the bot's VAD registers the end of the turn.
+	silenceTailMS = 1000
+)
+
+// errNoUserAudio is returned when the user TTS produced no audio for a turn.
+//
+//nolint:gochecknoglobals // sentinel error
+var errNoUserAudio = errors.New("eval: user TTS produced no audio")
+
+// sendUserAudio synthesizes text and streams it to the bot as microphone audio:
+// ~20ms frames at real-time cadence, then a tail of silence so the bot's VAD
+// ends the turn. Real-time pacing matters — flooding the whole utterance at once
+// breaks VAD windows and turn-detecting STTs.
+func (s *session) sendUserAudio(ctx context.Context, text string) error {
+	pcm, rate, err := synthesize(ctx, s.userTTS, text)
+	if err != nil {
+		return err
+	}
+	if rate == 0 || len(pcm) == 0 {
+		return errNoUserAudio
+	}
+
+	bytesPerChunk := (rate * audioChunkMS / 1000) * 2 // 16-bit mono
+	ticker := time.NewTicker(audioChunkMS * time.Millisecond)
+	defer ticker.Stop()
+
+	send := func(chunk []byte) error {
+		if err := s.client.send(ctx, rtviws.RawAudio(chunk, rate, 1)); err != nil {
+			return err
+		}
+		select {
+		case <-ticker.C:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	for off := 0; off < len(pcm); off += bytesPerChunk {
+		end := min(off+bytesPerChunk, len(pcm))
+		if err := send(pcm[off:end]); err != nil {
+			return err
+		}
+	}
+
+	silence := make([]byte, bytesPerChunk)
+	for sent := 0; sent < silenceTailMS; sent += audioChunkMS {
+		if err := send(silence); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// synthesize runs ttsService one-shot to render text to PCM, returning the audio
+// and its sample rate. It drives the service as a single-node pipeline and
+// collects the emitted TTS audio.
+func synthesize(ctx context.Context, ttsService *tts.Base, text string) ([]byte, int, error) {
+	var (
+		pcm  []byte
+		rate int
+		once sync.Once
+	)
+	done := make(chan struct{})
+	task := pipeline.NewTask(pipeline.New(ttsService), pipeline.TaskParams{
+		OnReachedDownstream: func(f frames.Frame) {
+			switch fr := f.(type) {
+			case *frames.TTSAudioRawFrame:
+				pcm = append(pcm, fr.Audio...)
+				rate = fr.SampleRate
+			case *frames.TTSStoppedFrame:
+				once.Do(func() { close(done) })
+			}
+		},
+	})
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- task.Run(ctx) }()
+
+	task.QueueFrame(frames.NewTTSSpeakFrame(text))
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		task.Cancel()
+		<-runErr
+		return nil, 0, ctx.Err()
+	}
+	task.StopWhenDone()
+	if err := <-runErr; err != nil {
+		return nil, 0, err
+	}
+	return pcm, rate, nil
+}

--- a/eval/audio_test.go
+++ b/eval/audio_test.go
@@ -1,0 +1,143 @@
+package eval_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gojargo/jargo/eval"
+	"github.com/gojargo/jargo/frames"
+	"github.com/gojargo/jargo/pipeline"
+	"github.com/gojargo/jargo/processor"
+	"github.com/gojargo/jargo/processor/aggregators"
+	"github.com/gojargo/jargo/processor/rtvi"
+	"github.com/gojargo/jargo/service/tts"
+)
+
+const audioRate = 16000
+
+// fakeSynth is a canned tts.Synthesizer: it emits ~200ms of non-silent PCM for
+// any text, so the harness has audio to stream and a downstream detector has
+// energy to trip on.
+type fakeSynth struct{}
+
+func (fakeSynth) SampleRate() int { return audioRate }
+
+func (fakeSynth) Synthesize(_ context.Context, _ string, emit func(pcm []byte) error) error {
+	pcm := make([]byte, audioRate/5*2) // 200ms of 16-bit mono
+	for i := range pcm {
+		pcm[i] = 0x20 // non-zero → "speech"
+	}
+	return emit(pcm)
+}
+
+// fakeAudioSTT stands in for a VAD + STT stack without the ONNX runtime: it
+// watches the streamed mic audio, marks the user speaking on the first non-silent
+// frame, and — once a stretch of silence follows — ends the turn and emits a
+// canned transcription. That drives the aggregator exactly as a real STT would.
+type fakeAudioSTT struct {
+	*processor.Base
+	speaking bool
+	silence  int
+}
+
+func newFakeAudioSTT() *fakeAudioSTT {
+	s := &fakeAudioSTT{}
+	s.Base = processor.New("FakeAudioSTT", s)
+	return s
+}
+
+func (s *fakeAudioSTT) ProcessFrame(ctx context.Context, f frames.Frame, dir processor.Direction) error {
+	if err := s.Base.ProcessFrame(ctx, f, dir); err != nil {
+		return err
+	}
+	af, ok := f.(*frames.InputAudioRawFrame)
+	if !ok {
+		return s.PushFrame(ctx, f, dir)
+	}
+	if err := s.observe(ctx, af.Audio); err != nil {
+		return err
+	}
+	return s.PushFrame(ctx, af, dir)
+}
+
+// observe tracks speech vs silence and drives the turn boundary.
+func (s *fakeAudioSTT) observe(ctx context.Context, audio []byte) error {
+	if !allZero(audio) {
+		s.silence = 0
+		if s.speaking {
+			return nil
+		}
+		s.speaking = true
+		return s.PushFrame(ctx, frames.NewUserStartedSpeakingFrame(), processor.Downstream)
+	}
+	if !s.speaking {
+		return nil
+	}
+	s.silence++
+	if s.silence < 10 { // wait for ~200ms of trailing silence
+		return nil
+	}
+	return s.endTurn(ctx)
+}
+
+// endTurn ends the user's turn and emits a canned transcription.
+func (s *fakeAudioSTT) endTurn(ctx context.Context) error {
+	s.speaking = false
+	s.silence = 0
+	if err := s.PushFrame(ctx, frames.NewUserStoppedSpeakingFrame(), processor.Downstream); err != nil {
+		return err
+	}
+	tf := frames.NewTranscriptionFrame("hello from audio", "user", "")
+	tf.Finalized = true
+	return s.PushFrame(ctx, tf, processor.Downstream)
+}
+
+func allZero(b []byte) bool {
+	for _, x := range b {
+		if x != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func buildAudioBot(in, out processor.Processor) *pipeline.Task {
+	agg := aggregators.New(frames.NewLLMContext("test"))
+	return pipeline.NewTask(pipeline.New(
+		in, newFakeAudioSTT(), agg.User(), newFakeLLM(), rtvi.NewProcessor(), out, agg.Assistant(),
+	), pipeline.TaskParams{AudioInSampleRate: audioRate})
+}
+
+// TestHarnessAudioMode drives the full real input path: the harness synthesizes
+// the user turn, streams it as mic audio, and the bot's (fake) VAD/STT turn it
+// into speaking + transcription events that reach the assertions.
+func TestHarnessAudioMode(t *testing.T) {
+	scenario, err := eval.Load(writeScenario(t, `
+name: audio
+turns:
+  - user: "hello"
+    expect:
+      - event: user_started_speaking
+      - event: user_transcription
+        text_contains: "audio"
+      - event: llm_response
+        text_contains: "you said"
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	res, err := eval.Host(ctx, scenario, buildAudioBot, eval.Options{
+		UserTTS: tts.New("fakeTTS", fakeSynth{}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.Passed() {
+		t.Fatalf("expected pass, got:\n%s", res)
+	}
+}

--- a/eval/client.go
+++ b/eval/client.go
@@ -1,0 +1,69 @@
+package eval
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/coder/websocket"
+	"github.com/gojargo/jargo/processor/rtvi"
+)
+
+// readLimit bounds a single inbound message; RTVI control messages are small.
+const readLimit = 1 << 20
+
+// client is an RTVI client over a plain WebSocket. It reads server messages in
+// the background and delivers them on incoming.
+type client struct {
+	conn     *websocket.Conn
+	incoming chan rtvi.Incoming
+}
+
+// dial connects to a bot's RTVI WebSocket endpoint and starts reading messages.
+func dial(ctx context.Context, url string) (*client, error) {
+	conn, resp, err := websocket.Dial(ctx, url, nil)
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	if err != nil {
+		return nil, fmt.Errorf("eval: dial %s: %w", url, err)
+	}
+	conn.SetReadLimit(readLimit)
+	c := &client{conn: conn, incoming: make(chan rtvi.Incoming, 64)}
+	go c.readLoop(ctx)
+	return c, nil
+}
+
+// readLoop reads RTVI messages until the socket closes or ctx is canceled.
+func (c *client) readLoop(ctx context.Context) {
+	defer close(c.incoming)
+	for {
+		_, data, err := c.conn.Read(ctx)
+		if err != nil {
+			return
+		}
+		in, err := rtvi.ParseIncoming(data)
+		if err != nil || in.Label != rtvi.MessageLabel {
+			continue
+		}
+		select {
+		case c.incoming <- in:
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// send writes an RTVI message to the bot.
+func (c *client) send(ctx context.Context, msg rtvi.Message) error {
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+	return c.conn.Write(ctx, websocket.MessageText, data)
+}
+
+// close shuts the connection down.
+func (c *client) close() {
+	_ = c.conn.Close(websocket.StatusNormalClosure, "")
+}

--- a/eval/client.go
+++ b/eval/client.go
@@ -29,7 +29,9 @@ func dial(ctx context.Context, url string) (*client, error) {
 		return nil, fmt.Errorf("eval: dial %s: %w", url, err)
 	}
 	conn.SetReadLimit(readLimit)
-	c := &client{conn: conn, incoming: make(chan rtvi.Incoming, 64)}
+	// A generous buffer so events emitted while the harness is busy streaming a
+	// turn's audio (audio mode) are not dropped before matching reads them.
+	c := &client{conn: conn, incoming: make(chan rtvi.Incoming, 256)}
 	go c.readLoop(ctx)
 	return c, nil
 }

--- a/eval/harness_test.go
+++ b/eval/harness_test.go
@@ -1,0 +1,143 @@
+package eval_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gojargo/jargo/eval"
+	"github.com/gojargo/jargo/frames"
+	"github.com/gojargo/jargo/pipeline"
+	"github.com/gojargo/jargo/processor"
+	"github.com/gojargo/jargo/processor/aggregators"
+	"github.com/gojargo/jargo/processor/rtvi"
+)
+
+// fakeLLM answers each turn deterministically so the harness can be exercised
+// end-to-end without a real model: it echoes the user's text, and on a weather
+// question it emits a get_weather tool call instead.
+type fakeLLM struct {
+	*processor.Base
+}
+
+func newFakeLLM() *fakeLLM {
+	f := &fakeLLM{}
+	f.Base = processor.New("FakeLLM", f)
+	return f
+}
+
+func (f *fakeLLM) ProcessFrame(ctx context.Context, frame frames.Frame, dir processor.Direction) error {
+	if err := f.Base.ProcessFrame(ctx, frame, dir); err != nil {
+		return err
+	}
+	cf, ok := frame.(*frames.LLMContextFrame)
+	if !ok {
+		return f.PushFrame(ctx, frame, dir)
+	}
+
+	msgs := cf.Context.Messages()
+	last := ""
+	if len(msgs) > 0 {
+		last = msgs[len(msgs)-1].Text
+	}
+
+	if err := f.PushFrame(ctx, frames.NewLLMFullResponseStartFrame(), processor.Downstream); err != nil {
+		return err
+	}
+	if strings.Contains(strings.ToLower(last), "weather") {
+		call := frames.NewFunctionCallInProgressFrame("call-1", "get_weather")
+		if err := f.PushFrame(ctx, call, processor.Downstream); err != nil {
+			return err
+		}
+	} else if err := f.PushFrame(ctx, frames.NewLLMTextFrame("you said: "+last), processor.Downstream); err != nil {
+		return err
+	}
+	return f.PushFrame(ctx, frames.NewLLMFullResponseEndFrame(), processor.Downstream)
+}
+
+func buildFakeBot(in, out processor.Processor) *pipeline.Task {
+	agg := aggregators.New(frames.NewLLMContext("test system"))
+	return pipeline.NewTask(pipeline.New(
+		in, agg.User(), newFakeLLM(), rtvi.NewProcessor(), out, agg.Assistant(),
+	), pipeline.TaskParams{})
+}
+
+func host(t *testing.T, body string) eval.Result {
+	t.Helper()
+	scenario, err := eval.Load(writeScenario(t, body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	res, err := eval.Host(ctx, scenario, buildFakeBot, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return res
+}
+
+func TestHarnessTextResponse(t *testing.T) {
+	res := host(t, `
+name: echo
+turns:
+  - user: "hello world"
+    expect:
+      - event: llm_started
+      - event: llm_response
+        text_contains: "hello world"
+`)
+	if !res.Passed() {
+		t.Fatalf("expected pass, got:\n%s", res)
+	}
+}
+
+func TestHarnessFunctionCall(t *testing.T) {
+	res := host(t, `
+name: weather
+turns:
+  - user: "what's the weather in Paris?"
+    expect:
+      - event: function_call
+        function: get_weather
+`)
+	if !res.Passed() {
+		t.Fatalf("expected pass, got:\n%s", res)
+	}
+}
+
+func TestHarnessReportsTextMismatch(t *testing.T) {
+	res := host(t, `
+name: mismatch
+turns:
+  - user: "hello"
+    expect:
+      - event: llm_response
+        text_contains: "goodbye"
+`)
+	if res.Passed() {
+		t.Fatal("expected a failure for the unmet text_contains")
+	}
+	if !strings.Contains(res.Failures[0].Reason, "does not contain") {
+		t.Fatalf("unexpected failure reason: %s", res.Failures[0].Reason)
+	}
+}
+
+func TestHarnessReportsMissingFunction(t *testing.T) {
+	res := host(t, `
+name: missing-call
+turns:
+  - user: "hello"
+    expect:
+      - event: function_call
+        function: get_weather
+        within_ms: 800
+`)
+	if res.Passed() {
+		t.Fatal("expected a timeout failure for the tool call that never happens")
+	}
+	if !strings.Contains(res.Failures[0].Reason, "no matching function_call") {
+		t.Fatalf("unexpected failure reason: %s", res.Failures[0].Reason)
+	}
+}

--- a/eval/harness_test.go
+++ b/eval/harness_test.go
@@ -71,7 +71,7 @@ func host(t *testing.T, body string) eval.Result {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
-	res, err := eval.Host(ctx, scenario, buildFakeBot, nil)
+	res, err := eval.Host(ctx, scenario, buildFakeBot, eval.Options{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/eval/judge.go
+++ b/eval/judge.go
@@ -1,6 +1,13 @@
 package eval
 
-import "context"
+import (
+	"context"
+	"strings"
+	"sync"
+
+	"github.com/gojargo/jargo/frames"
+	"github.com/gojargo/jargo/service/llm"
+)
 
 // Judge decides whether a bot reply satisfies a natural-language criterion — it
 // backs a scenario's `judge:` assertion. Implementations typically run a
@@ -10,4 +17,90 @@ type Judge interface {
 	// Evaluate reports whether reply meets criterion, with a short reason to
 	// surface when it does not.
 	Evaluate(ctx context.Context, criterion, reply string) (pass bool, reason string, err error)
+}
+
+// judgeInstruction steers the grading model toward a terse, parseable verdict.
+const judgeInstruction = "You grade a voice assistant's reply against a single criterion. " +
+	"Decide whether the reply satisfies the criterion. Start your response with the word " +
+	"PASS if it does or FAIL if it does not, then give a brief reason. Judge only against the " +
+	"stated criterion; do not invent extra requirements."
+
+// LLMJudge evaluates criteria with an LLM. It runs each judgement as a one-shot
+// generation off to the side of the pipeline (like the summarizer), so give it
+// its own service instance — ideally a small, fast model. Verdicts are cached by
+// (criterion, reply) so re-runs are stable and a repeated assertion pays only
+// one round-trip.
+type LLMJudge struct {
+	gen llm.Generator
+
+	mu    sync.Mutex
+	cache map[string]verdict
+}
+
+// verdict is a cached judgement.
+type verdict struct {
+	pass   bool
+	reason string
+}
+
+// NewLLMJudge builds a judge backed by gen. Any jargo LLM service works, e.g.
+// eval.NewLLMJudge(openai.NewLLM(openai.LLMConfig{APIKey: key})).
+func NewLLMJudge(gen llm.Generator) *LLMJudge {
+	return &LLMJudge{gen: gen, cache: make(map[string]verdict)}
+}
+
+// Evaluate grades reply against criterion, caching the result.
+func (j *LLMJudge) Evaluate(ctx context.Context, criterion, reply string) (bool, string, error) {
+	key := criterion + "\x00" + reply
+
+	j.mu.Lock()
+	if v, ok := j.cache[key]; ok {
+		j.mu.Unlock()
+		return v.pass, v.reason, nil
+	}
+	j.mu.Unlock()
+
+	convo := frames.NewLLMContext(judgeInstruction)
+	convo.AddUserMessage("Criterion: " + criterion + "\n\nReply to evaluate:\n" + reply)
+
+	var b strings.Builder
+	if err := j.gen.Generate(ctx, convo, func(text string) error {
+		b.WriteString(text)
+		return nil
+	}); err != nil {
+		return false, "", err
+	}
+	pass, reason := parseVerdict(b.String())
+
+	j.mu.Lock()
+	j.cache[key] = verdict{pass: pass, reason: reason}
+	j.mu.Unlock()
+
+	return pass, reason, nil
+}
+
+// parseVerdict reads a PASS/FAIL judgement out of the model's response. It trusts
+// a verdict word leading the first line, and otherwise falls back to whichever of
+// PASS/FAIL appears first anywhere in the text. The full response is returned as
+// the reason. Absent any verdict word it reports a failure, so an unparseable
+// judgement never silently passes.
+func parseVerdict(out string) (bool, string) {
+	out = strings.TrimSpace(out)
+	if out == "" {
+		return false, "judge returned no output"
+	}
+
+	firstLine, _, _ := strings.Cut(out, "\n")
+	upper := strings.ToUpper(strings.TrimSpace(firstLine))
+	switch {
+	case strings.HasPrefix(upper, "PASS"), strings.HasPrefix(upper, "YES"):
+		return true, out
+	case strings.HasPrefix(upper, "FAIL"), strings.HasPrefix(upper, "NO"):
+		return false, out
+	}
+
+	all := strings.ToUpper(out)
+	pi, fi := strings.Index(all, "PASS"), strings.Index(all, "FAIL")
+	pass := pi >= 0 && (fi < 0 || pi < fi)
+	return pass, out
 }

--- a/eval/judge.go
+++ b/eval/judge.go
@@ -1,0 +1,13 @@
+package eval
+
+import "context"
+
+// Judge decides whether a bot reply satisfies a natural-language criterion — it
+// backs a scenario's `judge:` assertion. Implementations typically run a
+// one-shot LLM inference; the harness treats the judge as optional, so a
+// scenario without any `judge:` assertions needs none.
+type Judge interface {
+	// Evaluate reports whether reply meets criterion, with a short reason to
+	// surface when it does not.
+	Evaluate(ctx context.Context, criterion, reply string) (pass bool, reason string, err error)
+}

--- a/eval/judge_test.go
+++ b/eval/judge_test.go
@@ -80,7 +80,7 @@ turns:
 		t.Fatal(err)
 	}
 	judge := eval.NewLLMJudge(&fakeGen{reply: "PASS — it echoes the greeting"})
-	res, err := eval.Host(context.Background(), scenario, buildFakeBot, judge)
+	res, err := eval.Host(context.Background(), scenario, buildFakeBot, eval.Options{Judge: judge})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -99,7 +99,7 @@ turns:
         judge: "asks a clarifying question"
 `))
 	judge := eval.NewLLMJudge(&fakeGen{reply: "FAIL: it just echoes, no question"})
-	res, err := eval.Host(context.Background(), scenario, buildFakeBot, judge)
+	res, err := eval.Host(context.Background(), scenario, buildFakeBot, eval.Options{Judge: judge})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/eval/judge_test.go
+++ b/eval/judge_test.go
@@ -1,0 +1,112 @@
+package eval_test
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gojargo/jargo/eval"
+	"github.com/gojargo/jargo/frames"
+	"github.com/gojargo/jargo/service/llm"
+)
+
+// fakeGen is a canned llm.Generator: it emits reply and counts its calls.
+type fakeGen struct {
+	reply string
+	calls atomic.Int32
+}
+
+func (g *fakeGen) Generate(_ context.Context, _ *frames.LLMContext, emit llm.Emit) error {
+	g.calls.Add(1)
+	return emit(g.reply)
+}
+
+func TestLLMJudgeVerdicts(t *testing.T) {
+	cases := map[string]struct {
+		out      string
+		wantPass bool
+	}{
+		"pass first line":   {"PASS — greets the user warmly", true},
+		"fail first line":   {"FAIL: too terse", false},
+		"yes":               {"YES, it answers the question", true},
+		"no":                {"NO, it dodges", false},
+		"pass mid-text":     {"The reply is good, so PASS.", true},
+		"no verdict word":   {"The reply seems fine.", false},
+		"contradictory ord": {"PASS. It does not FAIL the criterion.", true},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			j := eval.NewLLMJudge(&fakeGen{reply: tc.out})
+			pass, reason, err := j.Evaluate(context.Background(), "greets warmly", "hi there")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if pass != tc.wantPass {
+				t.Fatalf("pass = %v, want %v (reason %q)", pass, tc.wantPass, reason)
+			}
+		})
+	}
+}
+
+func TestLLMJudgeCaches(t *testing.T) {
+	gen := &fakeGen{reply: "PASS ok"}
+	j := eval.NewLLMJudge(gen)
+	for range 3 {
+		if _, _, err := j.Evaluate(context.Background(), "crit", "reply"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// A different (criterion, reply) is a cache miss.
+	if _, _, err := j.Evaluate(context.Background(), "crit", "other reply"); err != nil {
+		t.Fatal(err)
+	}
+	if got := gen.calls.Load(); got != 2 {
+		t.Fatalf("generator called %d times, want 2 (one per distinct input)", got)
+	}
+}
+
+func TestHarnessJudgePasses(t *testing.T) {
+	// The bot echoes "you said: hello there"; the judge is told to PASS.
+	scenario, err := eval.Load(writeScenario(t, `
+name: judged
+turns:
+  - user: "hello there"
+    expect:
+      - event: llm_response
+        judge: "acknowledges the user's greeting"
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	judge := eval.NewLLMJudge(&fakeGen{reply: "PASS — it echoes the greeting"})
+	res, err := eval.Host(context.Background(), scenario, buildFakeBot, judge)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.Passed() {
+		t.Fatalf("expected pass, got:\n%s", res)
+	}
+}
+
+func TestHarnessJudgeFailsSurfacesReason(t *testing.T) {
+	scenario, _ := eval.Load(writeScenario(t, `
+name: judged-fail
+turns:
+  - user: "hello there"
+    expect:
+      - event: llm_response
+        judge: "asks a clarifying question"
+`))
+	judge := eval.NewLLMJudge(&fakeGen{reply: "FAIL: it just echoes, no question"})
+	res, err := eval.Host(context.Background(), scenario, buildFakeBot, judge)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Passed() {
+		t.Fatal("expected the judge to fail the assertion")
+	}
+	if !strings.Contains(res.Failures[0].Reason, "no question") {
+		t.Fatalf("failure should surface the judge's reason, got: %s", res.Failures[0].Reason)
+	}
+}

--- a/eval/result.go
+++ b/eval/result.go
@@ -1,0 +1,47 @@
+package eval
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Failure is one unmet expectation in a scenario run.
+type Failure struct {
+	// Turn is the 1-based turn number.
+	Turn int
+	// Expectation is the 1-based expectation index within the turn.
+	Expectation int
+	// Event is the event name that was expected.
+	Event string
+	// Reason explains what went wrong.
+	Reason string
+}
+
+// String renders a failure as a single line.
+func (f Failure) String() string {
+	return fmt.Sprintf("turn %d expectation %d (%s): %s", f.Turn, f.Expectation, f.Event, f.Reason)
+}
+
+// Result is the outcome of running one scenario.
+type Result struct {
+	// Scenario is the scenario's name.
+	Scenario string
+	// Failures lists every unmet expectation; empty means the scenario passed.
+	Failures []Failure
+}
+
+// Passed reports whether every expectation was met.
+func (r Result) Passed() bool { return len(r.Failures) == 0 }
+
+// String renders a human-readable summary of the run.
+func (r Result) String() string {
+	if r.Passed() {
+		return "PASS " + r.Scenario
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "FAIL %s (%d failure(s))", r.Scenario, len(r.Failures))
+	for _, f := range r.Failures {
+		fmt.Fprintf(&b, "\n  - %s", f)
+	}
+	return b.String()
+}

--- a/eval/run.go
+++ b/eval/run.go
@@ -23,14 +23,22 @@ type Bot func(in, out processor.Processor) *pipeline.Task
 // Run plays the scenario at path against buildBot, hosted in-process over a
 // loopback WebSocket, and reports every unmet expectation through t. The bot's
 // real LLM (and STT/TTS, if wired) run; each user turn is injected as RTVI
-// send-text, so audio processors sit idle.
+// send-text, so audio processors sit idle. Scenarios that use `judge:` need a
+// judge — use RunWithJudge.
 func Run(t *testing.T, path string, buildBot Bot) {
+	t.Helper()
+	RunWithJudge(t, path, buildBot, nil)
+}
+
+// RunWithJudge is Run with an LLM judge supplied for the scenario's `judge:`
+// assertions (see NewLLMJudge). Pass nil when no scenario uses `judge:`.
+func RunWithJudge(t *testing.T, path string, buildBot Bot, judge Judge) {
 	t.Helper()
 	scenario, err := Load(path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := Host(context.Background(), scenario, buildBot, nil)
+	res, err := Host(context.Background(), scenario, buildBot, judge)
 	if err != nil {
 		t.Fatalf("eval: %v", err)
 	}

--- a/eval/run.go
+++ b/eval/run.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gojargo/jargo/pipeline"
 	"github.com/gojargo/jargo/processor"
+	"github.com/gojargo/jargo/service/tts"
 	"github.com/gojargo/jargo/transport"
 	"github.com/gojargo/jargo/transport/wsserver"
 	"github.com/gojargo/jargo/transport/wsserver/rtviws"
@@ -20,25 +21,41 @@ import (
 // agnostic: the harness supplies a WebSocket transport's input and output.
 type Bot func(in, out processor.Processor) *pipeline.Task
 
-// Run plays the scenario at path against buildBot, hosted in-process over a
-// loopback WebSocket, and reports every unmet expectation through t. The bot's
-// real LLM (and STT/TTS, if wired) run; each user turn is injected as RTVI
-// send-text, so audio processors sit idle. Scenarios that use `judge:` need a
-// judge — use RunWithJudge.
-func Run(t *testing.T, path string, buildBot Bot) {
-	t.Helper()
-	RunWithJudge(t, path, buildBot, nil)
+// Options configures a scenario run.
+type Options struct {
+	// Judge grades `judge:` assertions; nil is fine when no scenario uses one.
+	Judge Judge
+	// UserTTS selects audio mode. When set, each user turn is synthesized with
+	// this TTS service and streamed to the bot as microphone audio (so the bot's
+	// real VAD, turn detection and STT run), instead of the text-mode send-text.
+	// Any jargo TTS service works, e.g. cartesia.NewTTS(...).
+	UserTTS *tts.Base
 }
 
-// RunWithJudge is Run with an LLM judge supplied for the scenario's `judge:`
-// assertions (see NewLLMJudge). Pass nil when no scenario uses `judge:`.
+// Run plays the scenario at path against buildBot, hosted in-process over a
+// loopback WebSocket, and reports every unmet expectation through t. Text mode:
+// each user turn is injected as RTVI send-text, so audio processors sit idle.
+// For an LLM judge or audio mode, use RunWith.
+func Run(t *testing.T, path string, buildBot Bot) {
+	t.Helper()
+	RunWith(t, path, buildBot, Options{})
+}
+
+// RunWithJudge is Run with an LLM judge for the scenario's `judge:` assertions
+// (see NewLLMJudge). Pass nil when no scenario uses `judge:`.
 func RunWithJudge(t *testing.T, path string, buildBot Bot, judge Judge) {
+	t.Helper()
+	RunWith(t, path, buildBot, Options{Judge: judge})
+}
+
+// RunWith is Run with explicit Options (a judge, audio mode, or both).
+func RunWith(t *testing.T, path string, buildBot Bot, opts Options) {
 	t.Helper()
 	scenario, err := Load(path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := Host(context.Background(), scenario, buildBot, judge)
+	res, err := Host(context.Background(), scenario, buildBot, opts)
 	if err != nil {
 		t.Fatalf("eval: %v", err)
 	}
@@ -48,14 +65,13 @@ func RunWithJudge(t *testing.T, path string, buildBot Bot, judge Judge) {
 }
 
 // Host stands up buildBot on an in-process loopback WebSocket and plays scenario
-// against it, returning the result. judge may be nil when the scenario has no
-// `judge:` assertions. Run wraps this for the go-test path; callers that want
-// the Result directly (custom reporting, benchmarks) can use it.
-func Host(ctx context.Context, scenario *Scenario, buildBot Bot, judge Judge) (Result, error) {
+// against it, returning the result. Run wraps this for the go-test path; callers
+// that want the Result directly (custom reporting, benchmarks) can use it.
+func Host(ctx context.Context, scenario *Scenario, buildBot Bot, opts Options) (Result, error) {
 	srv := httptest.NewServer(Handler(buildBot))
 	defer srv.Close()
 
-	return runAgainst(ctx, scenario, wsURL(srv.URL), judge)
+	return runAgainst(ctx, scenario, wsURL(srv.URL), opts)
 }
 
 // Handler serves buildBot over RTVI on a plain WebSocket: it accepts one client
@@ -82,18 +98,18 @@ func Handler(buildBot Bot) http.Handler {
 // RunURL plays scenario against a bot already listening at botURL (a ws:// or
 // wss:// RTVI endpoint). It backs the command-line runner.
 func RunURL(ctx context.Context, scenario *Scenario, botURL string, judge Judge) (Result, error) {
-	return runAgainst(ctx, scenario, botURL, judge)
+	return runAgainst(ctx, scenario, botURL, Options{Judge: judge})
 }
 
 // runAgainst connects to a bot and plays the scenario.
-func runAgainst(ctx context.Context, scenario *Scenario, url string, judge Judge) (Result, error) {
+func runAgainst(ctx context.Context, scenario *Scenario, url string, opts Options) (Result, error) {
 	c, err := dial(ctx, url)
 	if err != nil {
 		return Result{Scenario: scenario.Name}, err
 	}
 	defer c.close()
 
-	sess := &session{client: c, scenario: scenario, judge: judge}
+	sess := &session{client: c, scenario: scenario, judge: opts.Judge, userTTS: opts.UserTTS}
 	return sess.run(ctx)
 }
 

--- a/eval/run.go
+++ b/eval/run.go
@@ -1,0 +1,95 @@
+package eval
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gojargo/jargo/pipeline"
+	"github.com/gojargo/jargo/processor"
+	"github.com/gojargo/jargo/transport"
+	"github.com/gojargo/jargo/transport/wsserver"
+	"github.com/gojargo/jargo/transport/wsserver/rtviws"
+)
+
+// Bot builds the bot's pipeline task around the harness-provided transport
+// endpoints. The pipeline must include an rtvi.Processor so the harness can
+// drive it (send-text) and observe its events. The builder is transport-
+// agnostic: the harness supplies a WebSocket transport's input and output.
+type Bot func(in, out processor.Processor) *pipeline.Task
+
+// Run plays the scenario at path against buildBot, hosted in-process over a
+// loopback WebSocket, and reports every unmet expectation through t. The bot's
+// real LLM (and STT/TTS, if wired) run; each user turn is injected as RTVI
+// send-text, so audio processors sit idle.
+func Run(t *testing.T, path string, buildBot Bot) {
+	t.Helper()
+	scenario, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := Host(context.Background(), scenario, buildBot, nil)
+	if err != nil {
+		t.Fatalf("eval: %v", err)
+	}
+	for _, f := range res.Failures {
+		t.Errorf("%s", f)
+	}
+}
+
+// Host stands up buildBot on an in-process loopback WebSocket and plays scenario
+// against it, returning the result. judge may be nil when the scenario has no
+// `judge:` assertions. Run wraps this for the go-test path; callers that want
+// the Result directly (custom reporting, benchmarks) can use it.
+func Host(ctx context.Context, scenario *Scenario, buildBot Bot, judge Judge) (Result, error) {
+	srv := httptest.NewServer(Handler(buildBot))
+	defer srv.Close()
+
+	return runAgainst(ctx, scenario, wsURL(srv.URL), judge)
+}
+
+// Handler serves buildBot over RTVI on a plain WebSocket: it accepts one client
+// per connection, wires the transport into the bot's pipeline, and runs it until
+// the client disconnects. Mount it in a bot's own HTTP server to expose an eval
+// endpoint that `jargo eval run` — or any RTVI WebSocket client — can drive. The
+// in-process Host uses it too.
+func Handler(buildBot Bot) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tr, err := wsserver.Accept(w, r, rtviws.New(), transport.DefaultParams())
+		if err != nil {
+			return
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		go func() {
+			<-tr.Done() // the client disconnected or the socket closed
+			cancel()
+		}()
+		_ = buildBot(tr.Input(), tr.Output()).Run(ctx)
+	})
+}
+
+// RunURL plays scenario against a bot already listening at botURL (a ws:// or
+// wss:// RTVI endpoint). It backs the command-line runner.
+func RunURL(ctx context.Context, scenario *Scenario, botURL string, judge Judge) (Result, error) {
+	return runAgainst(ctx, scenario, botURL, judge)
+}
+
+// runAgainst connects to a bot and plays the scenario.
+func runAgainst(ctx context.Context, scenario *Scenario, url string, judge Judge) (Result, error) {
+	c, err := dial(ctx, url)
+	if err != nil {
+		return Result{Scenario: scenario.Name}, err
+	}
+	defer c.close()
+
+	sess := &session{client: c, scenario: scenario, judge: judge}
+	return sess.run(ctx)
+}
+
+// wsURL rewrites an http(s) base URL to its ws(s) form.
+func wsURL(httpURL string) string {
+	return "ws" + strings.TrimPrefix(httpURL, "http")
+}

--- a/eval/scenario.go
+++ b/eval/scenario.go
@@ -38,6 +38,14 @@ var (
 // Event names a scenario can assert on. These are the friendly names scenarios
 // use; the harness maps the bot's RTVI server messages onto them.
 const (
+	// EventUserStartedSpeaking fires when the bot's VAD detects the user's speech
+	// beginning (audio mode only).
+	EventUserStartedSpeaking = "user_started_speaking"
+	// EventUserStoppedSpeaking fires when the user's turn ends (audio mode only).
+	EventUserStoppedSpeaking = "user_stopped_speaking"
+	// EventUserTranscription carries the bot's STT transcription of the user's
+	// speech (audio mode only).
+	EventUserTranscription = "user_transcription"
 	// EventLLMStarted fires when the bot begins generating a response.
 	EventLLMStarted = "llm_started"
 	// EventLLMResponse carries the bot's LLM text, joined across the response.
@@ -46,13 +54,17 @@ const (
 	EventFunctionCall = "function_call"
 )
 
-// knownEvents is the set of event names a text-mode scenario may assert on.
+// knownEvents is the set of event names a scenario may assert on. The user_*
+// events only fire in audio mode (see Options.UserTTS).
 //
 //nolint:gochecknoglobals // fixed lookup table
 var knownEvents = map[string]bool{
-	EventLLMStarted:   true,
-	EventLLMResponse:  true,
-	EventFunctionCall: true,
+	EventUserStartedSpeaking: true,
+	EventUserStoppedSpeaking: true,
+	EventUserTranscription:   true,
+	EventLLMStarted:          true,
+	EventLLMResponse:         true,
+	EventFunctionCall:        true,
 }
 
 // Scenario is a scripted conversation and the events it should produce.
@@ -136,8 +148,11 @@ func (e Expectation) validate() error {
 	if e.Function != "" && e.Event != EventFunctionCall {
 		return fmt.Errorf("%w: function is only valid on a %s event", errFieldForEvent, EventFunctionCall)
 	}
-	if (e.TextContains != "" || e.Judge != "") && e.Event != EventLLMResponse {
-		return fmt.Errorf("%w: text_contains/judge are only valid on a %s event", errFieldForEvent, EventLLMResponse)
+	if e.Judge != "" && e.Event != EventLLMResponse {
+		return fmt.Errorf("%w: judge is only valid on a %s event", errFieldForEvent, EventLLMResponse)
+	}
+	if e.TextContains != "" && e.Event != EventLLMResponse && e.Event != EventUserTranscription {
+		return fmt.Errorf("%w: text_contains needs %s or %s", errFieldForEvent, EventLLMResponse, EventUserTranscription)
 	}
 	if e.WithinMS < 0 {
 		return errNegativeBudget

--- a/eval/scenario.go
+++ b/eval/scenario.go
@@ -1,0 +1,146 @@
+// Package eval is a behavioral eval harness for jargo bots. It drives a real
+// bot over RTVI, plays scripted conversation turns, and asserts on the semantic
+// events the bot emits — a level above unit tests, which check one processor at
+// a time.
+//
+// A scenario is a YAML file of turns and the events each turn should produce.
+// The same scenario runs from a Go test (the bot hosted in-process, see Run) or
+// from the command line against a running bot. This first iteration covers
+// text-mode scenarios: each user turn is delivered as RTVI send-text and the
+// assertions read the bot's LLM output and tool calls. Audio-mode scenarios
+// (synthesized user speech, transcription of the bot's audio) build on the same
+// core later.
+package eval
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Validation errors. Callers surface these to the operator; they are sentinels
+// so a message change does not silently break a caller matching on them.
+//
+//nolint:gochecknoglobals // sentinel errors
+var (
+	errNoName         = errors.New("scenario has no name")
+	errNoTurns        = errors.New("scenario has no turns")
+	errNoUser         = errors.New("turn has no user input")
+	errNoExpect       = errors.New("turn has no expectations")
+	errUnknownEvent   = errors.New("unknown event")
+	errFieldForEvent  = errors.New("field not valid for this event")
+	errNegativeBudget = errors.New("within_ms must not be negative")
+)
+
+// Event names a scenario can assert on. These are the friendly names scenarios
+// use; the harness maps the bot's RTVI server messages onto them.
+const (
+	// EventLLMStarted fires when the bot begins generating a response.
+	EventLLMStarted = "llm_started"
+	// EventLLMResponse carries the bot's LLM text, joined across the response.
+	EventLLMResponse = "llm_response"
+	// EventFunctionCall fires when the bot invokes a tool.
+	EventFunctionCall = "function_call"
+)
+
+// knownEvents is the set of event names a text-mode scenario may assert on.
+//
+//nolint:gochecknoglobals // fixed lookup table
+var knownEvents = map[string]bool{
+	EventLLMStarted:   true,
+	EventLLMResponse:  true,
+	EventFunctionCall: true,
+}
+
+// Scenario is a scripted conversation and the events it should produce.
+type Scenario struct {
+	// Name identifies the scenario in reports; required.
+	Name string `yaml:"name"`
+	// Turns are played in order.
+	Turns []Turn `yaml:"turns"`
+}
+
+// Turn is one user utterance and the events expected in response.
+type Turn struct {
+	// User is the text the user "says" this turn (sent as RTVI send-text).
+	User string `yaml:"user"`
+	// Expect lists the events to match, in order, after the user input.
+	Expect []Expectation `yaml:"expect"`
+}
+
+// Expectation is one assertion about an event the bot emits.
+type Expectation struct {
+	// Event is the friendly event name to match (see the Event constants).
+	Event string `yaml:"event"`
+	// TextContains, when set, requires the event's text to contain this
+	// substring (case-insensitive). Applies to llm_response.
+	TextContains string `yaml:"text_contains,omitempty"`
+	// Judge, when set, is a natural-language criterion an LLM judge checks the
+	// event's text against. Applies to llm_response.
+	Judge string `yaml:"judge,omitempty"`
+	// Function, when set, is the tool name a function_call event must match.
+	Function string `yaml:"function,omitempty"`
+	// WithinMS is the latency budget for the event, measured from the user input;
+	// zero uses the harness default.
+	WithinMS int `yaml:"within_ms,omitempty"`
+}
+
+// Load reads and validates a scenario YAML file.
+func Load(path string) (*Scenario, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // scenario path is operator-supplied
+	if err != nil {
+		return nil, fmt.Errorf("eval: read scenario: %w", err)
+	}
+	var s Scenario
+	if err := yaml.Unmarshal(data, &s); err != nil {
+		return nil, fmt.Errorf("eval: parse %s: %w", path, err)
+	}
+	if err := s.validate(); err != nil {
+		return nil, fmt.Errorf("eval: %s: %w", path, err)
+	}
+	return &s, nil
+}
+
+// validate checks the scenario is well-formed and only references known events.
+func (s *Scenario) validate() error {
+	if strings.TrimSpace(s.Name) == "" {
+		return errNoName
+	}
+	if len(s.Turns) == 0 {
+		return fmt.Errorf("%w: %q", errNoTurns, s.Name)
+	}
+	for i, turn := range s.Turns {
+		if strings.TrimSpace(turn.User) == "" {
+			return fmt.Errorf("turn %d: %w", i+1, errNoUser)
+		}
+		if len(turn.Expect) == 0 {
+			return fmt.Errorf("turn %d: %w", i+1, errNoExpect)
+		}
+		for j, exp := range turn.Expect {
+			if err := exp.validate(); err != nil {
+				return fmt.Errorf("turn %d expectation %d: %w", i+1, j+1, err)
+			}
+		}
+	}
+	return nil
+}
+
+// validate checks a single expectation is well-formed for its event type.
+func (e Expectation) validate() error {
+	if !knownEvents[e.Event] {
+		return fmt.Errorf("%w %q", errUnknownEvent, e.Event)
+	}
+	if e.Function != "" && e.Event != EventFunctionCall {
+		return fmt.Errorf("%w: function is only valid on a %s event", errFieldForEvent, EventFunctionCall)
+	}
+	if (e.TextContains != "" || e.Judge != "") && e.Event != EventLLMResponse {
+		return fmt.Errorf("%w: text_contains/judge are only valid on a %s event", errFieldForEvent, EventLLMResponse)
+	}
+	if e.WithinMS < 0 {
+		return errNegativeBudget
+	}
+	return nil
+}

--- a/eval/scenario_test.go
+++ b/eval/scenario_test.go
@@ -85,7 +85,7 @@ func TestLoadRejectsInvalid(t *testing.T) {
 		},
 		"judge on wrong event": {
 			body: "name: x\nturns:\n  - user: hi\n    expect:\n      - event: function_call\n        judge: nice\n",
-			want: "text_contains/judge are only valid",
+			want: "judge is only valid",
 		},
 	}
 	for name, tc := range cases {

--- a/eval/scenario_test.go
+++ b/eval/scenario_test.go
@@ -1,0 +1,102 @@
+package eval_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gojargo/jargo/eval"
+)
+
+func writeScenario(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "scenario.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestLoadValidScenario(t *testing.T) {
+	path := writeScenario(t, `
+name: greeting
+turns:
+  - user: "hello there"
+    expect:
+      - event: llm_started
+      - event: llm_response
+        text_contains: "hi"
+        within_ms: 5000
+      - event: llm_response
+        judge: "greets the user warmly"
+  - user: "what's the weather in Paris?"
+    expect:
+      - event: function_call
+        function: get_weather
+`)
+
+	s, err := eval.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Name != "greeting" || len(s.Turns) != 2 {
+		t.Fatalf("unexpected scenario: %+v", s)
+	}
+	if s.Turns[0].User != "hello there" || len(s.Turns[0].Expect) != 3 {
+		t.Fatalf("unexpected turn 1: %+v", s.Turns[0])
+	}
+	if s.Turns[0].Expect[1].TextContains != "hi" || s.Turns[0].Expect[1].WithinMS != 5000 {
+		t.Fatalf("unexpected expectation: %+v", s.Turns[0].Expect[1])
+	}
+	if s.Turns[1].Expect[0].Event != eval.EventFunctionCall || s.Turns[1].Expect[0].Function != "get_weather" {
+		t.Fatalf("unexpected function_call expectation: %+v", s.Turns[1].Expect[0])
+	}
+}
+
+func TestLoadRejectsInvalid(t *testing.T) {
+	cases := map[string]struct {
+		body string
+		want string
+	}{
+		"no name": {
+			body: "turns:\n  - user: hi\n    expect:\n      - event: llm_started\n",
+			want: "no name",
+		},
+		"no turns": {
+			body: "name: empty\n",
+			want: "no turns",
+		},
+		"empty user": {
+			body: "name: x\nturns:\n  - user: \"\"\n    expect:\n      - event: llm_started\n",
+			want: "no user input",
+		},
+		"no expectations": {
+			body: "name: x\nturns:\n  - user: hi\n    expect: []\n",
+			want: "no expectations",
+		},
+		"unknown event": {
+			body: "name: x\nturns:\n  - user: hi\n    expect:\n      - event: teleport\n",
+			want: "unknown event",
+		},
+		"function on wrong event": {
+			body: "name: x\nturns:\n  - user: hi\n    expect:\n      - event: llm_response\n        function: foo\n",
+			want: "function is only valid",
+		},
+		"judge on wrong event": {
+			body: "name: x\nturns:\n  - user: hi\n    expect:\n      - event: function_call\n        judge: nice\n",
+			want: "text_contains/judge are only valid",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := eval.Load(writeScenario(t, tc.body))
+			if err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tc.want)
+			}
+		})
+	}
+}

--- a/eval/session.go
+++ b/eval/session.go
@@ -1,0 +1,212 @@
+package eval
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gojargo/jargo/processor/rtvi"
+)
+
+// defaultTimeout is the latency budget for an expectation that sets no within_ms.
+const defaultTimeout = 15 * time.Second
+
+// errBotNotReady is returned when the bot never completes the RTVI handshake.
+//
+//nolint:gochecknoglobals // sentinel error
+var errBotNotReady = errors.New("eval: bot did not become ready")
+
+// event is a friendly, translated view of an RTVI server message — the level a
+// scenario asserts on.
+type event struct {
+	kind     string // one of the Event* constants
+	text     string // llm_response: the bot's reply text, joined
+	function string // function_call: the tool name
+}
+
+// session drives one scenario against a connected bot.
+type session struct {
+	client   *client
+	scenario *Scenario
+	judge    Judge
+
+	// llmBuf accumulates bot-llm-text between bot-llm-started and bot-llm-stopped.
+	llmBuf strings.Builder
+}
+
+// run completes the handshake, then plays every turn.
+func (s *session) run(ctx context.Context) (Result, error) {
+	res := Result{Scenario: s.scenario.Name}
+	if err := s.handshake(ctx); err != nil {
+		return res, err
+	}
+	for i, turn := range s.scenario.Turns {
+		failures, err := s.runTurn(ctx, turn, i+1)
+		if err != nil {
+			return res, err
+		}
+		res.Failures = append(res.Failures, failures...)
+	}
+	return res, nil
+}
+
+// handshake sends client-ready and waits for the bot's bot-ready reply.
+func (s *session) handshake(ctx context.Context) error {
+	ready := rtvi.Message{
+		Label: rtvi.MessageLabel, Type: rtvi.TypeClientReady, ID: "eval",
+		Data: map[string]any{"version": rtvi.ProtocolVersion},
+	}
+	if err := s.client.send(ctx, ready); err != nil {
+		return err
+	}
+	deadline := time.Now().Add(defaultTimeout)
+	for {
+		in, ok := s.next(ctx, deadline)
+		if !ok {
+			return fmt.Errorf("%w within %s", errBotNotReady, defaultTimeout)
+		}
+		if in.Type == rtvi.TypeBotReady {
+			return nil
+		}
+	}
+}
+
+// runTurn sends the user's text and matches the turn's expectations in order.
+// Every expectation's budget is anchored at the send, so a stalled turn fails
+// within a single budget rather than one per expectation.
+func (s *session) runTurn(ctx context.Context, turn Turn, turnNum int) ([]Failure, error) {
+	if err := s.client.send(ctx, sendText(turn.User)); err != nil {
+		return nil, err
+	}
+	anchor := time.Now()
+
+	var failures []Failure
+	for j, exp := range turn.Expect {
+		budget := defaultTimeout
+		if exp.WithinMS > 0 {
+			budget = time.Duration(exp.WithinMS) * time.Millisecond
+		}
+		fail, timedOut := s.matchExpectation(ctx, exp, anchor.Add(budget), turnNum, j+1)
+		if fail != nil {
+			failures = append(failures, *fail)
+		}
+		if timedOut {
+			// No more events will match this turn's remaining expectations.
+			break
+		}
+	}
+	return failures, nil
+}
+
+// matchExpectation waits for an event matching exp, skipping unrelated events,
+// until deadline. It returns a failure (and whether it timed out) or nil on a
+// match.
+func (s *session) matchExpectation(
+	ctx context.Context, exp Expectation, deadline time.Time, turnNum, expNum int,
+) (*Failure, bool) {
+	for {
+		in, ok := s.next(ctx, deadline)
+		if !ok {
+			return &Failure{
+				Turn: turnNum, Expectation: expNum, Event: exp.Event,
+				Reason: fmt.Sprintf("no matching %s event arrived within budget", exp.Event),
+			}, true
+		}
+		ev := s.translate(in)
+		if ev == nil || ev.kind != exp.Event {
+			continue // not this expectation's event; skip it
+		}
+		// A named function_call skips calls to other tools and keeps waiting.
+		if exp.Event == EventFunctionCall && exp.Function != "" && ev.function != exp.Function {
+			continue
+		}
+		if reason := s.verify(ctx, exp, *ev); reason != "" {
+			return &Failure{Turn: turnNum, Expectation: expNum, Event: exp.Event, Reason: reason}, false
+		}
+		return nil, false
+	}
+}
+
+// verify checks an event that matched by kind against the expectation's content
+// assertions. It returns an empty string on success.
+func (s *session) verify(ctx context.Context, exp Expectation, ev event) string {
+	if exp.TextContains != "" &&
+		!strings.Contains(strings.ToLower(ev.text), strings.ToLower(exp.TextContains)) {
+		return fmt.Sprintf("reply %q does not contain %q", ev.text, exp.TextContains)
+	}
+	if exp.Judge != "" {
+		if s.judge == nil {
+			return fmt.Sprintf("judge criterion %q set but no judge is configured", exp.Judge)
+		}
+		pass, reason, err := s.judge.Evaluate(ctx, exp.Judge, ev.text)
+		if err != nil {
+			return fmt.Sprintf("judge error: %v", err)
+		}
+		if !pass {
+			return fmt.Sprintf("judge rejected %q: %s", exp.Judge, reason)
+		}
+	}
+	return ""
+}
+
+// translate converts an RTVI server message into a friendly event, or nil if it
+// carries no event on its own (bot-llm-text is accumulated until the response
+// ends).
+func (s *session) translate(in rtvi.Incoming) *event {
+	switch in.Type {
+	case rtvi.TypeBotLLMStarted:
+		s.llmBuf.Reset()
+		return &event{kind: EventLLMStarted}
+	case rtvi.TypeBotLLMText:
+		var d rtvi.TextData
+		if json.Unmarshal(in.Data, &d) == nil {
+			s.llmBuf.WriteString(d.Text)
+		}
+		return nil
+	case rtvi.TypeBotLLMStopped:
+		text := s.llmBuf.String()
+		s.llmBuf.Reset()
+		return &event{kind: EventLLMResponse, text: text}
+	case rtvi.TypeLLMFunctionCall:
+		var d rtvi.LLMFunctionCallData
+		_ = json.Unmarshal(in.Data, &d)
+		return &event{kind: EventFunctionCall, function: d.FunctionName}
+	default:
+		return nil
+	}
+}
+
+// next reads the next server message, blocking until one arrives, the deadline
+// passes, or ctx is canceled.
+func (s *session) next(ctx context.Context, deadline time.Time) (rtvi.Incoming, bool) {
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return rtvi.Incoming{}, false
+	}
+	timer := time.NewTimer(remaining)
+	defer timer.Stop()
+	select {
+	case in, ok := <-s.client.incoming:
+		return in, ok
+	case <-timer.C:
+		return rtvi.Incoming{}, false
+	case <-ctx.Done():
+		return rtvi.Incoming{}, false
+	}
+}
+
+// sendText builds a send-text message that appends the user's turn and runs the
+// LLM immediately, without a spoken audio response.
+func sendText(content string) rtvi.Message {
+	runNow, noAudio := true, false
+	return rtvi.Message{
+		Label: rtvi.MessageLabel, Type: rtvi.TypeSendText, ID: "eval",
+		Data: rtvi.SendTextData{
+			Content: content,
+			Options: &rtvi.SendTextOptions{RunImmediately: &runNow, AudioResponse: &noAudio},
+		},
+	}
+}

--- a/eval/session.go
+++ b/eval/session.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gojargo/jargo/processor/rtvi"
+	"github.com/gojargo/jargo/service/tts"
 )
 
 // defaultTimeout is the latency budget for an expectation that sets no within_ms.
@@ -32,6 +33,7 @@ type session struct {
 	client   *client
 	scenario *Scenario
 	judge    Judge
+	userTTS  *tts.Base // non-nil in audio mode: synthesizes each user turn
 
 	// llmBuf accumulates bot-llm-text between bot-llm-started and bot-llm-stopped.
 	llmBuf strings.Builder
@@ -78,7 +80,11 @@ func (s *session) handshake(ctx context.Context) error {
 // Every expectation's budget is anchored at the send, so a stalled turn fails
 // within a single budget rather than one per expectation.
 func (s *session) runTurn(ctx context.Context, turn Turn, turnNum int) ([]Failure, error) {
-	if err := s.client.send(ctx, sendText(turn.User)); err != nil {
+	if s.userTTS != nil {
+		if err := s.sendUserAudio(ctx, turn.User); err != nil {
+			return nil, err
+		}
+	} else if err := s.client.send(ctx, sendText(turn.User)); err != nil {
 		return nil, err
 	}
 	anchor := time.Now()
@@ -157,6 +163,16 @@ func (s *session) verify(ctx context.Context, exp Expectation, ev event) string 
 // ends).
 func (s *session) translate(in rtvi.Incoming) *event {
 	switch in.Type {
+	case rtvi.TypeUserStartedSpeaking:
+		return &event{kind: EventUserStartedSpeaking}
+	case rtvi.TypeUserStoppedSpeaking:
+		return &event{kind: EventUserStoppedSpeaking}
+	case rtvi.TypeUserTranscription:
+		var d rtvi.UserTranscriptionData
+		if json.Unmarshal(in.Data, &d) != nil || !d.Final {
+			return nil // only final transcriptions are turn-level events
+		}
+		return &event{kind: EventUserTranscription, text: d.Text}
 	case rtvi.TypeBotLLMStarted:
 		s.llmBuf.Reset()
 		return &event{kind: EventLLMStarted}

--- a/eval/suite.go
+++ b/eval/suite.go
@@ -1,0 +1,156 @@
+package eval
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+)
+
+// defaultConcurrency is how many scenarios run at once when a manifest sets none.
+const defaultConcurrency = 4
+
+// Manifest validation errors.
+//
+//nolint:gochecknoglobals // sentinel errors
+var (
+	errNoSuite     = errors.New("manifest has no suite entries")
+	errNoBotURL    = errors.New("suite entry has no bot_url")
+	errNoScenarios = errors.New("suite entry has no scenarios")
+)
+
+// Manifest lists the bots to test and the scenarios to run against each. Scenario
+// paths are resolved relative to the manifest file, so a manifest is portable.
+type Manifest struct {
+	// Concurrency is how many scenarios run at once; zero uses a default.
+	Concurrency int `yaml:"concurrency"`
+	// Suite is the list of bots and their scenarios.
+	Suite []SuiteEntry `yaml:"suite"`
+
+	dir string // directory of the manifest file, for resolving scenario paths
+}
+
+// SuiteEntry is one bot and the scenarios to play against it.
+type SuiteEntry struct {
+	// BotURL is the bot's RTVI WebSocket endpoint (ws:// or wss://).
+	BotURL string `yaml:"bot_url"`
+	// Scenarios are scenario file paths, resolved relative to the manifest.
+	Scenarios []string `yaml:"scenarios"`
+}
+
+// SuiteResult is the outcome of running one scenario against one bot.
+type SuiteResult struct {
+	// BotURL is the bot the scenario ran against.
+	BotURL string
+	// Scenario is the scenario file path.
+	Scenario string
+	// Result is the scenario result; zero-valued when Err is set.
+	Result Result
+	// Err is non-nil when the scenario could not be loaded or run.
+	Err error
+}
+
+// Passed reports whether the scenario ran and every expectation was met.
+func (r SuiteResult) Passed() bool { return r.Err == nil && r.Result.Passed() }
+
+// LoadManifest reads and validates a suite manifest.
+func LoadManifest(path string) (*Manifest, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // manifest path is operator-supplied
+	if err != nil {
+		return nil, fmt.Errorf("eval: read manifest: %w", err)
+	}
+	var m Manifest
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("eval: parse %s: %w", path, err)
+	}
+	if err := m.validate(); err != nil {
+		return nil, fmt.Errorf("eval: %s: %w", path, err)
+	}
+	m.dir = filepath.Dir(path)
+	return &m, nil
+}
+
+// validate checks the manifest is well-formed.
+func (m *Manifest) validate() error {
+	if len(m.Suite) == 0 {
+		return errNoSuite
+	}
+	for i, e := range m.Suite {
+		if e.BotURL == "" {
+			return fmt.Errorf("suite entry %d: %w", i+1, errNoBotURL)
+		}
+		if len(e.Scenarios) == 0 {
+			return fmt.Errorf("suite entry %d: %w", i+1, errNoScenarios)
+		}
+	}
+	return nil
+}
+
+// concurrency returns the effective worker count.
+func (m *Manifest) concurrency() int {
+	if m.Concurrency > 0 {
+		return m.Concurrency
+	}
+	return defaultConcurrency
+}
+
+// job is one scenario to run against one bot.
+type job struct {
+	botURL   string
+	scenario string
+}
+
+// jobs flattens the manifest into scenario/bot pairs, resolving scenario paths.
+func (m *Manifest) jobs() []job {
+	var js []job
+	for _, e := range m.Suite {
+		for _, sc := range e.Scenarios {
+			path := sc
+			if !filepath.IsAbs(path) {
+				path = filepath.Join(m.dir, path)
+			}
+			js = append(js, job{botURL: e.BotURL, scenario: path})
+		}
+	}
+	return js
+}
+
+// RunSuite runs every scenario in the manifest against its bot, up to
+// Concurrency at once, and returns one result per scenario in manifest order.
+// judge may be nil when no scenario uses `judge:`.
+func RunSuite(ctx context.Context, m *Manifest, judge Judge) []SuiteResult {
+	js := m.jobs()
+	results := make([]SuiteResult, len(js))
+
+	sem := make(chan struct{}, m.concurrency())
+	var wg sync.WaitGroup
+	for i, j := range js {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(i int, j job) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			results[i] = runOne(ctx, j, judge)
+		}(i, j)
+	}
+	wg.Wait()
+	return results
+}
+
+// runOne loads and plays a single scenario against its bot.
+func runOne(ctx context.Context, j job, judge Judge) SuiteResult {
+	sr := SuiteResult{BotURL: j.botURL, Scenario: j.scenario}
+	scenario, err := Load(j.scenario)
+	if err != nil {
+		sr.Err = err
+		return sr
+	}
+	res, err := RunURL(ctx, scenario, j.botURL, judge)
+	sr.Result = res
+	sr.Err = err
+	return sr
+}

--- a/eval/suite_test.go
+++ b/eval/suite_test.go
@@ -1,0 +1,97 @@
+package eval_test
+
+import (
+	"context"
+	"fmt"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gojargo/jargo/eval"
+)
+
+func writeFile(t *testing.T, dir, name, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRunSuite(t *testing.T) {
+	srv1 := httptest.NewServer(eval.Handler(buildFakeBot))
+	defer srv1.Close()
+	srv2 := httptest.NewServer(eval.Handler(buildFakeBot))
+	defer srv2.Close()
+	ws := func(s *httptest.Server) string { return "ws" + strings.TrimPrefix(s.URL, "http") }
+
+	dir := t.TempDir()
+	writeFile(t, dir, "pass.yaml", `name: pass
+turns:
+  - user: "hello world"
+    expect:
+      - event: llm_response
+        text_contains: "hello world"
+`)
+	writeFile(t, dir, "fail.yaml", `name: fail
+turns:
+  - user: "hello"
+    expect:
+      - event: llm_response
+        text_contains: "goodbye"
+`)
+	writeFile(t, dir, "manifest.yaml", fmt.Sprintf(`concurrency: 2
+suite:
+  - bot_url: %s
+    scenarios: [pass.yaml, fail.yaml]
+  - bot_url: %s
+    scenarios: [pass.yaml]
+`, ws(srv1), ws(srv2)))
+
+	m, err := eval.LoadManifest(filepath.Join(dir, "manifest.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	results := eval.RunSuite(context.Background(), m, nil)
+	if len(results) != 3 {
+		t.Fatalf("want 3 results, got %d", len(results))
+	}
+	passed := 0
+	for _, r := range results {
+		if r.Err != nil {
+			t.Fatalf("unexpected run error for %s: %v", r.Scenario, r.Err)
+		}
+		if r.Passed() {
+			passed++
+		}
+	}
+	if passed != 2 { // pass.yaml runs on both bots; fail.yaml fails
+		t.Fatalf("want 2 passed of 3, got %d\n%+v", passed, results)
+	}
+}
+
+func TestLoadManifestRejectsInvalid(t *testing.T) {
+	cases := map[string]struct {
+		body string
+		want string
+	}{
+		"no suite":     {"concurrency: 2\n", "no suite entries"},
+		"no bot_url":   {"suite:\n  - scenarios: [a.yaml]\n", "no bot_url"},
+		"no scenarios": {"suite:\n  - bot_url: ws://x\n", "no scenarios"},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFile(t, dir, "m.yaml", tc.body)
+			_, err := eval.LoadManifest(filepath.Join(dir, "m.yaml"))
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tc.want)
+			}
+		})
+	}
+}

--- a/examples/eval/eval_test.go
+++ b/examples/eval/eval_test.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/gojargo/jargo/eval"
+)
+
+// TestGreeting plays the greeting scenario against the demo bot in-process — the
+// same scenario `jargo eval run` drives over a WebSocket.
+func TestGreeting(t *testing.T) {
+	eval.Run(t, "scenarios/greeting.yaml", buildBot)
+}

--- a/examples/eval/main.go
+++ b/examples/eval/main.go
@@ -1,0 +1,96 @@
+// Command eval is a tiny demo bot for the jargo eval harness. It serves an eval
+// endpoint over a plain WebSocket — no WebRTC, no API keys — so you can drive it
+// with the CLI or from a Go test.
+//
+// Run it and eval it from the command line:
+//
+//	go run ./examples/eval    # serves ws://localhost:8080
+//	go run ./cmd/jargo eval run examples/eval/scenarios/greeting.yaml --bot-url ws://localhost:8080
+//
+// Or run the same scenario in-process:
+//
+//	go test ./examples/eval
+//
+// A real bot would wire an STT/LLM/TTS in buildBot; this one uses a canned,
+// deterministic responder so the example is self-contained and its assertions
+// are stable.
+package main
+
+import (
+	"context"
+	"log"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/gojargo/jargo/eval"
+	"github.com/gojargo/jargo/frames"
+	"github.com/gojargo/jargo/pipeline"
+	"github.com/gojargo/jargo/processor"
+	"github.com/gojargo/jargo/processor/aggregators"
+	"github.com/gojargo/jargo/processor/rtvi"
+)
+
+func main() {
+	const addr = ":8080"
+	http.Handle("/", eval.Handler(buildBot))
+	slog.Info("jargo eval demo bot listening", "url", "ws://localhost"+addr)
+	log.Fatal(http.ListenAndServe(addr, nil))
+}
+
+// buildBot assembles the demo pipeline around the harness-provided transport
+// endpoints. The rtvi.Processor is what lets the harness drive the bot and
+// observe its events.
+func buildBot(in, out processor.Processor) *pipeline.Task {
+	agg := aggregators.New(frames.NewLLMContext("You are a friendly demo assistant."))
+	return pipeline.NewTask(pipeline.New(
+		in, agg.User(), newDemoLLM(), rtvi.NewProcessor(), out, agg.Assistant(),
+	), pipeline.TaskParams{})
+}
+
+// demoLLM stands in for an LLM service: it answers each user turn with a canned
+// reply, so the example runs deterministically and without a provider.
+type demoLLM struct {
+	*processor.Base
+}
+
+func newDemoLLM() *demoLLM {
+	m := &demoLLM{}
+	m.Base = processor.New("DemoLLM", m)
+	return m
+}
+
+func (m *demoLLM) ProcessFrame(ctx context.Context, f frames.Frame, dir processor.Direction) error {
+	if err := m.Base.ProcessFrame(ctx, f, dir); err != nil {
+		return err
+	}
+	cf, ok := f.(*frames.LLMContextFrame)
+	if !ok {
+		return m.PushFrame(ctx, f, dir)
+	}
+
+	last := ""
+	if msgs := cf.Context.Messages(); len(msgs) > 0 {
+		last = msgs[len(msgs)-1].Text
+	}
+	if err := m.PushFrame(ctx, frames.NewLLMFullResponseStartFrame(), processor.Downstream); err != nil {
+		return err
+	}
+	if err := m.PushFrame(ctx, frames.NewLLMTextFrame(reply(last)), processor.Downstream); err != nil {
+		return err
+	}
+	return m.PushFrame(ctx, frames.NewLLMFullResponseEndFrame(), processor.Downstream)
+}
+
+// reply is the demo's canned response logic.
+func reply(userText string) string {
+	lower := strings.ToLower(userText)
+	switch {
+	case strings.Contains(lower, "hello"), strings.Contains(lower, "hey"):
+		return "Hello! How can I help you today?"
+	case strings.Contains(lower, "coffee"):
+		return "Sure — what kind of coffee would you like?"
+	default:
+		return "You said: " + userText
+	}
+}

--- a/examples/eval/scenarios/greeting.yaml
+++ b/examples/eval/scenarios/greeting.yaml
@@ -1,0 +1,11 @@
+name: greeting
+turns:
+  - user: "hello there"
+    expect:
+      - event: llm_started
+      - event: llm_response
+        text_contains: "how can I help"
+  - user: "I'd like a coffee"
+    expect:
+      - event: llm_response
+        text_contains: "what kind of coffee"

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/pion/opus v0.1.1-0.20260706164138-4d863e517a7a
 	github.com/pion/webrtc/v4 v4.2.16
+	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	github.com/vmihailenco/msgpack/v5 v5.4.1
 	github.com/yalue/onnxruntime_go v1.31.0
@@ -35,6 +36,7 @@ require (
 	gonum.org/v1/gonum v0.17.0
 	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.11
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -77,6 +79,7 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/invopop/jsonschema v0.14.0 // indirect
 	github.com/jxskiss/base62 v1.1.0 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
@@ -152,7 +155,6 @@ require (
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/pion/opus => github.com/gojargo/opus v0.1.1-0.20260710133549-77e753c0dd49

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,7 @@ github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG
 github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=
 github.com/containerd/errdefs/pkg v0.3.0/go.mod h1:NJw6s9HwNuRhnjJhM7pylWwMyAkmCQvQ4GpJHEqRLVk=
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dennwc/iters v1.2.2 h1:XH2/Etihiy9ZvPOVCR+icQXeYlhbvS7k0qro4x/2qQo=
@@ -135,6 +136,8 @@ github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5T
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/invopop/jsonschema v0.14.0 h1:MHQqLhvpNUZfw+hM3AZDYK7jxO8FZoQeQM77g8iyZjg=
 github.com/invopop/jsonschema v0.14.0/go.mod h1:ygm6C2EaVNMBDPpaPlnOA2pFAxBnxGjFlMZABxm9n2I=
 github.com/jfreymuth/pulse v0.1.2 h1:t4+ItUuWLlQnulVDOL2eAotKk+utKJzK8ol0iybYAmQ=
@@ -245,6 +248,7 @@ github.com/rodaine/protogofakeit v0.1.1 h1:ZKouljuRM3A+TArppfBqnH8tGZHOwM/pjvtXe
 github.com/rodaine/protogofakeit v0.1.1/go.mod h1:pXn/AstBYMaSfc1/RqH3N82pBuxtWgejz1AlYpY1mI0=
 github.com/rogpeppe/go-internal v1.15.0 h1:D0RCU5rMAp+SpgkiNdrjfJ+LX4J1M32V2NeCY7EJ6hc=
 github.com/rogpeppe/go-internal v1.15.0/go.mod h1:DrUVZyrJU+txYW5/1kwtXQSMFio52ZOxX7yM1VHvnxs=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.11.0 h1:1iurJgmM9G3PA/I+wWYIOw/5SyBtxapeHDcg+AAIFXc=
 github.com/sagikazarmark/locafero v0.11.0/go.mod h1:nVIGvgyzw595SUSUE6tvCp3YYTeHs15MvlmU87WwIik=
 github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
@@ -259,6 +263,9 @@ github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=
 github.com/spf13/afero v1.15.0/go.mod h1:NC2ByUVxtQs4b3sIUphxK0NioZnmxgyCrfzeuq8lxMg=
 github.com/spf13/cast v1.10.0 h1:h2x0u2shc1QuLHfxi+cTJvs30+ZAHOGRic8uyGTDWxY=
 github.com/spf13/cast v1.10.0/go.mod h1:jNfB8QC9IA6ZuY2ZjDp0KtFO2LZZlg4S/7bzP6qqeHo=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.21.0 h1:x5S+0EU27Lbphp4UKm1C+1oQO+rKx36vfCoaVebLFSU=

--- a/processor/rtvi/messages.go
+++ b/processor/rtvi/messages.go
@@ -20,18 +20,25 @@ const (
 
 // Message types exchanged over the data channel.
 const (
-	TypeClientReady         = "client-ready"
-	TypeBotReady            = "bot-ready"
-	TypeError               = "error"
-	TypeUserTranscription   = "user-transcription"
-	TypeBotTranscription    = "bot-transcription"
-	TypeBotTTSText          = "bot-tts-text"
-	TypeBotLLMText          = "bot-llm-text"
-	TypeUserStartedSpeaking = "user-started-speaking"
-	TypeUserStoppedSpeaking = "user-stopped-speaking"
-	TypeBotStartedSpeaking  = "bot-started-speaking"
-	TypeBotStoppedSpeaking  = "bot-stopped-speaking"
-	TypeMetrics             = "metrics"
+	TypeClientReady           = "client-ready"
+	TypeSendText              = "send-text"
+	TypeBotReady              = "bot-ready"
+	TypeError                 = "error"
+	TypeUserTranscription     = "user-transcription"
+	TypeBotTranscription      = "bot-transcription"
+	TypeBotTTSText            = "bot-tts-text"
+	TypeBotLLMText            = "bot-llm-text"
+	TypeUserStartedSpeaking   = "user-started-speaking"
+	TypeUserStoppedSpeaking   = "user-stopped-speaking"
+	TypeBotStartedSpeaking    = "bot-started-speaking"
+	TypeBotStoppedSpeaking    = "bot-stopped-speaking"
+	TypeBotLLMStarted         = "bot-llm-started"
+	TypeBotLLMStopped         = "bot-llm-stopped"
+	TypeBotTTSStarted         = "bot-tts-started"
+	TypeBotTTSStopped         = "bot-tts-stopped"
+	TypeLLMFunctionCall       = "llm-function-call-in-progress"
+	TypeLLMFunctionCallResult = "llm-function-call-result"
+	TypeMetrics               = "metrics"
 )
 
 // Message is the RTVI message envelope. Outgoing event messages omit id; bot-ready
@@ -62,6 +69,33 @@ func ParseIncoming(raw []byte) (Incoming, error) {
 	var m Incoming
 	err := json.Unmarshal(raw, &m)
 	return m, err
+}
+
+// SendTextOptions controls how the pipeline processes a send-text message.
+// Both fields default to true when absent, matching the RTVI client SDKs.
+type SendTextOptions struct {
+	RunImmediately *bool `json:"run_immediately,omitempty"`
+	AudioResponse  *bool `json:"audio_response,omitempty"`
+}
+
+// SendTextData is the payload of a send-text message: user text to inject into
+// the conversation, with options controlling whether the LLM runs immediately.
+type SendTextData struct {
+	Content string           `json:"content"`
+	Options *SendTextOptions `json:"options,omitempty"`
+}
+
+// RunImmediately reports whether the LLM should run as soon as the text is
+// appended. Absent options (or an absent flag) default to true.
+func (d SendTextData) RunImmediately() bool {
+	return d.Options == nil || d.Options.RunImmediately == nil || *d.Options.RunImmediately
+}
+
+// ParseSendTextData decodes the data payload of a send-text message.
+func ParseSendTextData(raw json.RawMessage) (SendTextData, error) {
+	var d SendTextData
+	err := json.Unmarshal(raw, &d)
+	return d, err
 }
 
 // BotReadyData is the payload of a bot-ready message.
@@ -104,6 +138,39 @@ func BotTTSText(text string) Message {
 // BotLLMText builds a bot-llm-text message.
 func BotLLMText(text string) Message {
 	return newMessage(TypeBotLLMText, "", TextData{Text: text})
+}
+
+// LLMFunctionCallData is the payload of a llm-function-call-in-progress message.
+// Arguments are intentionally omitted: the call name and id are enough for a
+// client to surface an "in progress" indication without exposing argument
+// values.
+type LLMFunctionCallData struct {
+	FunctionName string `json:"function_name"`
+	ToolCallID   string `json:"tool_call_id"`
+}
+
+// LLMFunctionCall builds a llm-function-call-in-progress message.
+func LLMFunctionCall(name, toolCallID string) Message {
+	return newMessage(TypeLLMFunctionCall, "", LLMFunctionCallData{
+		FunctionName: name,
+		ToolCallID:   toolCallID,
+	})
+}
+
+// LLMFunctionCallResultData is the payload of a llm-function-call-result message.
+type LLMFunctionCallResultData struct {
+	FunctionName string `json:"function_name"`
+	ToolCallID   string `json:"tool_call_id"`
+	Result       string `json:"result"`
+}
+
+// LLMFunctionCallResult builds a llm-function-call-result message.
+func LLMFunctionCallResult(name, toolCallID, result string) Message {
+	return newMessage(TypeLLMFunctionCallResult, "", LLMFunctionCallResultData{
+		FunctionName: name,
+		ToolCallID:   toolCallID,
+		Result:       result,
+	})
 }
 
 // UserTranscriptionData is the payload of a user-transcription message.

--- a/processor/rtvi/processor.go
+++ b/processor/rtvi/processor.go
@@ -34,34 +34,71 @@ func (p *Processor) ProcessFrame(ctx context.Context, f frames.Frame, dir proces
 		return err
 	}
 
-	switch fr := f.(type) {
-	case *frames.InputTransportMessageFrame:
-		// Client messages are consumed here, not forwarded downstream.
+	// Client messages are consumed here, not forwarded downstream.
+	if fr, ok := f.(*frames.InputTransportMessageFrame); ok {
 		return p.handleIncoming(ctx, fr)
+	}
+	if msg, ok := messageFor(f); ok {
+		return p.emitAndForward(ctx, f, dir, msg)
+	}
+	return p.PushFrame(ctx, f, dir)
+}
+
+// messageFor maps a pipeline frame to the RTVI server message it should emit,
+// reporting false for frames that produce no message. The mapping is split into
+// user- and bot-originated frames to keep each dispatch small.
+func messageFor(f frames.Frame) (Message, bool) {
+	if msg, ok := userMessageFor(f); ok {
+		return msg, true
+	}
+	return botMessageFor(f)
+}
+
+// userMessageFor maps user- and system-originated frames.
+func userMessageFor(f frames.Frame) (Message, bool) {
+	switch fr := f.(type) {
 	case *frames.TranscriptionFrame:
-		return p.emitAndForward(ctx, f, dir,
-			UserTranscription(fr.Text, fr.UserID, fr.Timestamp, true))
+		return UserTranscription(fr.Text, fr.UserID, fr.Timestamp, true), true
 	case *frames.InterimTranscriptionFrame:
-		return p.emitAndForward(ctx, f, dir,
-			UserTranscription(fr.Text, fr.UserID, fr.Timestamp, false))
+		return UserTranscription(fr.Text, fr.UserID, fr.Timestamp, false), true
 	case *frames.UserStartedSpeakingFrame:
-		return p.emitAndForward(ctx, f, dir, event(TypeUserStartedSpeaking))
+		return event(TypeUserStartedSpeaking), true
 	case *frames.UserStoppedSpeakingFrame:
-		return p.emitAndForward(ctx, f, dir, event(TypeUserStoppedSpeaking))
-	case *frames.BotStartedSpeakingFrame:
-		return p.emitAndForward(ctx, f, dir, event(TypeBotStartedSpeaking))
-	case *frames.BotStoppedSpeakingFrame:
-		return p.emitAndForward(ctx, f, dir, event(TypeBotStoppedSpeaking))
-	case *frames.LLMTextFrame:
-		return p.emitAndForward(ctx, f, dir, BotLLMText(fr.Text))
-	case *frames.TTSSpeakFrame:
-		return p.emitAndForward(ctx, f, dir, BotTTSText(fr.Text))
+		return event(TypeUserStoppedSpeaking), true
 	case *frames.ErrorFrame:
-		return p.emitAndForward(ctx, f, dir, Error(fr.Error, fr.Fatal))
+		return Error(fr.Error, fr.Fatal), true
 	case *frames.MetricsFrame:
-		return p.emitAndForward(ctx, f, dir, metricsMessage(fr))
+		return metricsMessage(fr), true
 	default:
-		return p.PushFrame(ctx, f, dir)
+		return Message{}, false
+	}
+}
+
+// botMessageFor maps bot-originated frames (speaking, LLM, TTS, tool calls).
+func botMessageFor(f frames.Frame) (Message, bool) {
+	switch fr := f.(type) {
+	case *frames.BotStartedSpeakingFrame:
+		return event(TypeBotStartedSpeaking), true
+	case *frames.BotStoppedSpeakingFrame:
+		return event(TypeBotStoppedSpeaking), true
+	case *frames.LLMFullResponseStartFrame:
+		return event(TypeBotLLMStarted), true
+	case *frames.LLMFullResponseEndFrame:
+		return event(TypeBotLLMStopped), true
+	case *frames.LLMTextFrame:
+		return BotLLMText(fr.Text), true
+	case *frames.TTSStartedFrame:
+		return event(TypeBotTTSStarted), true
+	case *frames.TTSStoppedFrame:
+		return event(TypeBotTTSStopped), true
+	case *frames.TTSSpeakFrame:
+		return BotTTSText(fr.Text), true
+	case *frames.FunctionCallInProgressFrame:
+		return LLMFunctionCall(fr.ToolName, fr.ToolCallID), true
+	case *frames.FunctionCallResultFrame:
+		return LLMFunctionCallResult(fr.ToolName, fr.ToolCallID, fr.Result), true
+	default:
+		return Message{}, false
 	}
 }
 
@@ -105,10 +142,36 @@ func (p *Processor) handleIncoming(ctx context.Context, f *frames.InputTransport
 	case TypeClientReady:
 		slog.Debug("RTVI client-ready", "id", in.ID)
 		return p.send(ctx, BotReady(in.ID))
+	case TypeSendText:
+		return p.handleSendText(ctx, in)
 	default:
 		slog.Debug("unhandled RTVI message", "type", in.Type)
 		return nil
 	}
+}
+
+// handleSendText injects a text user turn. The processor sits downstream of the
+// context aggregator, so the injected frames are pushed upstream to reach it:
+// the append adds the user message to the shared context, and — unless the
+// client opted out — the run makes the LLM respond immediately, bypassing the
+// VAD/turn-taking gating that governs spoken turns.
+func (p *Processor) handleSendText(ctx context.Context, in Incoming) error {
+	d, err := ParseSendTextData(in.Data)
+	if err != nil {
+		slog.Warn("invalid RTVI send-text", "err", err)
+		return nil
+	}
+	if d.Content == "" {
+		return nil
+	}
+	appendMsg := frames.NewLLMMessagesAppendFrame([]frames.Message{{Role: frames.RoleUser, Text: d.Content}})
+	if err := p.PushFrame(ctx, appendMsg, processor.Upstream); err != nil {
+		return err
+	}
+	if d.RunImmediately() {
+		return p.PushFrame(ctx, frames.NewLLMRunFrame(), processor.Upstream)
+	}
+	return nil
 }
 
 // emitAndForward sends an RTVI message and forwards the originating frame.

--- a/processor/rtvi/rtvi_test.go
+++ b/processor/rtvi/rtvi_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gojargo/jargo/frames"
 	"github.com/gojargo/jargo/pipeline"
+	"github.com/gojargo/jargo/processor/aggregators"
 	"github.com/gojargo/jargo/processor/rtvi"
 )
 
@@ -85,6 +86,114 @@ func TestProcessorHandshakeAndTranscript(t *testing.T) {
 	}
 	if d, ok := got.Data.(rtvi.UserTranscriptionData); !ok || d.Text != "bonjour" || !d.Final {
 		t.Fatalf("unexpected transcription data: %+v", got.Data)
+	}
+
+	task.StopWhenDone()
+	<-runDone
+}
+
+// TestProcessorLifecycleAndFunctionCalls drives the LLM/TTS lifecycle frames and
+// function-call frames through the RTVI processor and checks each maps to its
+// wire message.
+func TestProcessorLifecycleAndFunctionCalls(t *testing.T) {
+	out := make(chan rtvi.Message, 16)
+	task := pipeline.NewTask(pipeline.New(rtvi.NewProcessor()), pipeline.TaskParams{
+		OnReachedDownstream: func(f frames.Frame) {
+			if m, ok := f.(*frames.OutputTransportMessageFrame); ok {
+				if msg, ok := m.Message.(rtvi.Message); ok {
+					out <- msg
+				}
+			}
+		},
+	})
+
+	runDone := make(chan error, 1)
+	go func() { runDone <- task.Run(context.Background()) }()
+
+	task.QueueFrame(frames.NewLLMFullResponseStartFrame())
+	if got := waitMessage(t, out); got.Type != rtvi.TypeBotLLMStarted {
+		t.Fatalf("expected bot-llm-started, got %+v", got)
+	}
+	task.QueueFrame(frames.NewLLMFullResponseEndFrame())
+	if got := waitMessage(t, out); got.Type != rtvi.TypeBotLLMStopped {
+		t.Fatalf("expected bot-llm-stopped, got %+v", got)
+	}
+
+	task.QueueFrame(frames.NewTTSStartedFrame())
+	if got := waitMessage(t, out); got.Type != rtvi.TypeBotTTSStarted {
+		t.Fatalf("expected bot-tts-started, got %+v", got)
+	}
+	task.QueueFrame(frames.NewTTSStoppedFrame())
+	if got := waitMessage(t, out); got.Type != rtvi.TypeBotTTSStopped {
+		t.Fatalf("expected bot-tts-stopped, got %+v", got)
+	}
+
+	task.QueueFrame(frames.NewFunctionCallInProgressFrame("call-1", "get_weather"))
+	got := waitMessage(t, out)
+	if got.Type != rtvi.TypeLLMFunctionCall {
+		t.Fatalf("expected llm-function-call-in-progress, got %+v", got)
+	}
+	if d, ok := got.Data.(rtvi.LLMFunctionCallData); !ok || d.FunctionName != "get_weather" || d.ToolCallID != "call-1" {
+		t.Fatalf("unexpected function-call data: %+v", got.Data)
+	}
+
+	task.QueueFrame(frames.NewFunctionCallResultFrame("call-1", "get_weather", "sunny, 24C", false))
+	got = waitMessage(t, out)
+	if got.Type != rtvi.TypeLLMFunctionCallResult {
+		t.Fatalf("expected llm-function-call-result, got %+v", got)
+	}
+	if d, ok := got.Data.(rtvi.LLMFunctionCallResultData); !ok || d.Result != "sunny, 24C" {
+		t.Fatalf("unexpected function-call-result data: %+v", got.Data)
+	}
+
+	task.StopWhenDone()
+	<-runDone
+}
+
+// TestProcessorSendTextInjectsUserTurn verifies an inbound send-text message
+// appends a user message to the shared context and triggers an LLM run, even
+// though the RTVI processor sits downstream of the aggregator (the injection is
+// pushed upstream).
+func TestProcessorSendTextInjectsUserTurn(t *testing.T) {
+	convo := frames.NewLLMContext("system")
+	pair := aggregators.New(convo)
+
+	got := make(chan *frames.LLMContextFrame, 1)
+	task := pipeline.NewTask(pipeline.New(pair.User(), rtvi.NewProcessor()), pipeline.TaskParams{
+		OnReachedDownstream: func(f frames.Frame) {
+			if cf, ok := f.(*frames.LLMContextFrame); ok {
+				select {
+				case got <- cf:
+				default:
+				}
+			}
+		},
+	})
+
+	runDone := make(chan error, 1)
+	go func() { runDone <- task.Run(context.Background()) }()
+
+	sendText, _ := json.Marshal(rtvi.Message{
+		Label: rtvi.MessageLabel, Type: rtvi.TypeSendText, ID: "req-1",
+		Data: map[string]any{
+			"content": "what time is it",
+			"options": map[string]any{"run_immediately": true, "audio_response": false},
+		},
+	})
+	task.QueueFrame(frames.NewInputTransportMessageFrame(sendText))
+
+	select {
+	case cf := <-got:
+		msgs := cf.Context.Messages()
+		if len(msgs) == 0 {
+			t.Fatal("send-text produced an empty context")
+		}
+		last := msgs[len(msgs)-1]
+		if last.Role != frames.RoleUser || last.Text != "what time is it" {
+			t.Fatalf("expected appended user message, got %+v", msgs)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("send-text did not trigger an LLM run")
 	}
 
 	task.StopWhenDone()

--- a/transport/wsserver/rtviws/rtviws.go
+++ b/transport/wsserver/rtviws/rtviws.go
@@ -1,20 +1,49 @@
 // Package rtviws is the wsserver.Serializer that carries the RTVI protocol over
 // a plain WebSocket, so an RTVI client can drive a jargo bot without WebRTC.
-// Inbound RTVI messages are handed to the pipeline's RTVI processor; outbound
-// RTVI server messages reach the socket through the transport's own message
-// path (an OutputTransportMessageFrame), so the serializer only bridges the
-// inbound direction.
+// Inbound RTVI messages are handed to the pipeline's RTVI processor; a client's
+// microphone audio arrives as raw-audio messages and enters the pipeline as
+// InputAudioRawFrames (VAD, turn detection and STT then see it as a live mic).
+// Outbound RTVI server messages reach the socket through the transport's own
+// message path (an OutputTransportMessageFrame).
 //
-// This carries the RTVI control, event and text channel only — bot audio is not
-// streamed over the socket, so a client on this transport is text-first. Pair it
-// with a pipeline that includes an rtvi.Processor.
+// Bot audio is not yet streamed back over the socket, so a client on this
+// transport hears events and text, not synthesized speech. Pair it with a
+// pipeline that includes an rtvi.Processor.
 package rtviws
 
 import (
+	"encoding/base64"
+	"encoding/json"
+
 	"github.com/gojargo/jargo/frames"
 	"github.com/gojargo/jargo/processor/rtvi"
 	"github.com/gojargo/jargo/transport/wsserver"
 )
+
+// TypeRawAudio is the RTVI message type carrying a chunk of microphone PCM from
+// the client to the bot.
+const TypeRawAudio = "raw-audio"
+
+// RawAudioData is the payload of a raw-audio message: base64 16-bit mono PCM
+// with its sample rate.
+type RawAudioData struct {
+	Audio       string `json:"audio"`
+	SampleRate  int    `json:"sample_rate"`
+	NumChannels int    `json:"num_channels"`
+}
+
+// RawAudio builds a raw-audio message carrying pcm (16-bit PCM) at sampleRate.
+func RawAudio(pcm []byte, sampleRate, numChannels int) rtvi.Message {
+	return rtvi.Message{
+		Label: rtvi.MessageLabel,
+		Type:  TypeRawAudio,
+		Data: RawAudioData{
+			Audio:       base64.StdEncoding.EncodeToString(pcm),
+			SampleRate:  sampleRate,
+			NumChannels: numChannels,
+		},
+	}
+}
 
 // Serializer implements wsserver.Serializer.
 var _ wsserver.Serializer = (*Serializer)(nil)
@@ -35,9 +64,11 @@ func (*Serializer) Setup(*frames.StartFrame) error { return nil }
 // serializer, and bot audio is not streamed over this channel.
 func (*Serializer) Serialize(frames.Frame) ([]byte, error) { return nil, nil }
 
-// Deserialize wraps an inbound RTVI message in an InputTransportMessageFrame so
-// the pipeline's RTVI processor parses and routes it (the handshake, send-text,
-// and so on). Payloads that are not RTVI messages are ignored.
+// Deserialize turns an inbound RTVI message into a frame: raw-audio becomes an
+// InputAudioRawFrame (played into the pipeline as mic audio), and every other
+// RTVI message is wrapped in an InputTransportMessageFrame so the pipeline's RTVI
+// processor parses and routes it (the handshake, send-text, and so on). Payloads
+// that are not RTVI messages are ignored.
 func (*Serializer) Deserialize(data []byte) (frames.Frame, error) {
 	in, err := rtvi.ParseIncoming(data)
 	if err != nil || in.Label != rtvi.MessageLabel {
@@ -45,9 +76,30 @@ func (*Serializer) Deserialize(data []byte) (frames.Frame, error) {
 		// wsserver.Serializer contract — not an error.
 		return nil, nil //nolint:nilnil,nilerr // dropping a non-RTVI message is intentional
 	}
+	if in.Type == TypeRawAudio {
+		return decodeRawAudio(in.Data)
+	}
 	// The transport may reuse its read buffer, and the frame outlives this call,
 	// so hand the RTVI processor its own copy.
 	msg := make([]byte, len(data))
 	copy(msg, data)
 	return frames.NewInputTransportMessageFrame(msg), nil
+}
+
+// decodeRawAudio turns a raw-audio payload into an InputAudioRawFrame, or drops
+// it (nil, nil) if the payload is malformed.
+func decodeRawAudio(data json.RawMessage) (frames.Frame, error) {
+	var d RawAudioData
+	if err := json.Unmarshal(data, &d); err != nil {
+		return nil, nil //nolint:nilnil,nilerr // a malformed audio chunk is dropped
+	}
+	pcm, err := base64.StdEncoding.DecodeString(d.Audio)
+	if err != nil || len(pcm) == 0 {
+		return nil, nil //nolint:nilnil,nilerr // undecodable or empty audio is dropped
+	}
+	channels := d.NumChannels
+	if channels == 0 {
+		channels = 1
+	}
+	return frames.NewInputAudioRawFrame(pcm, d.SampleRate, channels), nil
 }

--- a/transport/wsserver/rtviws/rtviws.go
+++ b/transport/wsserver/rtviws/rtviws.go
@@ -1,0 +1,53 @@
+// Package rtviws is the wsserver.Serializer that carries the RTVI protocol over
+// a plain WebSocket, so an RTVI client can drive a jargo bot without WebRTC.
+// Inbound RTVI messages are handed to the pipeline's RTVI processor; outbound
+// RTVI server messages reach the socket through the transport's own message
+// path (an OutputTransportMessageFrame), so the serializer only bridges the
+// inbound direction.
+//
+// This carries the RTVI control, event and text channel only — bot audio is not
+// streamed over the socket, so a client on this transport is text-first. Pair it
+// with a pipeline that includes an rtvi.Processor.
+package rtviws
+
+import (
+	"github.com/gojargo/jargo/frames"
+	"github.com/gojargo/jargo/processor/rtvi"
+	"github.com/gojargo/jargo/transport/wsserver"
+)
+
+// Serializer implements wsserver.Serializer.
+var _ wsserver.Serializer = (*Serializer)(nil)
+
+// Serializer bridges RTVI JSON messages and pipeline frames over a WebSocket.
+// It holds no per-session state, so a single value may serve any session.
+type Serializer struct{}
+
+// New builds an RTVI WebSocket serializer.
+func New() *Serializer { return &Serializer{} }
+
+// Setup is a no-op: the RTVI channel carries no audio, so there is nothing to
+// configure from the StartFrame.
+func (*Serializer) Setup(*frames.StartFrame) error { return nil }
+
+// Serialize drops outbound frames. RTVI server messages reach the socket through
+// the transport's own OutputTransportMessageFrame path rather than the
+// serializer, and bot audio is not streamed over this channel.
+func (*Serializer) Serialize(frames.Frame) ([]byte, error) { return nil, nil }
+
+// Deserialize wraps an inbound RTVI message in an InputTransportMessageFrame so
+// the pipeline's RTVI processor parses and routes it (the handshake, send-text,
+// and so on). Payloads that are not RTVI messages are ignored.
+func (*Serializer) Deserialize(data []byte) (frames.Frame, error) {
+	in, err := rtvi.ParseIncoming(data)
+	if err != nil || in.Label != rtvi.MessageLabel {
+		// Malformed or non-RTVI payloads carry no frame and are dropped, per the
+		// wsserver.Serializer contract — not an error.
+		return nil, nil //nolint:nilnil,nilerr // dropping a non-RTVI message is intentional
+	}
+	// The transport may reuse its read buffer, and the frame outlives this call,
+	// so hand the RTVI processor its own copy.
+	msg := make([]byte, len(data))
+	copy(msg, data)
+	return frames.NewInputTransportMessageFrame(msg), nil
+}

--- a/transport/wsserver/rtviws/rtviws_test.go
+++ b/transport/wsserver/rtviws/rtviws_test.go
@@ -52,6 +52,23 @@ func TestDeserializeCopiesInput(t *testing.T) {
 	}
 }
 
+func TestDeserializeRawAudio(t *testing.T) {
+	pcm := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}
+	raw, _ := json.Marshal(rtviws.RawAudio(pcm, 16000, 1))
+
+	f, err := rtviws.New().Deserialize(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	af, ok := f.(*frames.InputAudioRawFrame)
+	if !ok {
+		t.Fatalf("expected *InputAudioRawFrame, got %T", f)
+	}
+	if !bytes.Equal(af.Audio, pcm) || af.SampleRate != 16000 || af.NumChannels != 1 {
+		t.Fatalf("unexpected audio frame: audio=%v rate=%d ch=%d", af.Audio, af.SampleRate, af.NumChannels)
+	}
+}
+
 func TestDeserializeIgnoresNonRTVI(t *testing.T) {
 	cases := map[string][]byte{
 		"wrong label": []byte(`{"label":"other","type":"x"}`),

--- a/transport/wsserver/rtviws/rtviws_test.go
+++ b/transport/wsserver/rtviws/rtviws_test.go
@@ -1,0 +1,86 @@
+package rtviws_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/gojargo/jargo/frames"
+	"github.com/gojargo/jargo/processor/rtvi"
+	"github.com/gojargo/jargo/transport/wsserver/rtviws"
+)
+
+func TestDeserializeWrapsRTVIMessage(t *testing.T) {
+	raw, _ := json.Marshal(rtvi.Message{
+		Label: rtvi.MessageLabel, Type: rtvi.TypeClientReady, ID: "req-1",
+	})
+
+	f, err := rtviws.New().Deserialize(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	msg, ok := f.(*frames.InputTransportMessageFrame)
+	if !ok {
+		t.Fatalf("expected *InputTransportMessageFrame, got %T", f)
+	}
+	if !bytes.Equal(msg.Message, raw) {
+		t.Fatalf("wrapped payload = %s, want %s", msg.Message, raw)
+	}
+	// The wrapped bytes must parse back to the same RTVI message.
+	in, err := rtvi.ParseIncoming(msg.Message)
+	if err != nil || in.Type != rtvi.TypeClientReady || in.ID != "req-1" {
+		t.Fatalf("round-trip failed: %+v (err %v)", in, err)
+	}
+}
+
+func TestDeserializeCopiesInput(t *testing.T) {
+	raw, _ := json.Marshal(rtvi.Message{Label: rtvi.MessageLabel, Type: rtvi.TypeClientReady})
+	buf := append([]byte(nil), raw...)
+
+	f, _ := rtviws.New().Deserialize(buf)
+	msg, ok := f.(*frames.InputTransportMessageFrame)
+	if !ok {
+		t.Fatalf("expected *InputTransportMessageFrame, got %T", f)
+	}
+
+	// Mutating the caller's buffer must not corrupt the frame's copy.
+	for i := range buf {
+		buf[i] = 'x'
+	}
+	if !bytes.Equal(msg.Message, raw) {
+		t.Fatalf("frame aliased the caller's buffer: %s", msg.Message)
+	}
+}
+
+func TestDeserializeIgnoresNonRTVI(t *testing.T) {
+	cases := map[string][]byte{
+		"wrong label": []byte(`{"label":"other","type":"x"}`),
+		"garbage":     []byte("not json"),
+		"empty":       nil,
+	}
+	for name, data := range cases {
+		t.Run(name, func(t *testing.T) {
+			f, err := rtviws.New().Deserialize(data)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if f != nil {
+				t.Fatalf("expected no frame, got %T", f)
+			}
+		})
+	}
+}
+
+func TestSerializeDropsFrames(t *testing.T) {
+	s := rtviws.New()
+	for _, f := range []frames.Frame{
+		frames.NewOutputAudioRawFrame([]byte{0, 0}, 16000, 1),
+		frames.NewInterruptionFrame(),
+		frames.NewEndFrame(),
+	} {
+		out, err := s.Serialize(f)
+		if err != nil || out != nil {
+			t.Fatalf("Serialize(%T) = %v, %v; want nil, nil", f, out, err)
+		}
+	}
+}


### PR DESCRIPTION
## Behavioral eval harness + `jargo` CLI

Adds a behavioral eval harness that drives a real bot over RTVI, plays scripted
YAML scenarios, and asserts on the semantic events the bot emits — a level above
unit tests, which check one processor at a time. Scenarios run two ways off one
core: in-process from a Go test, or from the command line against a running bot.

### What's included

- **`eval` package** — scenario loader, RTVI WebSocket client, an in-order,
  gap-tolerant matcher with per-expectation `within_ms` latency budgets, an LLM
  judge, and a concurrent suite runner.
- **`cmd/jargo`** — the project's first binary (Cobra): `jargo eval run` and
  `jargo eval suite`.
- **`processor/rtvi`** — inbound `send-text` handling (append a user turn and run
  the LLM) plus richer server messages: `bot-llm-started/stopped`,
  `bot-tts-started/stopped`, `llm-function-call-in-progress`, and
  `llm-function-call-result`. Useful to any RTVI client, not just the harness.
- **`transport/wsserver/rtviws`** — a general serializer that carries the RTVI
  control/event/text channel plus inbound microphone audio over a plain
  WebSocket, so a client can drive a bot without WebRTC.
- **`examples/eval`** — a keyless demo bot served via `eval.Handler`, a sample
  scenario, and a go-test.

### Usage

```go
// In-process, from a Go test — the bot is hosted on a loopback WebSocket.
func TestGreeting(t *testing.T) {
    eval.Run(t, "scenarios/greeting.yaml", buildBot)
}
```

```sh
# Against a running bot that mounts eval.Handler.
jargo eval run scenarios/greeting.yaml --bot-url ws://localhost:8080
jargo eval suite scenarios/manifest.yaml            # many scenarios, concurrently
```

```yaml
name: greeting
turns:
  - user: "hello there"
    expect:
      - event: llm_started
      - event: llm_response
        text_contains: "how can I help"
      - event: llm_response
        judge: "greets the user warmly"      # graded by an LLM judge
```

### Modes

- **Text mode** — each user turn is delivered as RTVI `send-text`; assertions
  match `llm_started`, `llm_response` (`text_contains` or an LLM `judge`), and
  `function_call`.
- **Audio mode** (`Options.UserTTS`) — each user turn is synthesized and streamed
  to the bot as microphone audio at real-time cadence, so the bot's real VAD,
  turn detection and STT run. Unlocks `user_started_speaking`,
  `user_stopped_speaking` and `user_transcription` assertions.

### Notes

- Default build stays cgo-free; new direct deps are `spf13/cobra` (CLI only) and
  `gopkg.in/yaml.v3` (already an indirect dep).
- Everything is covered by tests (including an audio-mode run with no ONNX
  runtime, via fakes), lint-clean, and race-clean.
- Follow-up: the bot-audio `response` assertion (transcribe the bot's synthesized
  speech with a local STT) is the natural next iteration.
