### PR TITLE
fix(transport): drain output audio on EndFrame; add EndWorkerFrame

### DIFF
--- a/frames/system.go
+++ b/frames/system.go
@@ -46,6 +46,28 @@ func (f *CancelFrame) String() string {
 	return fmt.Sprintf("%s(reason: %v)", f.Name(), f.Reason)
 }
 
+// EndWorkerFrame requests a graceful shutdown of the pipeline worker (the Task).
+// A processor pushes it upstream; on reaching the Task it queues an EndFrame
+// downstream (see Task.StopWhenDone), so frames already queued are flushed and
+// the bot finishes speaking before the pipeline ends. It is a system frame, so
+// a processor with no Task handle can end the run and the signal reaches the
+// Task even while the pipeline is busy.
+type EndWorkerFrame struct {
+	BaseSystemFrame
+	// Reason is an optional reason for ending.
+	Reason any
+}
+
+// NewEndWorkerFrame builds an EndWorkerFrame.
+func NewEndWorkerFrame() *EndWorkerFrame {
+	return &EndWorkerFrame{BaseSystemFrame: NewBaseSystemFrame("EndWorkerFrame")}
+}
+
+// String implements fmt.Stringer.
+func (f *EndWorkerFrame) String() string {
+	return fmt.Sprintf("%s(reason: %v)", f.Name(), f.Reason)
+}
+
 // ErrorSource identifies the component that raised an error — in practice the
 // frame processor that produced it. It is declared here, rather than imported
 // from the processor package, so the frames package keeps no dependency on it;

