### PR TITLE
fix(anthropic): inject a trailing user message for no-prefill Claude models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,17 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   PipeWire (pulse-compatible) server. See `examples/localaudio` for a no-keys
   microphone-to-speaker echo.
 
+### Fixed
+
+- **Anthropic/Bedrock assistant-prefill constraint** (`provider/anthropic`): the
+  Claude 4.6-generation models (Opus 4.8, Sonnet 4.6, …) reject a request whose
+  message list ends with an assistant message. When the configured model does not
+  support prefill, the service now appends a minimal `.` user message to such
+  requests at send time; the stored `LLMContext` is left untouched. Prefill
+  support is detected from a frozen allow-list of the models known to still
+  accept it, so every current and future no-prefill model is covered by default.
+  Bedrock is fixed by the same change, since it runs on the Anthropic service.
+
 ## [0.0.4] - 2026-07-12
 
 ### Added

--- a/provider/anthropic/anthropic.go
+++ b/provider/anthropic/anthropic.go
@@ -7,6 +7,7 @@ package anthropic
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"time"
 
 	sdk "github.com/anthropics/anthropic-sdk-go"
@@ -132,10 +133,16 @@ func NewLLMWithOptions(name string, cfg Config, extra ...option.RequestOption) *
 // token cap, the converted conversation, sampling controls and the cached
 // system prompt.
 func (s *Service) newParams(convo *frames.LLMContext) sdk.MessageNewParams {
+	messages := toMessages(convo.Messages())
+	// Models without assistant-prefill support reject a request whose message
+	// list ends with an assistant message; give them a trailing user turn.
+	if !supportsPrefill(s.model) {
+		messages = ensureLastMessageIsUser(messages)
+	}
 	params := sdk.MessageNewParams{
 		Model:       s.model,
 		MaxTokens:   s.maxTokens,
-		Messages:    toMessages(convo.Messages()),
+		Messages:    messages,
 		Temperature: s.temperature,
 		TopP:        s.topP,
 		TopK:        s.topK,
@@ -267,6 +274,51 @@ func toTools(tools []frames.Tool) []sdk.ToolUnionParam {
 		out = append(out, sdk.ToolUnionParam{OfTool: tool})
 	}
 	return out
+}
+
+// prefillSupportedPatterns lists the Claude models that still accept a request
+// whose message list ends with an assistant message (assistant prefill).
+// Anthropic dropped prefill support in the 4.6-generation models, so this is a
+// frozen legacy set; any Claude model not matching it is assumed to reject
+// prefill. Patterns are matched as substrings so Bedrock ids like
+// "us.anthropic.claude-sonnet-4-6-v1:0" are handled alongside direct ids.
+//
+//nolint:gochecknoglobals // fixed lookup table
+var prefillSupportedPatterns = []string{
+	"claude-2",
+	"claude-instant",
+	"claude-3",
+	"claude-opus-4-0",
+	"claude-opus-4-1",
+	"claude-sonnet-4-0",
+	"claude-sonnet-4-5",
+	"claude-haiku-4-5",
+}
+
+// supportsPrefill reports whether model accepts an assistant-prefilled request.
+// Non-Claude models are unaffected and reported as supporting it (so nothing is
+// injected); a Claude model is supported only when it matches the frozen legacy
+// set above.
+func supportsPrefill(model string) bool {
+	if !strings.Contains(model, "claude") {
+		return true
+	}
+	for _, p := range prefillSupportedPatterns {
+		if strings.Contains(model, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// ensureLastMessageIsUser appends a minimal user message when the list ends with
+// an assistant message, so a model without prefill support accepts the request.
+// The "." is a language-neutral no-op user turn; the stored context is untouched.
+func ensureLastMessageIsUser(msgs []sdk.MessageParam) []sdk.MessageParam {
+	if n := len(msgs); n > 0 && msgs[n-1].Role == sdk.MessageParamRoleAssistant {
+		return append(msgs, sdk.NewUserMessage(sdk.NewTextBlock(".")))
+	}
+	return msgs
 }
 
 // toMessages converts the conversation into Anthropic message params. Tool turns

--- a/provider/anthropic/anthropic_test.go
+++ b/provider/anthropic/anthropic_test.go
@@ -31,6 +31,69 @@ func TestToToolsMapsSchema(t *testing.T) {
 	}
 }
 
+func TestSupportsPrefill(t *testing.T) {
+	cases := map[string]bool{
+		// Direct model ids that still support prefill.
+		"claude-haiku-4-5":           true,
+		"claude-haiku-4-5-20251001":  true,
+		"claude-sonnet-4-5":          true,
+		"claude-3-5-sonnet-20241022": true,
+		"claude-opus-4-1":            true,
+		// Direct ids that dropped prefill.
+		"claude-opus-4-8":   false,
+		"claude-sonnet-4-6": false,
+		// Bedrock ids (region-prefixed) are matched as substrings.
+		"us.anthropic.claude-3-5-haiku-20241022-v1:0": true,
+		"us.anthropic.claude-sonnet-4-6-v1:0":         false,
+		"us.anthropic.claude-opus-4-8-v1:0":           false,
+		// Non-Claude models are unaffected (nothing is injected).
+		"amazon.titan-text-express-v1": true,
+		"":                             true,
+	}
+	for model, want := range cases {
+		if got := supportsPrefill(model); got != want {
+			t.Errorf("supportsPrefill(%q) = %v, want %v", model, got, want)
+		}
+	}
+}
+
+func TestEnsureLastMessageIsUser(t *testing.T) {
+	user := sdk.NewUserMessage(sdk.NewTextBlock("hi"))
+	assistant := sdk.NewAssistantMessage(sdk.NewTextBlock("hello"))
+
+	got := ensureLastMessageIsUser([]sdk.MessageParam{user, assistant})
+	if len(got) != 3 || got[2].Role != sdk.MessageParamRoleUser {
+		t.Fatalf("ending on assistant should append a user message; got %d messages", len(got))
+	}
+
+	got = ensureLastMessageIsUser([]sdk.MessageParam{assistant, user})
+	if len(got) != 2 {
+		t.Fatalf("ending on user should be unchanged; got %d messages", len(got))
+	}
+
+	if got := ensureLastMessageIsUser(nil); len(got) != 0 {
+		t.Fatalf("empty list should stay empty; got %d messages", len(got))
+	}
+}
+
+func TestNewParamsPrefillFixup(t *testing.T) {
+	convo := frames.NewLLMContext("system")
+	convo.AddUserMessage("hi")
+	convo.AddAssistantMessage("hello") // context ends on an assistant message
+
+	// A no-prefill model gets a trailing user message injected.
+	noPrefill := NewLLM(Config{Model: "claude-opus-4-8"}).newParams(convo).Messages
+	if n := len(noPrefill); n != 3 || noPrefill[n-1].Role != sdk.MessageParamRoleUser {
+		t.Fatalf("no-prefill model: want 3 messages ending in a user turn, got %d", n)
+	}
+
+	// A prefill-supported model keeps the assistant message last.
+	prefill := NewLLM(Config{Model: "claude-haiku-4-5"}).newParams(convo).Messages
+	if n := len(prefill); n != 2 || prefill[n-1].Role != sdk.MessageParamRoleAssistant {
+		t.Fatalf("prefill model: want the assistant message to stay last, got %d messages", n)
+	}
+}
+
 func TestNewParamsAppliesSampling(t *testing.T) {
 	temp, topP := 0.3, 0.9
 	topK := int64(40)


### PR DESCRIPTION
## Handle the Claude 4.6+ no-prefill constraint

The Claude 4.6-generation models — **Opus 4.8**, Sonnet 4.6, and newer — dropped
support for *assistant prefill*: they **reject any request whose message list
ends with an assistant message**. Today `provider/anthropic` converts the
`LLMContext` to request messages 1:1 with no fixup, so a context that ends on an
assistant turn (intentional prefill, or a bot-speaks-first design) sent to such a
model fails at request time.

### Fix

- `newParams` now appends a minimal `.` **user** message when the converted list
  ends with an assistant message and the configured model doesn't support
  prefill. The stored `LLMContext` is never mutated — the fixup is per-request.
- Prefill support is detected from a **frozen allow-list** of the models known to
  still accept it (`claude-2/instant/3`, `opus-4-0/4-1`, `sonnet-4-0/4-5`,
  `haiku-4-5`). Any Claude model not on it is assumed no-prefill, so every current
  and future model is covered by default (a deny-list would rot — `claude-opus-4-8`
  already rejects prefill). Non-Claude models are left untouched.
- Patterns match as substrings, so **Bedrock** ids like
  `us.anthropic.claude-sonnet-4-6-v1:0` are handled. Bedrock needs no change of
  its own — it runs on the Anthropic service.

### Scope

- The default Anthropic model (Haiku 4.5) is on the allow-list, so **defaults are
  unaffected**; this only changes behavior for no-prefill models with an
  assistant-terminated context.
- Both request paths (`Generate` and `GenerateWithTools`) route through
  `newParams`, so both are covered.

Tests cover the model detection (direct + Bedrock ids, non-Claude), the message
fixup, and the end-to-end `newParams` behavior for a no-prefill vs a
prefill-supported model. Lint-clean, race-clean, default build stays cgo-free.
