### PR TITLE
fix(llm): drive tool continuation from the assistant aggregator

### DIFF
--- a/frames/function.go
+++ b/frames/function.go
@@ -67,6 +67,9 @@ type FunctionCallResultFrame struct {
 	Result string
 	// IsError reports whether the tool failed.
 	IsError bool
+	// RunLLM reports whether generation should re-run after this result; a handler
+	// that stops the turn (ErrStopTurn) sets it false.
+	RunLLM bool
 }
 
 // NewFunctionCallResultFrame builds a FunctionCallResultFrame.
@@ -77,6 +80,7 @@ func NewFunctionCallResultFrame(toolCallID, name, result string, isError bool) *
 		ToolName:         name,
 		Result:           result,
 		IsError:          isError,
+		RunLLM:           true,
 	}
 }
 

--- a/processor/aggregators/aggregators.go
+++ b/processor/aggregators/aggregators.go
@@ -230,6 +230,8 @@ type AssistantAggregator struct {
 	// have arrived and they can be written as one tool-result message.
 	pendingResults []frames.ToolResult
 	pendingIDs     map[string]bool
+	// suppressRun is set when a result asks not to re-run (a stopped turn).
+	suppressRun bool
 }
 
 func newAssistant(ctx *frames.LLMContext, sc *SummarizeConfig) *AssistantAggregator {
@@ -261,7 +263,9 @@ func (a *AssistantAggregator) ProcessFrame(ctx context.Context, f frames.Frame, 
 	case *frames.FunctionCallsStartedFrame:
 		a.handleFunctionCallsStarted(fr)
 	case *frames.FunctionCallResultFrame:
-		a.handleFunctionCallResult(fr)
+		if err := a.handleFunctionCallResult(ctx, fr); err != nil {
+			return err
+		}
 	case *frames.LLMFullResponseEndFrame:
 		a.commit()
 	case *frames.TTSSpeakFrame:
@@ -292,8 +296,11 @@ func (a *AssistantAggregator) handleFunctionCallsStarted(fr *frames.FunctionCall
 }
 
 // handleFunctionCallResult buffers a tool result and, once every call from the
-// assistant turn has one, writes them as a single tool-result message.
-func (a *AssistantAggregator) handleFunctionCallResult(fr *frames.FunctionCallResultFrame) {
+// assistant turn has one, writes them as a single tool-result message and
+// re-triggers generation — unless a result asked to stop the turn. Writing the
+// results before re-triggering keeps the tool calls balanced for the next
+// inference.
+func (a *AssistantAggregator) handleFunctionCallResult(ctx context.Context, fr *frames.FunctionCallResultFrame) error {
 	a.mu.Lock()
 	a.pendingResults = append(a.pendingResults, frames.ToolResult{
 		ID:      fr.ToolCallID,
@@ -301,16 +308,29 @@ func (a *AssistantAggregator) handleFunctionCallResult(fr *frames.FunctionCallRe
 		Content: fr.Result,
 		IsError: fr.IsError,
 	})
+	if !fr.RunLLM {
+		a.suppressRun = true
+	}
 	delete(a.pendingIDs, fr.ToolCallID)
 	var results []frames.ToolResult
-	if len(a.pendingIDs) == 0 {
+	complete := len(a.pendingIDs) == 0
+	if complete {
 		results = a.pendingResults
 		a.pendingResults = nil
 	}
+	runLLM := complete && !a.suppressRun
+	if complete {
+		a.suppressRun = false
+	}
 	a.mu.Unlock()
+
 	if results != nil {
 		a.context.AddToolResults(results)
 	}
+	if runLLM {
+		return a.PushFrame(ctx, frames.NewLLMContextFrame(a.context), processor.Upstream)
+	}
+	return nil
 }
 
 // commit appends the aggregated assistant message to the context, if any, and
@@ -340,6 +360,7 @@ func (a *AssistantAggregator) commitInterrupted() {
 		results = append(results, frames.ToolResult{ID: id, Content: "interrupted", IsError: true})
 		delete(a.pendingIDs, id)
 	}
+	a.suppressRun = false
 	text := a.aggregation
 	a.aggregation = ""
 	a.started = false

--- a/service/llm/llm.go
+++ b/service/llm/llm.go
@@ -8,9 +8,9 @@
 // one place.
 //
 // A service that also supports tool calling implements ToolGenerator. When the
-// context carries tools, the base runs a tool loop: it streams text, dispatches
-// each requested call to a registered handler, emits the function-call frames,
-// and re-generates until the model produces a final answer.
+// context carries tools, the base streams text, dispatches each requested call to
+// a registered handler, and emits the function-call frames; the assistant
+// aggregator commits the results and re-triggers generation for the model's reply.
 package llm
 
 import (
@@ -230,12 +230,11 @@ type sink struct {
 func (s sink) Text(t string) error          { return s.text(t) }
 func (s sink) Tool(c frames.ToolCall) error { return s.tool(c) }
 
-// runWithTools runs the tool loop: stream text, dispatch any requested calls to
-// their handlers, emit the function-call frames, and re-generate until the model
-// answers without calling tools. The base writes nothing to the context — the
-// assistant aggregator records the tool turn from the emitted frames, keeping
-// the context's single writer. An interruption cancels ctx; the loop then stops
-// without emitting a partial tool turn.
+// runWithTools runs one tool-capable inference: it streams text and, when the
+// model requests tools, dispatches each call to its handler and emits the
+// function-call frames. It does not loop — the assistant aggregator commits the
+// results to the context and re-triggers generation, so the next inference reads a
+// context whose tool calls are balanced. The base writes nothing to the context.
 func (b *Base) runWithTools(ctx context.Context, convo *frames.LLMContext, tg ToolGenerator) error {
 	ctx, span := b.startSpan(ctx)
 	defer span.End()
@@ -246,78 +245,61 @@ func (b *Base) runWithTools(ctx context.Context, convo *frames.LLMContext, tg To
 	start := time.Now()
 	var ttfb time.Duration
 	hadTTFB := false
-	for {
-		var preamble strings.Builder
-		var calls []frames.ToolCall
-		s := sink{
-			text: func(t string) error {
-				if t == "" {
-					return nil
-				}
-				if !hadTTFB {
-					hadTTFB = true
-					ttfb = time.Since(start)
-					span.SetAttributes(attribute.Int64("llm.ttfb_ms", ttfb.Milliseconds()))
-				}
-				preamble.WriteString(t)
-				return b.PushFrame(ctx, frames.NewLLMTextFrame(t), processor.Downstream)
-			},
-			tool: func(c frames.ToolCall) error {
-				calls = append(calls, c)
+	var preamble strings.Builder
+	var calls []frames.ToolCall
+	s := sink{
+		text: func(t string) error {
+			if t == "" {
 				return nil
-			},
-		}
-		if err := tg.GenerateWithTools(ctx, convo, s); err != nil && ctx.Err() == nil {
-			b.PushError(ctx, "llm generation failed", err, false)
-			break
-		}
-		if ctx.Err() != nil {
-			break
-		}
-		if len(calls) == 0 {
-			break // final spoken answer; the assistant aggregator commits it
-		}
+			}
+			if !hadTTFB {
+				hadTTFB = true
+				ttfb = time.Since(start)
+				span.SetAttributes(attribute.Int64("llm.ttfb_ms", ttfb.Milliseconds()))
+			}
+			preamble.WriteString(t)
+			return b.PushFrame(ctx, frames.NewLLMTextFrame(t), processor.Downstream)
+		},
+		tool: func(c frames.ToolCall) error {
+			calls = append(calls, c)
+			return nil
+		},
+	}
+	if err := tg.GenerateWithTools(ctx, convo, s); err != nil && ctx.Err() == nil {
+		b.PushError(ctx, "llm generation failed", err, false)
+	} else if ctx.Err() == nil && len(calls) > 0 {
 		started := frames.NewFunctionCallsStartedFrame(preamble.String(), calls)
 		if err := b.PushFrame(ctx, started, processor.Downstream); err != nil {
 			return err
 		}
-		stop, err := b.runTools(ctx, calls)
-		if err != nil {
+		if err := b.runTools(ctx, calls); err != nil {
 			return err
 		}
-		if ctx.Err() != nil || stop {
-			break
-		}
-		// Loop: re-read the context (which a handler may have changed) and
-		// generate the model's response to the tool results.
 	}
 	b.emitTiming(ctx, ttfb, hadTTFB, time.Since(start))
 	return b.PushFrame(ctx, frames.NewLLMFullResponseEndFrame(), processor.Downstream)
 }
 
 // runTools executes each tool call in turn, emitting an in-progress frame and a
-// result frame for each, and reports whether a handler asked to stop the turn
-// (see ErrStopTurn). A canceled ctx stops the loop and is returned.
-func (b *Base) runTools(ctx context.Context, calls []frames.ToolCall) (bool, error) {
-	stop := false
+// result frame for each. A handler that returns ErrStopTurn marks its result so
+// the aggregator does not re-trigger generation. A canceled ctx stops the loop.
+func (b *Base) runTools(ctx context.Context, calls []frames.ToolCall) error {
 	for _, c := range calls {
 		if ctx.Err() != nil {
-			return stop, ctx.Err()
+			return ctx.Err()
 		}
 		inProgress := frames.NewFunctionCallInProgressFrame(c.ID, c.Name)
 		if err := b.PushFrame(ctx, inProgress, processor.Downstream); err != nil {
-			return stop, err
+			return err
 		}
 		result, isErr, stopTurn := b.invoke(ctx, c)
-		if stopTurn {
-			stop = true
-		}
 		resultFrame := frames.NewFunctionCallResultFrame(c.ID, c.Name, result, isErr)
+		resultFrame.RunLLM = !stopTurn
 		if err := b.PushFrame(ctx, resultFrame, processor.Downstream); err != nil {
-			return stop, err
+			return err
 		}
 	}
-	return stop, nil
+	return nil
 }
 
 // invoke dispatches a tool call to its handler, returning the result content,

--- a/service/llm/llm_tools_test.go
+++ b/service/llm/llm_tools_test.go
@@ -210,7 +210,11 @@ func TestToolContinuationSeesToolResult(t *testing.T) {
 	})
 
 	convo := frames.NewLLMContext("be brief")
-	convo.SetTools([]frames.Tool{{Name: "get_weather", Description: "weather", Parameters: json.RawMessage(`{"type":"object"}`)}})
+	convo.SetTools([]frames.Tool{{
+		Name:        "get_weather",
+		Description: "weather",
+		Parameters:  json.RawMessage(`{"type":"object"}`),
+	}})
 	convo.AddUserMessage("weather?")
 
 	pair := aggregators.New(convo)
@@ -218,7 +222,8 @@ func TestToolContinuationSeesToolResult(t *testing.T) {
 	done := make(chan struct{}, 1)
 	ends := 0
 	var mu sync.Mutex
-	task := pipeline.NewTask(pipeline.New(svc, newDelayResults(50*time.Millisecond), pair.Assistant()), pipeline.TaskParams{
+	pipe := pipeline.New(svc, newDelayResults(50*time.Millisecond), pair.Assistant())
+	task := pipeline.NewTask(pipe, pipeline.TaskParams{
 		OnReachedDownstream: func(f frames.Frame) {
 			if _, ok := f.(*frames.LLMFullResponseEndFrame); ok {
 				mu.Lock()

--- a/service/llm/llm_tools_test.go
+++ b/service/llm/llm_tools_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/gojargo/jargo/frames"
 	"github.com/gojargo/jargo/pipeline"
+	"github.com/gojargo/jargo/processor"
+	"github.com/gojargo/jargo/processor/aggregators"
 	"github.com/gojargo/jargo/service/llm"
 )
 
@@ -45,10 +47,23 @@ func TestBaseRunsToolLoop(t *testing.T) {
 		return "sunny, 20C", nil
 	})
 
+	convo := frames.NewLLMContext("be brief")
+	convo.SetTools([]frames.Tool{{
+		Name:        "get_weather",
+		Description: "weather",
+		Parameters:  json.RawMessage(`{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}`),
+	}})
+	convo.AddUserMessage("weather in Paris?")
+
+	// The assistant aggregator commits the tool turn and re-triggers generation,
+	// so the tool loop only completes end to end with it in the pipeline.
+	pair := aggregators.New(convo)
+
 	var mu sync.Mutex
 	var got []string
+	ends := 0
 	done := make(chan struct{}, 1)
-	task := pipeline.NewTask(pipeline.New(svc), pipeline.TaskParams{
+	task := pipeline.NewTask(pipeline.New(svc, pair.Assistant()), pipeline.TaskParams{
 		OnReachedDownstream: func(f frames.Frame) {
 			mu.Lock()
 			defer mu.Unlock()
@@ -65,9 +80,12 @@ func TestBaseRunsToolLoop(t *testing.T) {
 				got = append(got, "text:"+fr.Text)
 			case *frames.LLMFullResponseEndFrame:
 				got = append(got, "end")
-				select {
-				case done <- struct{}{}:
-				default:
+				ends++
+				if ends == 2 {
+					select {
+					case done <- struct{}{}:
+					default:
+					}
 				}
 			}
 		},
@@ -75,13 +93,6 @@ func TestBaseRunsToolLoop(t *testing.T) {
 	runDone := make(chan error, 1)
 	go func() { runDone <- task.Run(context.Background()) }()
 
-	convo := frames.NewLLMContext("be brief")
-	convo.SetTools([]frames.Tool{{
-		Name:        "get_weather",
-		Description: "weather",
-		Parameters:  json.RawMessage(`{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}`),
-	}})
-	convo.AddUserMessage("weather in Paris?")
 	task.QueueFrame(frames.NewLLMContextFrame(convo))
 
 	select {
@@ -99,6 +110,8 @@ func TestBaseRunsToolLoop(t *testing.T) {
 		"calls-started",
 		"in-progress:get_weather",
 		"result:sunny, 20C",
+		"end",
+		"start",
 		"text:It is sunny.",
 		"end",
 	}
@@ -113,9 +126,153 @@ func TestBaseRunsToolLoop(t *testing.T) {
 	if gotArgs != `{"location":"Paris"}` {
 		t.Fatalf("handler args = %q, want %q", gotArgs, `{"location":"Paris"}`)
 	}
-	// The LLM base must not write to the context; only the user message is there.
+	// The aggregator is the sole writer; the turn is recorded as user, assistant
+	// tool-use, tool result, assistant reply — with every tool call balanced.
 	msgs := convo.Messages()
-	if len(msgs) != 1 || msgs[0].Role != frames.RoleUser {
-		t.Fatalf("context messages = %+v, want only the user message", msgs)
+	if len(msgs) != 4 {
+		t.Fatalf("context messages = %+v, want 4", msgs)
 	}
+	if msgs[1].Role != frames.RoleAssistant || len(msgs[1].ToolCalls) != 1 {
+		t.Fatalf("message 1 = %+v, want an assistant tool-use", msgs[1])
+	}
+	if len(msgs[2].ToolResults) != 1 {
+		t.Fatalf("message 2 = %+v, want a tool-result message", msgs[2])
+	}
+	if !toolCallsBalanced(convo) {
+		t.Fatalf("context has an unbalanced tool call: %+v", msgs)
+	}
+}
+
+// balanceCheckGen records whether the context is balanced (every tool-use message
+// is followed by its tool-result message) at the moment the continuation runs.
+type balanceCheckGen struct {
+	mu              sync.Mutex
+	turn            int
+	sawContinuation bool
+	balanced        bool
+}
+
+func (g *balanceCheckGen) Generate(context.Context, *frames.LLMContext, llm.Emit) error { return nil }
+
+func (g *balanceCheckGen) GenerateWithTools(_ context.Context, convo *frames.LLMContext, sink llm.Sink) error {
+	g.mu.Lock()
+	turn := g.turn
+	g.turn++
+	g.mu.Unlock()
+	if turn == 0 {
+		return sink.Tool(frames.ToolCall{ID: "call_1", Name: "get_weather", Args: json.RawMessage(`{}`)})
+	}
+	g.mu.Lock()
+	g.sawContinuation = true
+	// The aggregator appends the tool result immediately before re-triggering, so
+	// a correct continuation always sees it as the last message. An internal loop
+	// that re-read the context early would see the tool_use still dangling.
+	g.balanced = endsWithToolResult(convo)
+	g.mu.Unlock()
+	return sink.Text("done")
+}
+
+// delayResults delays each tool-result frame before forwarding it, widening the
+// window between the model requesting a tool and the aggregator committing its
+// result. The continuation must still read a balanced context.
+type delayResults struct {
+	*processor.Base
+	d time.Duration
+}
+
+func newDelayResults(d time.Duration) *delayResults {
+	p := &delayResults{d: d}
+	p.Base = processor.New("DelayResults", p)
+	return p
+}
+
+func (p *delayResults) ProcessFrame(ctx context.Context, f frames.Frame, dir processor.Direction) error {
+	if err := p.Base.ProcessFrame(ctx, f, dir); err != nil {
+		return err
+	}
+	if _, ok := f.(*frames.FunctionCallResultFrame); ok {
+		select {
+		case <-time.After(p.d):
+		case <-ctx.Done():
+		}
+	}
+	return p.PushFrame(ctx, f, dir)
+}
+
+// TestToolContinuationSeesToolResult is the regression test for the tool
+// continuation race: even when result delivery lags, the continuation runs only
+// after the aggregator has written the result, so the context stays balanced.
+func TestToolContinuationSeesToolResult(t *testing.T) {
+	gen := &balanceCheckGen{}
+	svc := llm.New("FakeToolLLM", gen)
+	svc.RegisterFunction("get_weather", func(context.Context, json.RawMessage) (string, error) {
+		return "sunny", nil
+	})
+
+	convo := frames.NewLLMContext("be brief")
+	convo.SetTools([]frames.Tool{{Name: "get_weather", Description: "weather", Parameters: json.RawMessage(`{"type":"object"}`)}})
+	convo.AddUserMessage("weather?")
+
+	pair := aggregators.New(convo)
+
+	done := make(chan struct{}, 1)
+	ends := 0
+	var mu sync.Mutex
+	task := pipeline.NewTask(pipeline.New(svc, newDelayResults(50*time.Millisecond), pair.Assistant()), pipeline.TaskParams{
+		OnReachedDownstream: func(f frames.Frame) {
+			if _, ok := f.(*frames.LLMFullResponseEndFrame); ok {
+				mu.Lock()
+				ends++
+				if ends == 2 {
+					select {
+					case done <- struct{}{}:
+					default:
+					}
+				}
+				mu.Unlock()
+			}
+		},
+	})
+	runDone := make(chan error, 1)
+	go func() { runDone <- task.Run(context.Background()) }()
+
+	task.QueueFrame(frames.NewLLMContextFrame(convo))
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("tool loop did not complete")
+	}
+	task.StopWhenDone()
+	<-runDone
+
+	gen.mu.Lock()
+	defer gen.mu.Unlock()
+	if !gen.sawContinuation {
+		t.Fatal("continuation never ran")
+	}
+	if !gen.balanced {
+		t.Fatal("continuation read an unbalanced context (tool_use without tool_result)")
+	}
+}
+
+// toolCallsBalanced reports whether every assistant tool-use message is
+// immediately followed by a message carrying tool results.
+func toolCallsBalanced(convo *frames.LLMContext) bool {
+	msgs := convo.Messages()
+	for i, m := range msgs {
+		if len(m.ToolCalls) > 0 {
+			if i+1 >= len(msgs) || len(msgs[i+1].ToolResults) == 0 {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// endsWithToolResult reports whether the last context message carries tool
+// results — true once the aggregator has committed the turn's results.
+func endsWithToolResult(convo *frames.LLMContext) bool {
+	msgs := convo.Messages()
+	return len(msgs) > 0 && len(msgs[len(msgs)-1].ToolResults) > 0
 }


### PR DESCRIPTION
Closes #36.

The LLM tool loop re-generated from the shared context immediately after running tools, but the assistant aggregator (the sole context writer) commits the tool result asynchronously. The continuation could therefore send a `tool_use` with no matching `tool_result` → provider 400 (`messages.N: tool_use ids were found without tool_result blocks`).

The fix follows Pipecat: the LLM service no longer loops internally — it emits the function-call frames and returns; the assistant aggregator writes the results to the context and then re-triggers generation (an upstream `LLMContextFrame`), so the next inference always reads a balanced context. A `RunLLM` flag on the result frame carries `ErrStopTurn` through, so a stopped turn does not re-trigger.

- `service/llm`: `runWithTools` is single-shot; `runTools` sets `RunLLM`.
- `processor/aggregators`: the assistant aggregator re-triggers after `AddToolResults`.
- Tests: the tool-loop test now wires the aggregator; a new test proves the continuation reads the committed result even when result delivery lags (it fails on the pre-fix code).

Verified `go test`/`go vet` on the affected packages, and voice-server builds against this. Not yet exercised against a live provider over WebRTC — worth a smoke test before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)