--- a/pipeline/task.go
+++ b/pipeline/task.go
@@ -215,6 +215,11 @@ func (t *Task) sourcePush(_ context.Context, f frames.Frame, _ processor.Directi
 	if ef, ok := f.(*frames.ErrorFrame); ok && ef.Fatal {
 		t.Cancel()
 	}
+	// A processor asked to end gracefully: queue an EndFrame so frames already
+	// queued flush before the pipeline stops.
+	if _, ok := f.(*frames.EndWorkerFrame); ok {
+		t.StopWhenDone()
+	}
 	if t.params.OnReachedUpstream != nil {
 		t.params.OnReachedUpstream(f)
 	}

--- a/transport/output.go
+++ b/transport/output.go
@@ -40,6 +40,9 @@ type BaseOutput struct {
 	audioCtx    context.Context
 	audioCancel context.CancelFunc
 	audioWG     sync.WaitGroup
+	// drainWait, set under bufMu before a drain marker is queued, is closed by
+	// the audio loop once it has paced out everything ahead of the marker.
+	drainWait chan struct{}
 
 	// Bot-speaking detection: a BotStartedSpeakingFrame is emitted upstream when
 	// audio starts flowing and a BotStoppedSpeakingFrame after it drains, so the
@@ -82,6 +85,7 @@ func (bo *BaseOutput) ProcessFrame(ctx context.Context, f frames.Frame, dir proc
 		bo.startStreaming(ctx, fr)
 		return bo.PushFrame(ctx, f, dir)
 	case *frames.EndFrame:
+		bo.drainAudio(ctx)
 		bo.stopStreaming(ctx)
 		return bo.PushFrame(ctx, f, dir)
 	case *frames.CancelFrame:
@@ -166,6 +170,39 @@ func (bo *BaseOutput) stopStreaming(ctx context.Context) {
 	if cancel != nil {
 		cancel()
 		bo.audioWG.Wait()
+	}
+}
+
+// drainMarker is a sentinel queued on audioOut to detect when the audio loop has
+// paced out everything ahead of it. It is compared by identity and never played.
+//
+//nolint:gochecknoglobals // sentinel value
+var drainMarker = &frames.OutputAudioRawFrame{}
+
+// drainAudio blocks until the audio loop has paced out everything it has queued,
+// so a graceful EndFrame lets the bot finish speaking (a farewell, say) instead
+// of cutting off. A CancelFrame or an interruption skips it and stops at once. It
+// queues a marker behind the buffered audio and waits for the loop to reach it.
+func (bo *BaseOutput) drainAudio(ctx context.Context) {
+	bo.bufMu.Lock()
+	ac := bo.audioCtx
+	if ac == nil {
+		bo.bufMu.Unlock()
+		return
+	}
+	if len(bo.buffer) > 0 { // flush the sub-chunk tail so it plays too
+		sendAudio(ac, bo.audioOut, frames.NewOutputAudioRawFrame(bo.buffer, bo.sampleRate, bo.channels))
+		bo.buffer = nil
+	}
+	done := make(chan struct{})
+	bo.drainWait = done
+	bo.bufMu.Unlock()
+
+	sendAudio(ac, bo.audioOut, drainMarker)
+	select {
+	case <-done:
+	case <-ac.Done():
+	case <-ctx.Done():
 	}
 }
 
@@ -310,6 +347,16 @@ func (bo *BaseOutput) audioLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case chunk := <-bo.audioOut:
+			if chunk == drainMarker {
+				bo.bufMu.Lock()
+				w := bo.drainWait
+				bo.drainWait = nil
+				bo.bufMu.Unlock()
+				if w != nil {
+					close(w)
+				}
+				continue
+			}
 			audio := chunk.Audio
 			if bo.params.AudioOutMixer != nil {
 				if mixed, err := bo.params.AudioOutMixer.Mix(ctx, audio); err == nil {

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gojargo/jargo/frames"
 	"github.com/gojargo/jargo/pipeline"
+	"github.com/gojargo/jargo/processor"
 	"github.com/gojargo/jargo/transport"
 )
 
@@ -198,4 +199,90 @@ func TestBaseOutputChunksAudio(t *testing.T) {
 
 	task.StopWhenDone()
 	<-runDone
+}
+
+// pacedOutput records how many chunks it was asked to write, sleeping on each so
+// a drain must wait for the queued backlog to finish.
+type pacedOutput struct {
+	*transport.BaseOutput
+	writes atomic.Int32
+}
+
+func newPacedOutput(p transport.Params) *pacedOutput {
+	o := &pacedOutput{}
+	o.BaseOutput = transport.NewBaseOutput("PacedOutput", p, o)
+	return o
+}
+
+func (o *pacedOutput) WriteAudio(context.Context, []byte) error {
+	time.Sleep(3 * time.Millisecond) // stand in for real-time pacing
+	o.writes.Add(1)
+	return nil
+}
+
+// TestBaseOutputEndFrameDrainsAudio is the regression test for the farewell
+// cutoff: a graceful EndFrame must let the queued audio finish before the
+// pipeline stops, unlike a CancelFrame which stops at once.
+func TestBaseOutputEndFrameDrainsAudio(t *testing.T) {
+	params := transport.DefaultParams()
+	params.AudioOutSampleRate = 48000 // 1920-byte chunks
+
+	o := newPacedOutput(params)
+	task := pipeline.NewTask(pipeline.New(o), pipeline.TaskParams{})
+	runDone := make(chan error, 1)
+	go func() { runDone <- task.Run(context.Background()) }()
+
+	const chunks = 15
+	task.QueueFrame(frames.NewOutputAudioRawFrame(make([]byte, 1920*chunks), 48000, 1))
+	task.StopWhenDone() // EndFrame right behind the audio
+
+	select {
+	case <-runDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("pipeline did not end")
+	}
+	if got := o.writes.Load(); got != chunks {
+		t.Fatalf("wrote %d/%d chunks — EndFrame cut off queued audio", got, chunks)
+	}
+}
+
+// ender pushes an EndWorkerFrame upstream once the pipeline has started.
+type ender struct {
+	*processor.Base
+}
+
+func newEnder() *ender {
+	e := &ender{}
+	e.Base = processor.New("Ender", e)
+	return e
+}
+
+func (e *ender) ProcessFrame(ctx context.Context, f frames.Frame, dir processor.Direction) error {
+	if err := e.Base.ProcessFrame(ctx, f, dir); err != nil {
+		return err
+	}
+	if _, ok := f.(*frames.StartFrame); ok {
+		if err := e.PushFrame(ctx, f, dir); err != nil {
+			return err
+		}
+		return e.PushFrame(ctx, frames.NewEndWorkerFrame(), processor.Upstream)
+	}
+	return e.PushFrame(ctx, f, dir)
+}
+
+// TestEndWorkerFrameEndsTask checks a processor can end the run gracefully by
+// pushing an EndWorkerFrame upstream — the Task turns it into an EndFrame.
+func TestEndWorkerFrameEndsTask(t *testing.T) {
+	task := pipeline.NewTask(pipeline.New(newEnder()), pipeline.TaskParams{})
+	runDone := make(chan error, 1)
+	go func() { runDone <- task.Run(context.Background()) }()
+
+	select {
+	case err := <-runDone:
+		if err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("task did not end on EndWorkerFrame")
+	}
 }


### PR DESCRIPTION
Closes #40.

**Farewell cutoff.** `BaseOutput` handled `EndFrame` exactly like `CancelFrame` — `stopStreaming` cancels the audio loop immediately — so audio still queued (an `end_conversation` farewell) was dropped. Pipecat gets away with an in-order `EndFrame` because its output writes audio inline; jargo paces audio in a **separate goroutine**, so the `EndFrame` in `ProcessFrame` races ahead of playback. Fix: on `EndFrame`, `drainAudio` flushes the sub-chunk tail and queues a sentinel marker behind the buffered audio, waiting for the audio loop to pace it all out before `stopStreaming`. `CancelFrame` and interruptions stay immediate.

**EndWorkerFrame (Pipecat parity).** Added `frames.EndWorkerFrame` (a system frame). A processor pushes it upstream; the `Task` (`sourcePush`) converts it to `StopWhenDone()` → a downstream `EndFrame`, so a processor with no task handle can end the run gracefully — mirroring Pipecat, where `EndWorkerFrame` signals the worker and `EndFrame` performs the shutdown. (`StopWhenDone` itself is already a faithful port of Pipecat’s `PipelineWorker.stop_when_done()`.)

- `frames/system.go`: `EndWorkerFrame`
- `pipeline/task.go`: `sourcePush` handles it
- `transport/output.go`: `EndFrame` drains via a marker before stopping
- Tests: a paced output proves a 15-chunk backlog fully drains on `EndFrame` (fails 3/15 without the fix); a processor ends the task via `EndWorkerFrame`.

Verified `go test`/`go vet`/`golangci-lint` on the touched packages. Not yet exercised over a live WebRTC transport — worth a farewell smoke-test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)