### PR TITLE
test: raise library coverage to 58%, and fix a pipeline stall in the telephony transport

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,10 @@ sudo apt-get install -y libopus-dev   # for -tags libopus
 
 - `go build ./...` — build everything with the pure-Go / purego defaults.
 - `go test ./...` — run tests. Add `-race` as CI does.
+- `go test -coverprofile=coverage.out ./... && go tool cover -func=coverage.out`
+  — coverage. CI uploads the same profile to Codecov, which applies the
+  `ignore:` rules in `codecov.yml` (`examples/`, generated protobuf) — so the
+  raw local total reads roughly 13 points lower than the reported one.
 - `go build -tags libsoxr ./...` — opt into libsoxr resampling (SoX Resampler,
   highest quality; the default is the pure-Go `github.com/gojargo/go-resample`
   converter). Needs cgo.

--- a/audio/chain_test.go
+++ b/audio/chain_test.go
@@ -1,0 +1,165 @@
+package audio_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gojargo/jargo/audio"
+)
+
+// The failures the fake filters report.
+//
+//nolint:gochecknoglobals // sentinel errors
+var (
+	errBoom  = errors.New("boom")
+	errEarly = errors.New("early")
+)
+
+// fake is a Filter that records its lifecycle calls, tags the audio it sees, and
+// can be made to fail at any stage.
+type fake struct {
+	tag byte
+
+	started   int
+	stopped   int
+	filtered  int
+	startErr  error
+	stopErr   error
+	filterErr error
+}
+
+func (f *fake) Start(context.Context, int) error {
+	f.started++
+	return f.startErr
+}
+
+func (f *fake) Stop(context.Context) error {
+	f.stopped++
+	return f.stopErr
+}
+
+// Filter appends the filter's tag so the test can read the order filters ran in
+// straight off the output.
+func (f *fake) Filter(_ context.Context, pcm []byte) ([]byte, error) {
+	f.filtered++
+	if f.filterErr != nil {
+		return nil, f.filterErr
+	}
+	return append(append([]byte{}, pcm...), f.tag), nil
+}
+
+// TestChainAppliesInOrder checks filters run front to back, which matters
+// because denoising before gating is not the same as gating before denoising.
+func TestChainAppliesInOrder(t *testing.T) {
+	a, b, c := &fake{tag: 'a'}, &fake{tag: 'b'}, &fake{tag: 'c'}
+	chain := audio.NewChain(a, b, c)
+
+	out, err := chain.Filter(t.Context(), []byte("in:"))
+	if err != nil {
+		t.Fatalf("Filter: %v", err)
+	}
+	if string(out) != "in:abc" {
+		t.Errorf("output = %q, want the filters applied in order", out)
+	}
+}
+
+// TestChainEmpty checks a chain with no filters is a pass-through, so an app can
+// build one from an optional list without special-casing the empty case.
+func TestChainEmpty(t *testing.T) {
+	chain := audio.NewChain()
+
+	if err := chain.Start(t.Context(), 16000); err != nil {
+		t.Errorf("Start: %v", err)
+	}
+	out, err := chain.Filter(t.Context(), []byte("pcm"))
+	if err != nil {
+		t.Fatalf("Filter: %v", err)
+	}
+	if string(out) != "pcm" {
+		t.Errorf("output = %q, want the input unchanged", out)
+	}
+	if err := chain.Stop(t.Context()); err != nil {
+		t.Errorf("Stop: %v", err)
+	}
+}
+
+func TestChainStart(t *testing.T) {
+	t.Run("starts every filter", func(t *testing.T) {
+		a, b := &fake{}, &fake{}
+		if err := audio.NewChain(a, b).Start(t.Context(), 16000); err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+		if a.started != 1 || b.started != 1 {
+			t.Errorf("started a=%d b=%d, want 1 each", a.started, b.started)
+		}
+	})
+
+	t.Run("stops at the first failure", func(t *testing.T) {
+		a := &fake{startErr: errBoom}
+		b := &fake{}
+
+		err := audio.NewChain(a, b).Start(t.Context(), 16000)
+		if !errors.Is(err, errBoom) {
+			t.Fatalf("Start error = %v, want errBoom", err)
+		}
+		// A filter after a failed one must not be started; the chain is unusable.
+		if b.started != 0 {
+			t.Errorf("second filter started %d times, want 0", b.started)
+		}
+	})
+}
+
+// TestChainStopIsBestEffort checks every filter gets stopped even when an
+// earlier one fails, so a single bad filter cannot leak the others' resources —
+// and that the failure is still reported rather than masked by the successes
+// that follow it.
+func TestChainStopIsBestEffort(t *testing.T) {
+	a := &fake{stopErr: errBoom}
+	b := &fake{}
+
+	err := audio.NewChain(a, b).Stop(t.Context())
+	if !errors.Is(err, errBoom) {
+		t.Errorf("Stop error = %v, want errBoom; a later success must not mask it", err)
+	}
+	if a.stopped != 1 || b.stopped != 1 {
+		t.Errorf("stopped a=%d b=%d, want 1 each despite the failure", a.stopped, b.stopped)
+	}
+}
+
+// TestChainStopReportsLastFailure checks that when several filters fail, the
+// last failure is the one returned.
+func TestChainStopReportsLastFailure(t *testing.T) {
+	a := &fake{stopErr: errEarly}
+	b := &fake{stopErr: errBoom}
+
+	if err := audio.NewChain(a, b).Stop(t.Context()); !errors.Is(err, errBoom) {
+		t.Errorf("Stop error = %v, want the last failure", err)
+	}
+}
+
+// TestChainStopAllSucceed checks the happy path reports no error.
+func TestChainStopAllSucceed(t *testing.T) {
+	if err := audio.NewChain(&fake{}, &fake{}).Stop(t.Context()); err != nil {
+		t.Errorf("Stop error = %v, want nil", err)
+	}
+}
+
+// TestChainFilterShortCircuits checks a failing filter aborts the chain: passing
+// half-processed audio downstream would be worse than dropping the chunk.
+func TestChainFilterShortCircuits(t *testing.T) {
+	a := &fake{tag: 'a'}
+	b := &fake{filterErr: errBoom}
+	c := &fake{tag: 'c'}
+
+	out, err := audio.NewChain(a, b, c).Filter(t.Context(), []byte("in"))
+	if !errors.Is(err, errBoom) {
+		t.Fatalf("Filter error = %v, want errBoom", err)
+	}
+	if out != nil {
+		t.Errorf("output = %q, want nil on failure", out)
+	}
+	if c.filtered != 0 {
+		t.Errorf("the filter after the failure ran %d times, want 0", c.filtered)
+	}
+}

--- a/audio/mixer/mixer_test.go
+++ b/audio/mixer/mixer_test.go
@@ -1,0 +1,235 @@
+package mixer_test
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/gojargo/jargo/audio/mixer"
+)
+
+// pcm encodes samples as 16-bit little-endian mono PCM, the format the mixer
+// works in.
+func pcm(samples ...int16) []byte {
+	b := make([]byte, 2*len(samples))
+	for i, s := range samples {
+		binary.LittleEndian.PutUint16(b[2*i:], uint16(s))
+	}
+	return b
+}
+
+// samples decodes 16-bit little-endian PCM back to signed samples.
+func samples(b []byte) []int16 {
+	out := make([]int16, len(b)/2)
+	for i := range out {
+		out[i] = int16(binary.LittleEndian.Uint16(b[2*i:]))
+	}
+	return out
+}
+
+// mix runs one chunk through the mixer and returns the decoded result.
+func mix(t *testing.T, m *mixer.Loop, in []byte) []int16 {
+	t.Helper()
+	out, err := m.Mix(t.Context(), in)
+	if err != nil {
+		t.Fatalf("Mix: %v", err)
+	}
+	return samples(out)
+}
+
+func equal(got []int16, want ...int16) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestDisabledPassesThrough checks a mixer that is off does not touch the audio,
+// which is what lets an app add one and enable it later.
+func TestDisabledPassesThrough(t *testing.T) {
+	m := mixer.NewLoop(mixer.LoopConfig{Background: pcm(1000, 1000), Volume: 1})
+	if got := mix(t, m, pcm(100, 200)); !equal(got, 100, 200) {
+		t.Errorf("samples = %v, want the input unchanged", got)
+	}
+}
+
+// TestEmptyBackgroundPassesThrough checks a mixer with nothing to play is a
+// no-op rather than a source of silence.
+func TestEmptyBackgroundPassesThrough(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		bg   []byte
+	}{
+		{"nil background", nil},
+		{"single byte, less than one sample", []byte{0x01}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			m := mixer.NewLoop(mixer.LoopConfig{Background: tt.bg, Volume: 1, Enabled: true})
+			if got := mix(t, m, pcm(100, 200)); !equal(got, 100, 200) {
+				t.Errorf("samples = %v, want the input unchanged", got)
+			}
+		})
+	}
+}
+
+// TestMixesAtVolume checks the background is scaled before being added, since
+// the volume is what keeps it under the bot's speech rather than over it.
+func TestMixesAtVolume(t *testing.T) {
+	tests := []struct {
+		name   string
+		volume float64
+		want   []int16
+	}{
+		{"full volume adds the background as-is", 1, []int16{1100, 1200}},
+		{"half volume halves it", 0.5, []int16{600, 700}},
+		{"silent background leaves the foreground", 0.0001, []int16{100, 200}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := mixer.NewLoop(mixer.LoopConfig{
+				Background: pcm(1000, 1000),
+				Volume:     tt.volume,
+				Enabled:    true,
+			})
+			if got := mix(t, m, pcm(100, 200)); !equal(got, tt.want...) {
+				t.Errorf("samples = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDefaultVolume checks the documented 0.3 default applies when none is set,
+// so an app that forgets the field still gets a background it can talk over.
+func TestDefaultVolume(t *testing.T) {
+	m := mixer.NewLoop(mixer.LoopConfig{Background: pcm(1000), Enabled: true})
+	// 0 + 1000*0.3 = 300.
+	if got := mix(t, m, pcm(0)); !equal(got, 300) {
+		t.Errorf("samples = %v, want the 0.3 default volume applied", got)
+	}
+}
+
+// TestClipping checks the sum is clamped to the 16-bit range. Without it the sum
+// wraps and a loud passage turns into audible noise rather than distortion.
+func TestClipping(t *testing.T) {
+	tests := []struct {
+		name string
+		fg   int16
+		bg   int16
+		want int16
+	}{
+		{"positive overflow clamps to max", 32000, 32000, 32767},
+		{"negative overflow clamps to min", -32000, -32000, -32768},
+		{"exactly at the ceiling", 32767, 0, 32767},
+		{"exactly at the floor", -32768, 0, -32768},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := mixer.NewLoop(mixer.LoopConfig{Background: pcm(tt.bg), Volume: 1, Enabled: true})
+			if got := mix(t, m, pcm(tt.fg)); !equal(got, tt.want) {
+				t.Errorf("samples = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestLoopWraps checks the background restarts from the beginning when it runs
+// out, which is what makes it a loop rather than a one-shot.
+func TestLoopWraps(t *testing.T) {
+	m := mixer.NewLoop(mixer.LoopConfig{Background: pcm(10, 20), Volume: 1, Enabled: true})
+
+	// Six silent samples over a two-sample background: 10, 20, 10, 20, 10, 20.
+	got := mix(t, m, pcm(0, 0, 0, 0, 0, 0))
+	if !equal(got, 10, 20, 10, 20, 10, 20) {
+		t.Errorf("samples = %v, want the background looped", got)
+	}
+}
+
+// TestLoopPositionPersistsAcrossChunks checks the loop keeps its place between
+// calls; restarting each chunk would click at every audio-frame boundary.
+func TestLoopPositionPersistsAcrossChunks(t *testing.T) {
+	m := mixer.NewLoop(mixer.LoopConfig{Background: pcm(10, 20, 30, 40), Volume: 1, Enabled: true})
+
+	if got := mix(t, m, pcm(0, 0)); !equal(got, 10, 20) {
+		t.Fatalf("first chunk = %v, want the start of the background", got)
+	}
+	if got := mix(t, m, pcm(0, 0)); !equal(got, 30, 40) {
+		t.Errorf("second chunk = %v, want the background to continue, not restart", got)
+	}
+}
+
+// TestControl covers the runtime updates a MixerControlFrame carries.
+func TestControl(t *testing.T) {
+	t.Run("enable and disable", func(t *testing.T) {
+		m := mixer.NewLoop(mixer.LoopConfig{Background: pcm(1000), Volume: 1})
+
+		if got := mix(t, m, pcm(0)); !equal(got, 0) {
+			t.Fatalf("samples = %v, want silence while disabled", got)
+		}
+		if err := m.Control(t.Context(), map[string]any{"enabled": true}); err != nil {
+			t.Fatalf("Control: %v", err)
+		}
+		if got := mix(t, m, pcm(0)); !equal(got, 1000) {
+			t.Errorf("samples = %v, want the background once enabled", got)
+		}
+		if err := m.Control(t.Context(), map[string]any{"enabled": false}); err != nil {
+			t.Fatalf("Control: %v", err)
+		}
+		if got := mix(t, m, pcm(0)); !equal(got, 0) {
+			t.Errorf("samples = %v, want silence once disabled again", got)
+		}
+	})
+
+	t.Run("volume", func(t *testing.T) {
+		m := mixer.NewLoop(mixer.LoopConfig{Background: pcm(1000), Volume: 1, Enabled: true})
+		if err := m.Control(t.Context(), map[string]any{"volume": 0.5}); err != nil {
+			t.Fatalf("Control: %v", err)
+		}
+		if got := mix(t, m, pcm(0)); !equal(got, 500) {
+			t.Errorf("samples = %v, want the new volume applied", got)
+		}
+	})
+
+	t.Run("background swap restarts the loop", func(t *testing.T) {
+		m := mixer.NewLoop(mixer.LoopConfig{Background: pcm(10, 20), Volume: 1, Enabled: true})
+		mix(t, m, pcm(0)) // advance into the current track
+
+		if err := m.Control(t.Context(), map[string]any{"background": pcm(70, 80)}); err != nil {
+			t.Fatalf("Control: %v", err)
+		}
+		// A new track must start at its beginning, not at the old offset.
+		if got := mix(t, m, pcm(0, 0)); !equal(got, 70, 80) {
+			t.Errorf("samples = %v, want the new background from its start", got)
+		}
+	})
+
+	t.Run("unknown and mistyped settings are ignored", func(t *testing.T) {
+		m := mixer.NewLoop(mixer.LoopConfig{Background: pcm(1000), Volume: 1, Enabled: true})
+		err := m.Control(t.Context(), map[string]any{
+			"volume":  "loud", // wrong type
+			"enabled": 1,      // wrong type
+			"unknown": true,
+		})
+		if err != nil {
+			t.Fatalf("Control: %v", err)
+		}
+		if got := mix(t, m, pcm(0)); !equal(got, 1000) {
+			t.Errorf("samples = %v, want the settings unchanged", got)
+		}
+	})
+}
+
+// TestStartStop checks the lifecycle hooks are usable no-ops; the transport
+// calls them around every session.
+func TestStartStop(t *testing.T) {
+	m := mixer.NewLoop(mixer.LoopConfig{})
+	if err := m.Start(t.Context(), 16000); err != nil {
+		t.Errorf("Start: %v", err)
+	}
+	if err := m.Stop(t.Context()); err != nil {
+		t.Errorf("Stop: %v", err)
+	}
+}

--- a/audio/noise/gate/gate_test.go
+++ b/audio/noise/gate/gate_test.go
@@ -1,0 +1,128 @@
+package gate_test
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+
+	"github.com/gojargo/jargo/audio/noise/gate"
+)
+
+// tone builds n samples of constant amplitude, expressed as a fraction of full
+// scale. A constant signal has an RMS equal to its amplitude, which makes the
+// gate's threshold easy to reason about.
+func tone(amplitude float64, n int) []byte {
+	b := make([]byte, 2*n)
+	s := int16(amplitude * 32768)
+	for i := range n {
+		binary.LittleEndian.PutUint16(b[2*i:], uint16(s))
+	}
+	return b
+}
+
+// dbfs converts a dBFS threshold to the normalized amplitude it corresponds to.
+func dbfs(db float64) float64 { return math.Pow(10, db/20) }
+
+func isSilence(b []byte) bool {
+	for _, v := range b {
+		if v != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// filter starts the gate and runs one chunk through it.
+func filter(t *testing.T, g *gate.Gate, pcm []byte) []byte {
+	t.Helper()
+	if err := g.Start(t.Context(), 16000); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	out, err := g.Filter(t.Context(), pcm)
+	if err != nil {
+		t.Fatalf("Filter: %v", err)
+	}
+	return out
+}
+
+// TestGatesBelowThreshold is the core contract: quiet audio becomes silence,
+// louder audio passes through untouched.
+func TestGatesBelowThreshold(t *testing.T) {
+	const threshold = -40.0
+	tests := []struct {
+		name      string
+		amplitude float64
+		wantMuted bool
+	}{
+		{"well below the threshold", dbfs(-60), true},
+		{"just below the threshold", dbfs(-41), true},
+		{"just above the threshold", dbfs(-39), false},
+		{"well above the threshold", dbfs(-6), false},
+		{"digital silence", 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in := tone(tt.amplitude, 160)
+			out := filter(t, gate.New(threshold), in)
+
+			if got := isSilence(out); got != tt.wantMuted {
+				t.Errorf("silenced = %v, want %v", got, tt.wantMuted)
+			}
+			if len(out) != len(in) {
+				t.Errorf("length = %d, want %d; the gate must not resize the chunk", len(out), len(in))
+			}
+		})
+	}
+}
+
+// TestPassthroughIsUnchanged checks audio above the gate is returned byte for
+// byte, not re-encoded.
+func TestPassthroughIsUnchanged(t *testing.T) {
+	in := tone(dbfs(-10), 160)
+	out := filter(t, gate.New(-40), in)
+	for i := range in {
+		if out[i] != in[i] {
+			t.Fatalf("byte %d changed: got %d, want %d", i, out[i], in[i])
+		}
+	}
+}
+
+// TestDefaultThreshold checks the documented -50 dBFS default, by placing signals
+// either side of it.
+func TestDefaultThreshold(t *testing.T) {
+	if out := filter(t, gate.New(0), tone(dbfs(-55), 160)); !isSilence(out) {
+		t.Error("-55 dBFS should be gated at the -50 dBFS default")
+	}
+	if out := filter(t, gate.New(0), tone(dbfs(-45), 160)); isSilence(out) {
+		t.Error("-45 dBFS should pass at the -50 dBFS default")
+	}
+}
+
+// TestEmptyChunk checks a zero-length chunk is returned as-is rather than
+// dividing by zero when computing RMS.
+func TestEmptyChunk(t *testing.T) {
+	out := filter(t, gate.New(-40), []byte{})
+	if len(out) != 0 {
+		t.Errorf("length = %d, want 0", len(out))
+	}
+}
+
+// TestFilterBeforeStart pins the fail-open behavior: Start computes the gate
+// level, so a filter used before it lets everything through rather than
+// silencing the whole call.
+func TestFilterBeforeStart(t *testing.T) {
+	g := gate.New(-40)
+	out, err := g.Filter(t.Context(), tone(dbfs(-80), 160))
+	if err != nil {
+		t.Fatalf("Filter: %v", err)
+	}
+	if isSilence(out) {
+		t.Error("an unstarted gate should pass audio through, not silence it")
+	}
+}
+
+func TestStop(t *testing.T) {
+	if err := gate.New(-40).Stop(t.Context()); err != nil {
+		t.Errorf("Stop: %v", err)
+	}
+}

--- a/clock/clock_test.go
+++ b/clock/clock_test.go
@@ -1,0 +1,68 @@
+package clock_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gojargo/jargo/clock"
+)
+
+// TestTimeBeforeStart pins the documented contract: an unstarted clock reports
+// zero rather than the time since the epoch, so a frame timestamped before the
+// pipeline starts is recognizably unset instead of absurdly large.
+func TestTimeBeforeStart(t *testing.T) {
+	if got := clock.NewSystem().Time(); got != 0 {
+		t.Errorf("Time() = %v, want 0 before Start", got)
+	}
+}
+
+func TestTimeAdvancesAfterStart(t *testing.T) {
+	c := clock.NewSystem()
+	c.Start()
+
+	time.Sleep(10 * time.Millisecond)
+	first := c.Time()
+	if first <= 0 {
+		t.Fatalf("Time() = %v, want a positive elapsed time", first)
+	}
+
+	time.Sleep(10 * time.Millisecond)
+	if second := c.Time(); second <= first {
+		t.Errorf("Time() = %v, want it to advance past %v", second, first)
+	}
+}
+
+// TestRestartResetsReference checks a second Start moves the reference point, so
+// a reused clock measures the new session rather than accumulating.
+func TestRestartResetsReference(t *testing.T) {
+	c := clock.NewSystem()
+	c.Start()
+	time.Sleep(20 * time.Millisecond)
+
+	before := c.Time()
+	c.Start()
+	if after := c.Time(); after >= before {
+		t.Errorf("Time() = %v after restart, want less than %v", after, before)
+	}
+}
+
+// TestConcurrentUse checks the clock is safe to read while the pipeline starts
+// it, which is how it is used: one starter, many readers.
+func TestConcurrentUse(t *testing.T) {
+	c := clock.NewSystem()
+	var wg sync.WaitGroup
+
+	wg.Go(c.Start)
+	for range 8 {
+		wg.Go(func() {
+			for range 50 {
+				_ = c.Time()
+			}
+		})
+	}
+	wg.Wait()
+}
+
+// System must satisfy the Clock interface a pipeline depends on.
+var _ clock.Clock = (*clock.System)(nil)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,29 @@
+coverage:
+  # Below 50 is red, above 85 green, graded in between.
+  range: 50..85
+
+  status:
+    project:
+      default:
+        # Never regress against the parent commit by more than a rounding error.
+        target: auto
+        threshold: 1%
+    # New code should carry tests, but don't block on a strict patch target
+    # while the historical gaps are still being filled.
+    patch:
+      default:
+        target: 60%
+        threshold: 5%
+
+# Coverage should measure the library, not the demo programs or generated code.
+#
+# `examples/` is 24 runnable `main()` programs that exist as documentation; they
+# are compiled by CI but will never carry unit tests, and counting them hides
+# ~13 points of real library coverage. `rivapb` is protoc output.
+ignore:
+  - "examples/**"
+  - "**/internal/rivapb/**"
+
+comment:
+  layout: "reach, diff, flags, files"
+  require_changes: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -20,9 +20,12 @@ coverage:
 # `examples/` is 24 runnable `main()` programs that exist as documentation; they
 # are compiled by CI but will never carry unit tests, and counting them hides
 # ~13 points of real library coverage. `rivapb` is protoc output.
+# `internal/providertest` is test scaffolding: it runs on every provider test but
+# is credited to none of them, so it would read 0% forever.
 ignore:
   - "examples/**"
   - "**/internal/rivapb/**"
+  - "internal/providertest/**"
 
 comment:
   layout: "reach, diff, flags, files"

--- a/frames/catalog_test.go
+++ b/frames/catalog_test.go
@@ -1,0 +1,519 @@
+package frames_test
+
+// A catalog sweep over every constructible frame type.
+//
+// Frames are mostly declaration: a constructor that fills a few fields and a
+// String that renders them. Testing each one by hand would be dozens of
+// near-identical functions, so instead every frame is listed once here and the
+// invariants that hold for all of them are checked in one place: the name label,
+// the String prefix, and exactly one of the system/data/control categories.
+// Anything a specific frame does beyond that has its own test below or in
+// concrete_test.go.
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gojargo/jargo/frames"
+)
+
+// category is the frame class a type belongs to. Every frame belongs to exactly
+// one, which is what decides whether an interruption may drop it.
+type category int
+
+const (
+	system category = iota
+	data
+	control
+)
+
+func (c category) String() string {
+	switch c {
+	case system:
+		return "system"
+	case data:
+		return "data"
+	case control:
+		return "control"
+	}
+	return "unknown"
+}
+
+// catalogEntry is one frame type: how to build it, the label it should report,
+// and the class it belongs to.
+type catalogEntry struct {
+	label string
+	cat   category
+	build func() frames.Frame
+	// wantString, when set, must appear in the frame's String output — used for
+	// the frames whose String renders their payload.
+	wantString string
+	// uninterruptible marks frames that must survive a barge-in.
+	uninterruptible bool
+}
+
+// catalog lists every frame a caller can construct. Adding a frame type means
+// adding a line here.
+//
+//nolint:funlen // a flat catalog of every frame type; length is the point
+func catalog() []catalogEntry {
+	return []catalogEntry{
+		// System frames: priority delivery, unaffected by interruptions.
+		{
+			label: "StartFrame", cat: system,
+			build: func() frames.Frame { return frames.NewStartFrame() },
+		},
+		{
+			label: "CancelFrame", cat: system, wantString: "reason:",
+			build: func() frames.Frame { return frames.NewCancelFrame() },
+		},
+		{
+			label: "EndWorkerFrame", cat: system, wantString: "reason:",
+			build: func() frames.Frame { return frames.NewEndWorkerFrame() },
+		},
+		{
+			label: "ErrorFrame", cat: system, wantString: "boom",
+			build: func() frames.Frame { return frames.NewErrorFrame("boom") },
+		},
+		{
+			label: "InterruptionFrame", cat: system,
+			build: func() frames.Frame { return frames.NewInterruptionFrame() },
+		},
+		{
+			label: "UserStartedSpeakingFrame", cat: system,
+			build: func() frames.Frame { return frames.NewUserStartedSpeakingFrame() },
+		},
+		{
+			label: "UserStoppedSpeakingFrame", cat: system,
+			build: func() frames.Frame { return frames.NewUserStoppedSpeakingFrame() },
+		},
+		{
+			label: "BotStartedSpeakingFrame", cat: system,
+			build: func() frames.Frame { return frames.NewBotStartedSpeakingFrame() },
+		},
+		{
+			label: "BotStoppedSpeakingFrame", cat: system,
+			build: func() frames.Frame { return frames.NewBotStoppedSpeakingFrame() },
+		},
+		{
+			label: "UserSpeakingFrame", cat: system,
+			build: func() frames.Frame { return frames.NewUserSpeakingFrame() },
+		},
+		{
+			label: "BotSpeakingFrame", cat: system,
+			build: func() frames.Frame { return frames.NewBotSpeakingFrame() },
+		},
+		{
+			label: "UserMuteStartedFrame", cat: system,
+			build: func() frames.Frame { return frames.NewUserMuteStartedFrame() },
+		},
+		{
+			label: "UserMuteStoppedFrame", cat: system,
+			build: func() frames.Frame { return frames.NewUserMuteStoppedFrame() },
+		},
+		{
+			label: "VADUserStartedSpeakingFrame", cat: system, wantString: "start_secs: 1.500",
+			build: func() frames.Frame { return frames.NewVADUserStartedSpeakingFrame(1.5) },
+		},
+		{
+			label: "VADUserStoppedSpeakingFrame", cat: system, wantString: "stop_secs: 2.250",
+			build: func() frames.Frame { return frames.NewVADUserStoppedSpeakingFrame(2.25, "ts") },
+		},
+		{
+			label: "STTMetadataFrame", cat: system, wantString: "ttfs_p99: 300ms",
+			build: func() frames.Frame { return frames.NewSTTMetadataFrame(300 * time.Millisecond) },
+		},
+		{
+			label: "UserIdleTimeoutUpdateFrame", cat: system, wantString: "timeout: 5s",
+			build: func() frames.Frame { return frames.NewUserIdleTimeoutUpdateFrame(5 * time.Second) },
+		},
+		{
+			label: "SpeechControlParamsFrame", cat: system,
+			build: func() frames.Frame { return frames.NewSpeechControlParamsFrame(0.8, 200, 8) },
+		},
+		{
+			label: "ServiceMetadataFrame", cat: system, wantString: "service: stt-1",
+			build: func() frames.Frame { return frames.NewServiceMetadataFrame("stt-1") },
+		},
+		{
+			label: "LLMServiceMetadataFrame", cat: system, wantString: "service: llm-1",
+			build: func() frames.Frame { return frames.NewLLMServiceMetadataFrame("llm-1") },
+		},
+		{
+			label: "InputAudioRawFrame", cat: system, wantString: "sample_rate: 16000",
+			build: func() frames.Frame { return frames.NewInputAudioRawFrame(make([]byte, 4), 16000, 1) },
+		},
+		{
+			label: "InputDTMFFrame", cat: system, wantString: "button: 7",
+			build: func() frames.Frame { return frames.NewInputDTMFFrame(frames.KeypadSeven) },
+		},
+		{
+			label: "InputTransportMessageFrame", cat: system, wantString: "size: 3",
+			build: func() frames.Frame { return frames.NewInputTransportMessageFrame([]byte("abc")) },
+		},
+		{
+			label: "OutputTransportMessageFrame", cat: system,
+			build: func() frames.Frame { return frames.NewOutputTransportMessageFrame(map[string]any{"a": 1}) },
+		},
+		{
+			label: "MetricsFrame", cat: system, wantString: "processor: tts-1",
+			build: func() frames.Frame { return frames.NewMetricsFrame("tts-1") },
+		},
+
+		// Data frames: carried in order, dropped on interruption.
+		{
+			label: "TextFrame", cat: data, wantString: "hello",
+			build: func() frames.Frame { return frames.NewTextFrame("hello") },
+		},
+		{
+			label: "LLMTextFrame", cat: data, wantString: "hello",
+			build: func() frames.Frame { return frames.NewLLMTextFrame("hello") },
+		},
+		{
+			label: "TTSTextFrame", cat: data, wantString: "hello",
+			build: func() frames.Frame { return frames.NewTTSTextFrame("hello") },
+		},
+		{
+			label: "TTSSpeakFrame", cat: data, wantString: "hello",
+			build: func() frames.Frame { return frames.NewTTSSpeakFrame("hello") },
+		},
+		{
+			label: "TranscriptionFrame", cat: data, wantString: "hello",
+			build: func() frames.Frame { return frames.NewTranscriptionFrame("hello", "user-1", "ts") },
+		},
+		{
+			label: "InterimTranscriptionFrame", cat: data, wantString: "hello",
+			build: func() frames.Frame { return frames.NewInterimTranscriptionFrame("hello", "user-1", "ts") },
+		},
+		{
+			label: "OutputAudioRawFrame", cat: data, wantString: "sample_rate: 24000",
+			build: func() frames.Frame { return frames.NewOutputAudioRawFrame(make([]byte, 4), 24000, 1) },
+		},
+		{
+			label: "TTSAudioRawFrame", cat: data, wantString: "sample_rate: 24000",
+			build: func() frames.Frame { return frames.NewTTSAudioRawFrame(make([]byte, 4), 24000, 1) },
+		},
+		{
+			label: "LLMContextFrame", cat: data,
+			build: func() frames.Frame { return frames.NewLLMContextFrame(frames.NewLLMContext("be brief")) },
+		},
+		{
+			label: "LLMMarkerFrame", cat: data,
+			build: func() frames.Frame { return frames.NewLLMMarkerFrame("check") },
+		},
+		{
+			label: "LLMRunFrame", cat: data,
+			build: func() frames.Frame { return frames.NewLLMRunFrame() },
+		},
+
+		// Control frames: in order like data frames, but carrying instructions.
+		{
+			label: "EndFrame", cat: control, uninterruptible: true,
+			build: func() frames.Frame { return frames.NewEndFrame() },
+		},
+		{
+			label: "LLMFullResponseStartFrame", cat: control,
+			build: func() frames.Frame { return frames.NewLLMFullResponseStartFrame() },
+		},
+		{
+			label: "LLMFullResponseEndFrame", cat: control,
+			build: func() frames.Frame { return frames.NewLLMFullResponseEndFrame() },
+		},
+		{
+			label: "TTSStartedFrame", cat: control,
+			build: func() frames.Frame { return frames.NewTTSStartedFrame() },
+		},
+		{
+			label: "TTSStoppedFrame", cat: control,
+			build: func() frames.Frame { return frames.NewTTSStoppedFrame() },
+		},
+		{
+			label: "UserTurnInferenceCompletedFrame", cat: control,
+			build: func() frames.Frame { return frames.NewUserTurnInferenceCompletedFrame() },
+		},
+		{
+			label: "OutputDTMFFrame", cat: control, wantString: "button: 7",
+			build: func() frames.Frame { return frames.NewOutputDTMFFrame(frames.KeypadSeven) },
+		},
+		{
+			label: "MixerControlFrame", cat: control,
+			build: func() frames.Frame { return frames.NewMixerControlFrame(map[string]any{"volume": 0.5}) },
+		},
+		{
+			label: "LLMMessagesAppendFrame", cat: control,
+			build: func() frames.Frame {
+				return frames.NewLLMMessagesAppendFrame([]frames.Message{{Role: frames.RoleUser, Text: "hi"}})
+			},
+		},
+		{
+			label: "FunctionCallsStartedFrame", cat: control, wantString: "calls: 1",
+			build: func() frames.Frame {
+				return frames.NewFunctionCallsStartedFrame("", []frames.ToolCall{{ID: "a", Name: "get_weather"}})
+			},
+		},
+		{
+			label: "FunctionCallInProgressFrame", cat: control, wantString: "get_weather",
+			build: func() frames.Frame { return frames.NewFunctionCallInProgressFrame("a", "get_weather") },
+		},
+		{
+			label: "FunctionCallResultFrame", cat: control, wantString: "get_weather",
+			build: func() frames.Frame { return frames.NewFunctionCallResultFrame("a", "get_weather", "sunny", false) },
+		},
+		{
+			label: "FunctionCallCancelFrame", cat: control, wantString: "get_weather",
+			build: func() frames.Frame { return frames.NewFunctionCallCancelFrame("a", "get_weather") },
+		},
+		{
+			label: "AudioBufferStartRecordingFrame", cat: control, uninterruptible: true,
+			build: func() frames.Frame { return frames.NewAudioBufferStartRecordingFrame() },
+		},
+		{
+			label: "AudioBufferStopRecordingFrame", cat: control, uninterruptible: true,
+			build: func() frames.Frame { return frames.NewAudioBufferStopRecordingFrame() },
+		},
+	}
+}
+
+// TestCatalogInvariants checks the properties every frame must have, whatever it
+// carries.
+func TestCatalogInvariants(t *testing.T) {
+	for _, entry := range catalog() {
+		t.Run(entry.label, func(t *testing.T) {
+			f := entry.build()
+
+			if f.ID() == 0 {
+				t.Error("ID() = 0; every frame must get a nonzero id")
+			}
+			if got := f.Name(); !strings.HasPrefix(got, entry.label+"#") {
+				t.Errorf("Name() = %q, want the %q label", got, entry.label)
+			}
+			// Every String renders the name first, so a log line always
+			// identifies the frame before its payload.
+			if got := f.String(); !strings.HasPrefix(got, f.Name()) {
+				t.Errorf("String() = %q, want it to start with Name() %q", got, f.Name())
+			}
+			if entry.wantString != "" {
+				if got := f.String(); !strings.Contains(got, entry.wantString) {
+					t.Errorf("String() = %q, want it to contain %q", got, entry.wantString)
+				}
+			}
+			assertCategory(t, f, entry.cat)
+
+			if _, ok := f.(frames.Uninterruptible); ok != entry.uninterruptible {
+				t.Errorf("Uninterruptible = %v, want %v", ok, entry.uninterruptible)
+			}
+		})
+	}
+}
+
+// assertCategory checks a frame is in want and in neither of the other two.
+func assertCategory(t *testing.T, f frames.Frame, want category) {
+	t.Helper()
+	_, isSystem := f.(frames.SystemFrame)
+	_, isData := f.(frames.DataFrame)
+	_, isControl := f.(frames.ControlFrame)
+
+	got := map[category]bool{system: isSystem, data: isData, control: isControl}
+	for _, c := range []category{system, data, control} {
+		if got[c] != (c == want) {
+			t.Errorf("%s category = %v, want %v (frame should be %s)", c, got[c], c == want, want)
+		}
+	}
+}
+
+// TestCatalogIDsAreUnique checks the process-wide id source hands out a distinct
+// id per frame, which is what lets observers correlate frames across a pipeline.
+func TestCatalogIDsAreUnique(t *testing.T) {
+	seen := map[uint64]string{}
+	for _, entry := range catalog() {
+		f := entry.build()
+		if prev, dup := seen[f.ID()]; dup {
+			t.Errorf("%s reused id %d, already held by %s", entry.label, f.ID(), prev)
+		}
+		seen[f.ID()] = entry.label
+	}
+}
+
+func TestConstructorFields(t *testing.T) {
+	t.Run("DTMF", func(t *testing.T) {
+		if got := frames.NewInputDTMFFrame(frames.KeypadStar).Button; got != frames.KeypadStar {
+			t.Errorf("Button = %q, want *", got)
+		}
+		if got := frames.NewOutputDTMFFrame(frames.KeypadPound).Button; got != frames.KeypadPound {
+			t.Errorf("Button = %q, want #", got)
+		}
+	})
+
+	t.Run("function calls", func(t *testing.T) {
+		calls := []frames.ToolCall{{ID: "a", Name: "one"}, {ID: "b", Name: "two"}}
+		started := frames.NewFunctionCallsStartedFrame("thinking", calls)
+		if started.PreambleText != "thinking" || len(started.Calls) != 2 {
+			t.Errorf("started = %+v, want the preamble and both calls", started)
+		}
+
+		prog := frames.NewFunctionCallInProgressFrame("a", "one")
+		if prog.ToolCallID != "a" || prog.ToolName != "one" {
+			t.Errorf("in-progress = %+v", prog)
+		}
+
+		res := frames.NewFunctionCallResultFrame("a", "one", "done", false)
+		if res.ToolCallID != "a" || res.Result != "done" || res.IsError {
+			t.Errorf("result = %+v", res)
+		}
+		// Generation re-runs after a tool result unless a handler stops the turn.
+		if !res.RunLLM {
+			t.Error("RunLLM should default to true")
+		}
+
+		cancel := frames.NewFunctionCallCancelFrame("a", "one")
+		if cancel.ToolCallID != "a" || cancel.ToolName != "one" {
+			t.Errorf("cancel = %+v", cancel)
+		}
+	})
+
+	t.Run("speech control params", func(t *testing.T) {
+		f := frames.NewSpeechControlParamsFrame(0.8, 200, 8)
+		if f.StopSecs != 0.8 || f.PreSpeechMs != 200 || f.MaxDurationSecs != 8 {
+			t.Errorf("params = %+v", f)
+		}
+	})
+
+	t.Run("mixer settings", func(t *testing.T) {
+		f := frames.NewMixerControlFrame(map[string]any{"volume": 0.5})
+		if f.Settings["volume"] != 0.5 {
+			t.Errorf("Settings = %v", f.Settings)
+		}
+	})
+
+	t.Run("transport messages", func(t *testing.T) {
+		in := frames.NewInputTransportMessageFrame([]byte("payload"))
+		if string(in.Message) != "payload" {
+			t.Errorf("Message = %q", in.Message)
+		}
+		out := frames.NewOutputTransportMessageFrame("payload")
+		if out.Message != "payload" {
+			t.Errorf("Message = %v", out.Message)
+		}
+	})
+
+	t.Run("messages append", func(t *testing.T) {
+		msgs := []frames.Message{{Role: frames.RoleUser, Text: "hi"}}
+		if got := frames.NewLLMMessagesAppendFrame(msgs); len(got.Messages) != 1 {
+			t.Errorf("Messages = %v", got.Messages)
+		}
+	})
+
+	t.Run("LLM marker", func(t *testing.T) {
+		if got := frames.NewLLMMarkerFrame("check").Marker; got != "check" {
+			t.Errorf("Marker = %q", got)
+		}
+	})
+}
+
+// TestServiceMetadataInterface checks both metadata frames satisfy the interface
+// downstream processors assert on, rather than each carrying its own accessors.
+func TestServiceMetadataInterface(t *testing.T) {
+	stt := frames.NewSTTMetadataFrame(250 * time.Millisecond)
+	stt.ServiceName = "deepgram"
+	stt.UserTurns = frames.UserTurnExternal
+
+	llm := frames.NewLLMServiceMetadataFrame("openai-realtime")
+	llm.UserTurns = frames.UserTurnUnspecified
+
+	tests := []struct {
+		name      string
+		meta      frames.ServiceMetadata
+		wantName  string
+		wantTurns frames.UserTurnRecommendation
+	}{
+		{"STT", stt, "deepgram", frames.UserTurnExternal},
+		{"LLM", llm, "openai-realtime", frames.UserTurnUnspecified},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.meta.Service(); got != tt.wantName {
+				t.Errorf("Service() = %q, want %q", got, tt.wantName)
+			}
+			if got := tt.meta.RecommendedUserTurns(); got != tt.wantTurns {
+				t.Errorf("RecommendedUserTurns() = %v, want %v", got, tt.wantTurns)
+			}
+		})
+	}
+
+	if got := stt.TTFSP99Latency; got != 250*time.Millisecond {
+		t.Errorf("TTFSP99Latency = %v, want 250ms", got)
+	}
+}
+
+func TestUserTurnRecommendationString(t *testing.T) {
+	tests := []struct {
+		in   frames.UserTurnRecommendation
+		want string
+	}{
+		{frames.UserTurnExternal, "external"},
+		{frames.UserTurnUnspecified, "unspecified"},
+		{frames.UserTurnRecommendation(99), "unspecified"},
+	}
+	for _, tt := range tests {
+		if got := tt.in.String(); got != tt.want {
+			t.Errorf("String() = %q, want %q", got, tt.want)
+		}
+	}
+}
+
+// TestTTSTextFrameOriginal checks which text is recorded in the LLM context: the
+// raw text when the TTS rewrote it, otherwise the spoken text.
+func TestTTSTextFrameOriginal(t *testing.T) {
+	f := frames.NewTTSTextFrame("one hundred")
+	if got := f.Original(); got != "one hundred" {
+		t.Errorf("Original() = %q, want the spoken text when RawText is unset", got)
+	}
+	if !f.AppendToContext {
+		t.Error("AppendToContext should default to true")
+	}
+
+	f.RawText = "100"
+	if got := f.Original(); got != "100" {
+		t.Errorf("Original() = %q, want the raw text once set", got)
+	}
+	if got := f.String(); !strings.Contains(got, "raw: [100]") {
+		t.Errorf("String() = %q, want it to render RawText", got)
+	}
+}
+
+func TestTTSSpeakFrameDefaults(t *testing.T) {
+	f := frames.NewTTSSpeakFrame("welcome")
+	if f.Text != "welcome" {
+		t.Errorf("Text = %q", f.Text)
+	}
+	if !f.AppendToContext {
+		t.Error("AppendToContext should default to true")
+	}
+}
+
+// TestMetricsFrameString covers both renderings: with and without token usage.
+func TestMetricsFrameString(t *testing.T) {
+	f := frames.NewMetricsFrame("llm-1")
+	if got := f.String(); !strings.Contains(got, "processor: llm-1") || strings.Contains(got, "tokens") {
+		t.Errorf("String() = %q, want the processor only", got)
+	}
+
+	f.Tokens = &frames.LLMTokenUsage{PromptTokens: 12, CompletionTokens: 34}
+	if got := f.String(); !strings.Contains(got, "12 in / 34 out") {
+		t.Errorf("String() = %q, want the token counts", got)
+	}
+}
+
+// TestFramePTSRendering checks the presentation timestamp shows as "none" until
+// it is set, so an unset PTS is never confused with zero.
+func TestFramePTSRendering(t *testing.T) {
+	f := frames.NewInputAudioRawFrame(nil, 16000, 1)
+	if got := f.String(); !strings.Contains(got, "pts: none") {
+		t.Errorf("String() = %q, want an unset pts to render as none", got)
+	}
+	f.SetPTS(1234)
+	if got := f.String(); !strings.Contains(got, "pts: 1234") {
+		t.Errorf("String() = %q, want the pts value", got)
+	}
+}

--- a/frames/llm_context_test.go
+++ b/frames/llm_context_test.go
@@ -182,3 +182,128 @@ func TestSystemWithoutSummaryIsUnchanged(t *testing.T) {
 		t.Fatalf("System() = %q, want the base prompt verbatim before any summary", c.System())
 	}
 }
+
+// TestContextMutators covers the setters a mid-session reconfiguration uses:
+// swapping the system prompt, the toolset, and the transient recall block.
+func TestContextMutators(t *testing.T) {
+	c := frames.NewLLMContext("original")
+
+	c.SetSystem("replaced")
+	if got := c.System(); !strings.Contains(got, "replaced") {
+		t.Errorf("System() = %q, want the replacement prompt", got)
+	}
+	if strings.Contains(c.System(), "original") {
+		t.Error("System() still contains the original prompt")
+	}
+
+	tools := []frames.Tool{{Name: "get_weather", Description: "look up weather"}}
+	c.SetTools(tools)
+	got := c.Tools()
+	if len(got) != 1 || got[0].Name != "get_weather" {
+		t.Fatalf("Tools() = %+v, want the tool that was set", got)
+	}
+	// Tools returns a copy, so a caller cannot reach into the context.
+	got[0].Name = "mutated"
+	if c.Tools()[0].Name != "get_weather" {
+		t.Error("Tools() handed out the backing slice; a caller mutated the context")
+	}
+}
+
+// TestContextRecall checks retrieved memories are folded into the system prompt
+// and can be cleared, since a memory processor refreshes them every turn.
+func TestContextRecall(t *testing.T) {
+	c := frames.NewLLMContext("be brief")
+	if got := c.Recall(); got != "" {
+		t.Errorf("Recall() = %q, want empty before anything is recalled", got)
+	}
+
+	c.SetRecall("the user prefers window seats")
+	if got := c.Recall(); got != "the user prefers window seats" {
+		t.Errorf("Recall() = %q", got)
+	}
+	sys := c.System()
+	if !strings.Contains(sys, "be brief") || !strings.Contains(sys, "window seats") {
+		t.Errorf("System() = %q, want both the prompt and the recall", sys)
+	}
+
+	c.SetRecall("")
+	if strings.Contains(c.System(), "window seats") {
+		t.Error("clearing recall should drop it from the system prompt")
+	}
+}
+
+// TestReplaceLastAssistantText checks the aggregator can keep an in-progress
+// assistant turn in sync with the words actually spoken, and that it refuses to
+// touch anything else.
+func TestReplaceLastAssistantText(t *testing.T) {
+	t.Run("plain assistant message", func(t *testing.T) {
+		c := frames.NewLLMContext("")
+		c.AddUserMessage("hello")
+		c.AddAssistantMessage("full response")
+
+		if !c.ReplaceLastAssistantText("interrupted here") {
+			t.Fatal("want the replacement to apply")
+		}
+		msgs := c.Messages()
+		if got := msgs[len(msgs)-1].Text; got != "interrupted here" {
+			t.Errorf("text = %q, want the replacement", got)
+		}
+	})
+
+	t.Run("empty context", func(t *testing.T) {
+		if frames.NewLLMContext("").ReplaceLastAssistantText("x") {
+			t.Error("want false with no messages to replace")
+		}
+	})
+
+	t.Run("last message is the user's", func(t *testing.T) {
+		c := frames.NewLLMContext("")
+		c.AddAssistantMessage("earlier")
+		c.AddUserMessage("hello")
+		if c.ReplaceLastAssistantText("x") {
+			t.Error("want false when the last message is not the assistant's")
+		}
+	})
+
+	t.Run("assistant turn carrying tool calls", func(t *testing.T) {
+		c := frames.NewLLMContext("")
+		c.AddAssistantToolCalls("thinking", []frames.ToolCall{{ID: "a", Name: "one"}})
+		if c.ReplaceLastAssistantText("x") {
+			t.Error("want false for a tool-call turn; its text is not spoken output")
+		}
+	})
+}
+
+// TestEstimatedTokens checks the compaction trigger counts every part of the
+// context, not just the messages.
+func TestEstimatedTokens(t *testing.T) {
+	empty := frames.NewLLMContext("")
+	if got := empty.EstimatedTokens(); got != 0 {
+		t.Errorf("EstimatedTokens() = %d, want 0 for an empty context", got)
+	}
+
+	c := frames.NewLLMContext(strings.Repeat("a", 40)) // ~10 tokens
+	base := c.EstimatedTokens()
+	if base == 0 {
+		t.Fatal("the system prompt should count toward the estimate")
+	}
+
+	c.AddUserMessage(strings.Repeat("b", 40))
+	withMsg := c.EstimatedTokens()
+	if withMsg <= base {
+		t.Errorf("EstimatedTokens() = %d, want it to grow past %d once a message is added", withMsg, base)
+	}
+
+	c.SetRecall(strings.Repeat("c", 40))
+	if c.EstimatedTokens() <= withMsg {
+		t.Error("recall should count toward the estimate; it is sent to the model")
+	}
+
+	// Tool calls and results are part of what the model reads.
+	before := c.EstimatedTokens()
+	c.AddAssistantToolCalls("", []frames.ToolCall{{ID: "a", Name: "get_weather", Args: []byte(`{"city":"Paris"}`)}})
+	c.AddToolResults([]frames.ToolResult{{ID: "a", Name: "get_weather", Content: strings.Repeat("d", 40)}})
+	if c.EstimatedTokens() <= before {
+		t.Error("tool calls and results should count toward the estimate")
+	}
+}

--- a/internal/onnxrt/onnxrt_test.go
+++ b/internal/onnxrt/onnxrt_test.go
@@ -1,0 +1,249 @@
+package onnxrt
+
+// These tests deliberately stop at the native boundary.
+//
+// Most of this package is FFI: purego symbol lookup into libonnxruntime, unsafe
+// pointer arithmetic, and a cgo alternative behind a build tag. Exercising that
+// needs the shared library present, which CI does not guarantee — a test that
+// skips when it is missing buys nothing, and one that fakes the library tests
+// the fake. So what is covered here is the logic that is genuinely independent
+// of the runtime: locating the library, the session wrapper's lifecycle, and the
+// tensor constructors. Loading and running a real model is exercised for real by
+// the vad and turn packages when a runtime is installed.
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// errBackend is the failure the fake backend session reports.
+//
+//nolint:gochecknoglobals // sentinel error
+var errBackend = errors.New("backend failed")
+
+// fakeSession stands in for a loaded model so the Session wrapper's locking and
+// lifecycle can be tested without a runtime.
+type fakeSession struct {
+	mu       sync.Mutex
+	runs     int
+	closes   int
+	runErr   error
+	closeErr error
+	outputs  []Tensor
+}
+
+func (f *fakeSession) run(inputs []Tensor) ([]Tensor, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.runs++
+	if f.runErr != nil {
+		return nil, f.runErr
+	}
+	return append(f.outputs, inputs...), nil
+}
+
+func (f *fakeSession) close() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.closes++
+	return f.closeErr
+}
+
+func (f *fakeSession) counts() (runs, closes int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.runs, f.closes
+}
+
+// TestLibraryPathFromEnv checks an operator-supplied path is used when it points
+// at a real file, and rejected with a useful error when it does not — a typo in
+// JARGO_ONNXRUNTIME_LIB must not silently fall back to the default name and load
+// some other runtime.
+func TestLibraryPathFromEnv(t *testing.T) {
+	t.Run("existing file is used", func(t *testing.T) {
+		lib := filepath.Join(t.TempDir(), "libonnxruntime.so")
+		if err := os.WriteFile(lib, []byte("not really a library"), 0o600); err != nil {
+			t.Fatalf("writing the fake library: %v", err)
+		}
+		t.Setenv(LibPathEnv, lib)
+
+		got, err := libraryPath()
+		if err != nil {
+			t.Fatalf("libraryPath: %v", err)
+		}
+		if got != lib {
+			t.Errorf("libraryPath() = %q, want %q", got, lib)
+		}
+	})
+
+	t.Run("missing file is an error", func(t *testing.T) {
+		missing := filepath.Join(t.TempDir(), "nope.so")
+		t.Setenv(LibPathEnv, missing)
+
+		got, err := libraryPath()
+		if err == nil {
+			t.Fatalf("libraryPath() = %q, want an error for a nonexistent path", got)
+		}
+		// The message must name the variable and the path, or an operator
+		// cannot tell which of the two is wrong.
+		if msg := err.Error(); !strings.Contains(msg, LibPathEnv) || !strings.Contains(msg, missing) {
+			t.Errorf("error = %q, want it to name %s and the path", msg, LibPathEnv)
+		}
+	})
+}
+
+// TestLibraryPathDefault checks the platform's conventional library name is used
+// when nothing is configured, so a system-installed runtime is found on the
+// loader's default search path.
+func TestLibraryPathDefault(t *testing.T) {
+	t.Setenv(LibPathEnv, "")
+
+	got, err := libraryPath()
+	if err != nil {
+		t.Fatalf("libraryPath: %v", err)
+	}
+
+	want := map[string]string{
+		"windows": "onnxruntime.dll",
+		"darwin":  "libonnxruntime.dylib",
+	}[runtime.GOOS]
+	if want == "" {
+		want = "libonnxruntime.so"
+	}
+	if got != want {
+		t.Errorf("libraryPath() = %q, want %q on %s", got, want, runtime.GOOS)
+	}
+	if filepath.IsAbs(got) {
+		t.Errorf("libraryPath() = %q, want a bare name so the loader searches its default paths", got)
+	}
+}
+
+// TestSessionRun checks the wrapper passes inputs through and returns the
+// backend's outputs and errors unchanged.
+func TestSessionRun(t *testing.T) {
+	t.Run("delegates to the backend", func(t *testing.T) {
+		fake := &fakeSession{outputs: []Tensor{Float32([]int64{1}, []float32{0.5})}}
+		s := &Session{b: fake}
+
+		out, err := s.Run([]Tensor{Int64([]int64{1}, []int64{7})})
+		if err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		if len(out) != 2 {
+			t.Fatalf("outputs = %d, want the backend's output plus the echoed input", len(out))
+		}
+		if runs, _ := fake.counts(); runs != 1 {
+			t.Errorf("backend runs = %d, want 1", runs)
+		}
+	})
+
+	t.Run("propagates backend errors", func(t *testing.T) {
+		s := &Session{b: &fakeSession{runErr: errBackend}}
+		if _, err := s.Run(nil); !errors.Is(err, errBackend) {
+			t.Errorf("Run error = %v, want errBackend", err)
+		}
+	})
+
+	t.Run("after close", func(t *testing.T) {
+		s := &Session{b: &fakeSession{}}
+		if err := s.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+		if _, err := s.Run(nil); !errors.Is(err, errClosed) {
+			t.Errorf("Run error = %v, want errClosed", err)
+		}
+	})
+}
+
+// TestSessionClose checks closing is idempotent and releases the backend exactly
+// once — a second native close would be a double free.
+func TestSessionClose(t *testing.T) {
+	fake := &fakeSession{}
+	s := &Session{b: fake}
+
+	if err := s.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Errorf("second Close: %v, want nil", err)
+	}
+	if _, closes := fake.counts(); closes != 1 {
+		t.Errorf("backend closes = %d, want exactly 1", closes)
+	}
+}
+
+// TestSessionCloseError checks a backend failure on close is reported, while the
+// session still drops its reference so it cannot be closed twice.
+func TestSessionCloseError(t *testing.T) {
+	fake := &fakeSession{closeErr: errBackend}
+	s := &Session{b: fake}
+
+	if err := s.Close(); !errors.Is(err, errBackend) {
+		t.Errorf("Close error = %v, want errBackend", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Errorf("second Close = %v, want nil", err)
+	}
+	if _, closes := fake.counts(); closes != 1 {
+		t.Errorf("backend closes = %d, want exactly 1", closes)
+	}
+}
+
+// TestSessionConcurrentRun checks Run serializes on the session, which is the
+// contract that lets one analyzer share a session across goroutines.
+func TestSessionConcurrentRun(t *testing.T) {
+	fake := &fakeSession{}
+	s := &Session{b: fake}
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Go(func() {
+			for range 25 {
+				if _, err := s.Run(nil); err != nil {
+					t.Errorf("Run: %v", err)
+					return
+				}
+			}
+		})
+	}
+	wg.Wait()
+
+	if runs, _ := fake.counts(); runs != 200 {
+		t.Errorf("backend runs = %d, want 200", runs)
+	}
+}
+
+// TestTensorConstructors checks each constructor fills exactly its own element
+// type, since the backends switch on which field is non-nil.
+func TestTensorConstructors(t *testing.T) {
+	f := Float32([]int64{1, 2}, []float32{1, 2})
+	if f.I64 != nil {
+		t.Error("Float32 should leave I64 nil")
+	}
+	if len(f.F32) != 2 || len(f.Shape) != 2 {
+		t.Errorf("Float32 = %+v", f)
+	}
+
+	i := Int64([]int64{2}, []int64{3, 4})
+	if i.F32 != nil {
+		t.Error("Int64 should leave F32 nil")
+	}
+	if len(i.I64) != 2 || len(i.Shape) != 1 {
+		t.Errorf("Int64 = %+v", i)
+	}
+}
+
+// TestBackendName checks the build reports which binding was compiled in, which
+// is what a bug report needs to be actionable.
+func TestBackendName(t *testing.T) {
+	switch got := Backend(); got {
+	case "cgo (yalue)", "purego":
+	default:
+		t.Errorf("Backend() = %q, want one of the two known bindings", got)
+	}
+}

--- a/internal/providertest/providertest.go
+++ b/internal/providertest/providertest.go
@@ -1,0 +1,141 @@
+// Package providertest holds shared assertions for provider packages whose
+// behavior is fully determined by the base service they delegate to.
+//
+// A dozen providers are nothing but a name, a base URL and a default model
+// handed to openai.NewCompatLLM. Testing each one separately would be a dozen
+// copies of the same httptest server; testing them all from one package would
+// leave every one of them reporting zero coverage, because Go credits a package
+// only for the tests that live in it. So the assertions live here and each
+// provider keeps a small test that calls them.
+package providertest
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gojargo/jargo/frames"
+	"github.com/gojargo/jargo/provider/openai"
+)
+
+// CompatLLMBuilder builds an OpenAI-compatible LLM service from a config, i.e.
+// the NewLLM function every compatible provider exposes.
+type CompatLLMBuilder func(openai.LLMConfig) *openai.LLMService
+
+// CompatLLM checks that build produces a usable OpenAI-compatible LLM service:
+// it is named wantName, defaults to wantModel, lets a caller override the model,
+// addresses the chat-completions endpoint under the configured base URL, sends a
+// Bearer key, and streams the response back.
+//
+// It deliberately does not assert the provider's own default base URL — that
+// constant names a host the tests must never contact. What it does assert is
+// that a configured base URL is honored, which is the half a provider can get
+// wrong without anyone noticing.
+func CompatLLM(t *testing.T, wantName, wantModel string, build CompatLLMBuilder) {
+	t.Helper()
+
+	t.Run("defaults", func(t *testing.T) {
+		svc := build(openai.LLMConfig{APIKey: "test-key"})
+		if svc == nil {
+			t.Fatal("NewLLM returned nil")
+		}
+		// processor.New appends a "#<id>" instance counter, so only the label
+		// the provider chose is stable across runs.
+		if got := svc.Name(); !strings.HasPrefix(got, wantName+"#") {
+			t.Errorf("Name() = %q, want the %q label", got, wantName)
+		}
+	})
+
+	t.Run("streams a completion", func(t *testing.T) {
+		req := captureRequest(t, build, openai.LLMConfig{APIKey: "test-key"}, "Hello there")
+
+		if req.path != "/chat/completions" {
+			t.Errorf("path = %q, want /chat/completions", req.path)
+		}
+		if got := req.header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("Authorization = %q, want the Bearer key", got)
+		}
+		if got := req.header.Get("Content-Type"); got != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", got)
+		}
+		if req.body.Model != wantModel {
+			t.Errorf("model = %q, want the provider default %q", req.body.Model, wantModel)
+		}
+		if !req.body.Stream {
+			t.Error("stream = false, want true")
+		}
+		if req.reply != "Hello there" {
+			t.Errorf("streamed reply = %q, want %q", req.reply, "Hello there")
+		}
+	})
+
+	t.Run("model override", func(t *testing.T) {
+		req := captureRequest(t, build, openai.LLMConfig{APIKey: "k", Model: "override-model"}, "hi")
+		if req.body.Model != "override-model" {
+			t.Errorf("model = %q, want the override", req.body.Model)
+		}
+	})
+}
+
+// capturedRequest is what the fake endpoint saw, plus what the service streamed
+// back to its caller.
+type capturedRequest struct {
+	path   string
+	header http.Header
+	body   struct {
+		Model    string `json:"model"`
+		Stream   bool   `json:"stream"`
+		Messages []struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		} `json:"messages"`
+	}
+	reply string
+}
+
+// captureRequest points the service at a fake chat-completions endpoint, runs one
+// generation, and reports what crossed the wire in both directions.
+func captureRequest(t *testing.T, build CompatLLMBuilder, cfg openai.LLMConfig, reply string) capturedRequest {
+	t.Helper()
+
+	var got capturedRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got.path = r.URL.Path
+		got.header = r.Header.Clone()
+		if err := json.NewDecoder(r.Body).Decode(&got.body); err != nil {
+			t.Errorf("decoding request body: %v", err)
+		}
+
+		chunk, err := json.Marshal(map[string]any{
+			"choices": []map[string]any{{"delta": map[string]string{"content": reply}}},
+		})
+		if err != nil {
+			t.Errorf("encoding response chunk: %v", err)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: " + string(chunk) + "\n\ndata: [DONE]\n\n"))
+	}))
+	defer srv.Close()
+
+	cfg.BaseURL = srv.URL
+	svc := build(cfg)
+	if svc == nil {
+		t.Fatal("NewLLM returned nil")
+	}
+
+	convo := frames.NewLLMContext("be brief")
+	convo.AddUserMessage("hello")
+
+	var out strings.Builder
+	if err := svc.Generate(t.Context(), convo, func(text string) error {
+		out.WriteString(text)
+		return nil
+	}); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	got.reply = out.String()
+	return got
+}

--- a/internal/providertest/providertest.go
+++ b/internal/providertest/providertest.go
@@ -139,3 +139,60 @@ func captureRequest(t *testing.T, build CompatLLMBuilder, cfg openai.LLMConfig, 
 	got.reply = out.String()
 	return got
 }
+
+// Validator is the shape every provider config shares: a Validate that reports
+// whether the config is usable before anything tries to connect with it.
+type Validator interface {
+	Validate() error
+}
+
+// ConfigCase is one configuration and whether Validate should accept it.
+type ConfigCase struct {
+	// Name describes what the case exercises, e.g. "missing API key".
+	Name string
+	// Cfg is the configuration under test.
+	Cfg Validator
+	// Valid is whether Validate should return nil.
+	Valid bool
+}
+
+// Configs runs each case through Validate. It is the check that a provider's
+// `validate` struct tags actually say what the field comments claim: a required
+// credential must be rejected when absent, and an otherwise-empty config must be
+// accepted when the provider documents defaults for everything else.
+func Configs(t *testing.T, cases []ConfigCase) {
+	t.Helper()
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			err := c.Cfg.Validate()
+			if c.Valid && err != nil {
+				t.Errorf("Validate() = %v, want nil", err)
+			}
+			if !c.Valid && err == nil {
+				t.Error("Validate() = nil, want an error")
+			}
+		})
+	}
+}
+
+// namer is satisfied by every service, which embeds a processor.
+type namer interface {
+	Name() string
+}
+
+// Service checks a constructor returned a usable service carrying wantLabel.
+// Constructors take no error return, so a misconfigured provider surfaces only
+// as a nil service or a mislabeled processor in the logs and traces.
+func Service(t *testing.T, wantLabel string, svc namer) {
+	t.Helper()
+	// A nil interface means the constructor returned nothing; a non-nil
+	// interface holding a nil pointer would panic on Name, which is also a
+	// failure worth catching here rather than in a pipeline.
+	if svc == nil {
+		t.Fatalf("constructor returned nil, want a %s service", wantLabel)
+	}
+	// processor.New appends a "#<id>" instance counter.
+	if got := svc.Name(); !strings.HasPrefix(got, wantLabel+"#") {
+		t.Errorf("Name() = %q, want the %q label", got, wantLabel)
+	}
+}

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -1,0 +1,102 @@
+package query_test
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/gojargo/jargo/internal/query"
+)
+
+// TestSetBoolTrue covers the "on unless told otherwise" setter: a nil pointer
+// means the caller did not configure the field, and the parameter is still sent
+// as true because that is the provider default these fields describe.
+func TestSetBoolTrue(t *testing.T) {
+	tests := []struct {
+		name string
+		v    *bool
+		want string
+	}{
+		{"nil defaults to true", nil, "true"},
+		{"explicit true", new(true), "true"},
+		{"explicit false", new(false), "false"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := url.Values{}
+			query.SetBoolTrue(q, "punctuate", tt.v)
+			if got := q.Get("punctuate"); got != tt.want {
+				t.Errorf("punctuate = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestOptionalSettersOmitUnset checks the whole point of these helpers: an unset
+// field must not appear in the query at all, so the provider applies its own
+// default rather than receiving a zero value.
+func TestOptionalSettersOmitUnset(t *testing.T) {
+	q := url.Values{}
+	query.SetBoolOpt(q, "b", nil)
+	query.SetIntOpt(q, "i", nil)
+	query.SetFloatOpt(q, "f", nil)
+	query.SetStrOpt(q, "s", "")
+
+	if len(q) != 0 {
+		t.Errorf("query = %v, want every unset field omitted", q)
+	}
+}
+
+func TestOptionalSettersFormatting(t *testing.T) {
+	tests := []struct {
+		name string
+		set  func(url.Values)
+		key  string
+		want string
+	}{
+		{"bool true", func(q url.Values) { query.SetBoolOpt(q, "b", new(true)) }, "b", "true"},
+		{"bool false", func(q url.Values) { query.SetBoolOpt(q, "b", new(false)) }, "b", "false"},
+		{"int", func(q url.Values) { query.SetIntOpt(q, "i", new(42)) }, "i", "42"},
+		// A zero value is still sent once the caller has set it explicitly.
+		{"int zero", func(q url.Values) { query.SetIntOpt(q, "i", new(0)) }, "i", "0"},
+		{"negative int", func(q url.Values) { query.SetIntOpt(q, "i", new(-5)) }, "i", "-5"},
+		{"float", func(q url.Values) { query.SetFloatOpt(q, "f", new(0.75)) }, "f", "0.75"},
+		// 'g' with -1 precision keeps the shortest exact representation rather
+		// than padding to a fixed number of decimals.
+		{"float whole number", func(q url.Values) { query.SetFloatOpt(q, "f", new(2.0)) }, "f", "2"},
+		{"string", func(q url.Values) { query.SetStrOpt(q, "s", "en-US") }, "s", "en-US"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := url.Values{}
+			tt.set(q)
+			if got := q.Get(tt.key); got != tt.want {
+				t.Errorf("%s = %q, want %q", tt.key, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestAddAll checks repeated parameters are preserved rather than collapsed,
+// which is how providers take lists such as keyword boosts.
+func TestAddAll(t *testing.T) {
+	q := url.Values{}
+	query.AddAll(q, "keywords", []string{"jargo", "pipeline", "jargo"})
+
+	got := q["keywords"]
+	want := []string{"jargo", "pipeline", "jargo"}
+	if len(got) != len(want) {
+		t.Fatalf("keywords = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("keywords[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+
+	// An empty list adds nothing rather than an empty parameter.
+	q2 := url.Values{}
+	query.AddAll(q2, "keywords", nil)
+	if len(q2) != 0 {
+		t.Errorf("query = %v, want an empty list to add nothing", q2)
+	}
+}

--- a/internal/tagscan/tagscan_test.go
+++ b/internal/tagscan/tagscan_test.go
@@ -1,0 +1,196 @@
+package tagscan_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gojargo/jargo/internal/tagscan"
+)
+
+// tagEvent is one tag the scanner reported.
+type tagEvent struct {
+	tag   string
+	value string
+}
+
+// feedAll pushes each chunk through the scanner and returns the emitted text
+// (including whatever Flush releases) plus the tags seen, in order.
+func feedAll(s *tagscan.Scanner, chunks ...string) (string, []tagEvent) {
+	var out strings.Builder
+	var tags []tagEvent
+	for _, c := range chunks {
+		out.WriteString(s.Feed(c, func(tag, value string) {
+			tags = append(tags, tagEvent{tag, value})
+		}))
+	}
+	out.WriteString(s.Flush())
+	return out.String(), tags
+}
+
+func TestFeedExtractsTags(t *testing.T) {
+	tests := []struct {
+		name     string
+		chunks   []string
+		wantText string
+		wantTags []tagEvent
+	}{
+		{
+			name:     "no tags passes through",
+			chunks:   []string{"hello there"},
+			wantText: "hello there",
+		},
+		{
+			name:     "single tag is extracted and stripped",
+			chunks:   []string{"press <dtmf>1</dtmf> now"},
+			wantText: "press  now",
+			wantTags: []tagEvent{{"dtmf", "1"}},
+		},
+		{
+			name:     "several tags in one chunk, in order",
+			chunks:   []string{"<dtmf>1</dtmf>then<dtmf>2</dtmf>"},
+			wantText: "then",
+			wantTags: []tagEvent{{"dtmf", "1"}, {"dtmf", "2"}},
+		},
+		{
+			name:     "empty tag value",
+			chunks:   []string{"a<dtmf></dtmf>b"},
+			wantText: "ab",
+			wantTags: []tagEvent{{"dtmf", ""}},
+		},
+		{
+			name:     "unknown tag is left in the text",
+			chunks:   []string{"say <bold>hi</bold>"},
+			wantText: "say <bold>hi</bold>",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			text, tags := feedAll(tagscan.New("dtmf"), tt.chunks...)
+			if text != tt.wantText {
+				t.Errorf("text = %q, want %q", text, tt.wantText)
+			}
+			assertTags(t, tags, tt.wantTags)
+		})
+	}
+}
+
+// TestFeedAcrossChunks is the reason this package exists: a streamed LLM
+// response splits tags at arbitrary token boundaries, and a tag must still be
+// recognized once its pieces arrive.
+func TestFeedAcrossChunks(t *testing.T) {
+	tests := []struct {
+		name     string
+		chunks   []string
+		wantText string
+		wantTags []tagEvent
+	}{
+		{
+			name:     "split mid-tag",
+			chunks:   []string{"press <dt", "mf>1</dtm", "f> now"},
+			wantText: "press  now",
+			wantTags: []tagEvent{{"dtmf", "1"}},
+		},
+		{
+			name:     "split one character at a time",
+			chunks:   strings.Split("go <dtmf>5</dtmf> on", ""),
+			wantText: "go  on",
+			wantTags: []tagEvent{{"dtmf", "5"}},
+		},
+		{
+			name:     "value split across chunks",
+			chunks:   []string{"<voicemail>ye", "s</voicemail>"},
+			wantText: "",
+			wantTags: []tagEvent{{"voicemail", "yes"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			text, tags := feedAll(tagscan.New("dtmf", "voicemail"), tt.chunks...)
+			if text != tt.wantText {
+				t.Errorf("text = %q, want %q", text, tt.wantText)
+			}
+			assertTags(t, tags, tt.wantTags)
+		})
+	}
+}
+
+// TestFeedHoldsBackPartialTag checks text is withheld from the moment a '<'
+// appears, so half a tag is never spoken aloud while the rest is still in
+// flight.
+func TestFeedHoldsBackPartialTag(t *testing.T) {
+	s := tagscan.New("dtmf")
+
+	if got := s.Feed("press <dt", noTags); got != "press " {
+		t.Errorf("Feed = %q, want only the text before the partial tag", got)
+	}
+	// Still incomplete: nothing more may be emitted.
+	if got := s.Feed("mf>9</dt", noTags); got != "" {
+		t.Errorf("Feed = %q, want nothing while the tag is incomplete", got)
+	}
+
+	var seen []tagEvent
+	got := s.Feed("mf> done", func(tag, value string) { seen = append(seen, tagEvent{tag, value}) })
+	if got != " done" {
+		t.Errorf("Feed = %q, want the text after the completed tag", got)
+	}
+	assertTags(t, seen, []tagEvent{{"dtmf", "9"}})
+}
+
+// TestFlushReleasesIncompleteTag checks that when a response ends mid-tag the
+// held-back text is released rather than silently dropped.
+func TestFlushReleasesIncompleteTag(t *testing.T) {
+	s := tagscan.New("dtmf")
+
+	if got := s.Feed("almost <dtm", noTags); got != "almost " {
+		t.Errorf("Feed = %q", got)
+	}
+	if got := s.Flush(); got != "<dtm" {
+		t.Errorf("Flush = %q, want the held-back partial tag", got)
+	}
+	// Flush empties the buffer, so a second call yields nothing.
+	if got := s.Flush(); got != "" {
+		t.Errorf("second Flush = %q, want empty", got)
+	}
+}
+
+// TestScannerReusableAcrossResponses checks a flushed scanner starts clean, so
+// one response cannot leak a partial tag into the next.
+func TestScannerReusableAcrossResponses(t *testing.T) {
+	s := tagscan.New("dtmf")
+	s.Feed("leftover <dt", noTags)
+	s.Flush()
+
+	text, tags := feedAll(s, "<dtmf>3</dtmf>ok")
+	if text != "ok" {
+		t.Errorf("text = %q, want %q", text, "ok")
+	}
+	assertTags(t, tags, []tagEvent{{"dtmf", "3"}})
+}
+
+// TestMultipleTagNames checks a scanner built for several names matches each of
+// them, which is how the voicemail detector distinguishes its verdicts.
+func TestMultipleTagNames(t *testing.T) {
+	text, tags := feedAll(
+		tagscan.New("voicemail", "human", "conversation"),
+		"<human></human>", "hi there", "<voicemail></voicemail>",
+	)
+	if text != "hi there" {
+		t.Errorf("text = %q", text)
+	}
+	assertTags(t, tags, []tagEvent{{"human", ""}, {"voicemail", ""}})
+}
+
+// noTags is the callback for cases that expect no tag to fire.
+func noTags(string, string) {}
+
+func assertTags(t *testing.T, got, want []tagEvent) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("tags = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("tag %d = %v, want %v", i, got[i], want[i])
+		}
+	}
+}

--- a/processor/langchain/langchain_test.go
+++ b/processor/langchain/langchain_test.go
@@ -1,0 +1,275 @@
+package langchain_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gojargo/jargo/frames"
+	"github.com/gojargo/jargo/pipeline"
+	"github.com/gojargo/jargo/processor/langchain"
+)
+
+// errChain is the failure the fake chains report.
+//
+//nolint:gochecknoglobals // sentinel error
+var errChain = errors.New("chain failed")
+
+// recorder captures the frames a chain's output produces, in order.
+type recorder struct {
+	mu     sync.Mutex
+	names  []string
+	text   strings.Builder
+	errMsg string
+}
+
+func (r *recorder) down(f frames.Frame) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	switch fr := f.(type) {
+	case *frames.LLMFullResponseStartFrame:
+		r.names = append(r.names, "start")
+	case *frames.LLMTextFrame:
+		r.names = append(r.names, "text")
+		r.text.WriteString(fr.Text)
+	case *frames.LLMFullResponseEndFrame:
+		r.names = append(r.names, "end")
+	}
+}
+
+func (r *recorder) up(f frames.Frame) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if ef, ok := f.(*frames.ErrorFrame); ok {
+		r.errMsg = ef.Error
+	}
+}
+
+func (r *recorder) snapshot() ([]string, string, string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.names...), r.text.String(), r.errMsg
+}
+
+// runChain drives the given frames through a langchain processor and returns
+// what came out.
+func runChain(t *testing.T, chain langchain.Chain, in ...frames.Frame) *recorder {
+	t.Helper()
+	rec := &recorder{}
+	p := langchain.New(chain)
+	task := pipeline.NewTask(pipeline.New(p), pipeline.TaskParams{
+		OnReachedDownstream: rec.down,
+		OnReachedUpstream:   rec.up,
+	})
+	done := make(chan error, 1)
+	go func() { done <- task.Run(context.Background()) }()
+
+	task.QueueFrames(in)
+	task.StopWhenDone()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("pipeline did not finish")
+	}
+	return rec
+}
+
+// contextWith builds an LLM context frame carrying the given user message.
+func contextWith(text string) *frames.LLMContextFrame {
+	c := frames.NewLLMContext("be brief")
+	c.AddUserMessage(text)
+	return frames.NewLLMContextFrame(c)
+}
+
+// echo is a chain that streams its input back one word at a time.
+func echo(_ context.Context, input string, emit func(string) error) error {
+	for w := range strings.FieldsSeq(input) {
+		if err := emit(w); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// TestBracketsChainOutput is the contract that lets a chain stand in for an LLM:
+// the streamed tokens must be wrapped in the response start/end frames the
+// assistant aggregator and TTS expect.
+func TestBracketsChainOutput(t *testing.T) {
+	rec := runChain(t, echo, contextWith("hello there world"))
+
+	names, text, _ := rec.snapshot()
+	want := []string{"start", "text", "text", "text", "end"}
+	if !equalStrings(names, want) {
+		t.Errorf("frames = %v, want %v", names, want)
+	}
+	if text != "hellothereworld" {
+		t.Errorf("streamed text = %q, want the tokens in order", text)
+	}
+}
+
+// TestPassesInputToChain checks the chain receives the latest user message.
+func TestPassesInputToChain(t *testing.T) {
+	got := make(chan string, 1)
+	capture := func(_ context.Context, input string, _ func(string) error) error {
+		got <- input
+		return nil
+	}
+	runChain(t, capture, contextWith("  book me a table  "))
+
+	select {
+	case in := <-got:
+		// The text is trimmed before the chain sees it.
+		if in != "book me a table" {
+			t.Errorf("chain input = %q, want the trimmed user message", in)
+		}
+	default:
+		t.Fatal("the chain was never invoked")
+	}
+}
+
+// TestUsesLatestUserMessage checks the most recent user turn wins, not the first.
+func TestUsesLatestUserMessage(t *testing.T) {
+	c := frames.NewLLMContext("")
+	c.AddUserMessage("first question")
+	c.AddAssistantMessage("an answer")
+	c.AddUserMessage("second question")
+
+	got := make(chan string, 1)
+	capture := func(_ context.Context, input string, _ func(string) error) error {
+		got <- input
+		return nil
+	}
+	runChain(t, capture, frames.NewLLMContextFrame(c))
+
+	if in := <-got; in != "second question" {
+		t.Errorf("chain input = %q, want the most recent user message", in)
+	}
+}
+
+// TestSkipsToolResultTurns checks a tool-result message — stored under the user
+// role but not something a person said — is not fed to the chain as input.
+func TestSkipsToolResultTurns(t *testing.T) {
+	c := frames.NewLLMContext("")
+	c.AddUserMessage("weather in Paris?")
+	c.AddAssistantToolCalls("", []frames.ToolCall{{ID: "a", Name: "get_weather"}})
+	c.AddToolResults([]frames.ToolResult{{ID: "a", Name: "get_weather", Content: "sunny"}})
+
+	got := make(chan string, 1)
+	capture := func(_ context.Context, input string, _ func(string) error) error {
+		got <- input
+		return nil
+	}
+	runChain(t, capture, frames.NewLLMContextFrame(c))
+
+	if in := <-got; in != "weather in Paris?" {
+		t.Errorf("chain input = %q, want the real user question, not the tool result", in)
+	}
+}
+
+// TestNoUserMessageForwardsFrame checks a context with nothing to answer is
+// passed along untouched rather than invoking the chain with empty input.
+func TestNoUserMessageForwardsFrame(t *testing.T) {
+	called := false
+	chain := func(context.Context, string, func(string) error) error {
+		called = true
+		return nil
+	}
+
+	c := frames.NewLLMContext("be brief")
+	c.AddAssistantMessage("hello")
+	rec := runChain(t, chain, frames.NewLLMContextFrame(c))
+
+	if called {
+		t.Error("the chain must not run without a user message")
+	}
+	if names, _, _ := rec.snapshot(); len(names) != 0 {
+		t.Errorf("frames = %v, want no LLM response frames", names)
+	}
+}
+
+// TestEmptyTokensSkipped checks the chain can emit empty strings without
+// producing empty text frames downstream.
+func TestEmptyTokensSkipped(t *testing.T) {
+	chain := func(_ context.Context, _ string, emit func(string) error) error {
+		for _, tok := range []string{"a", "", "b", ""} {
+			if err := emit(tok); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	rec := runChain(t, chain, contextWith("go"))
+
+	names, text, _ := rec.snapshot()
+	want := []string{"start", "text", "text", "end"}
+	if !equalStrings(names, want) {
+		t.Errorf("frames = %v, want %v; empty tokens should not become frames", names, want)
+	}
+	if text != "ab" {
+		t.Errorf("streamed text = %q, want %q", text, "ab")
+	}
+}
+
+// TestChainErrorIsReported checks a failing chain surfaces as a pipeline error —
+// and that the response is still closed, so downstream stages are not left
+// waiting for an end frame that never comes.
+func TestChainErrorIsReported(t *testing.T) {
+	chain := func(_ context.Context, _ string, emit func(string) error) error {
+		if err := emit("partial"); err != nil {
+			return err
+		}
+		return errChain
+	}
+	rec := runChain(t, chain, contextWith("go"))
+
+	names, _, errMsg := rec.snapshot()
+	if errMsg == "" {
+		t.Error("a chain failure should be reported upstream as an error frame")
+	}
+	if len(names) == 0 || names[len(names)-1] != "end" {
+		t.Errorf("frames = %v, want the response closed with an end frame", names)
+	}
+}
+
+// TestOtherFramesPassThrough checks frames that are not LLM contexts are
+// forwarded untouched.
+func TestOtherFramesPassThrough(t *testing.T) {
+	seen := make(chan struct{}, 1)
+	p := langchain.New(echo)
+	task := pipeline.NewTask(pipeline.New(p), pipeline.TaskParams{
+		OnReachedDownstream: func(f frames.Frame) {
+			if _, ok := f.(*frames.TTSSpeakFrame); ok {
+				select {
+				case seen <- struct{}{}:
+				default:
+				}
+			}
+		},
+	})
+	done := make(chan error, 1)
+	go func() { done <- task.Run(context.Background()) }()
+
+	task.QueueFrame(frames.NewTTSSpeakFrame("hello"))
+	select {
+	case <-seen:
+	case <-time.After(5 * time.Second):
+		t.Fatal("an unrelated frame was not forwarded")
+	}
+	task.StopWhenDone()
+	<-done
+}
+
+func equalStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/processor/turns/strategies_internal_test.go
+++ b/processor/turns/strategies_internal_test.go
@@ -1,0 +1,1011 @@
+package turns
+
+// Unit tests for the individual start, stop and mute strategies.
+//
+// These are in-package because a strategy only signals through the unexported
+// strategyEnv the controller attaches; driving them from turns_test would mean
+// standing up a whole pipeline to observe a switch statement. The pipeline-level
+// behavior is covered by turns_test.go — this file covers the decision logic.
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gojargo/jargo/frames"
+	"github.com/gojargo/jargo/processor"
+)
+
+// spy records everything a strategy signals through its environment.
+type spy struct {
+	mu sync.Mutex
+
+	started    []UserTurnStartedParams
+	stopped    []UserTurnStoppedParams
+	resets     int
+	inferences int
+	pushed     []processor.Direction
+	broadcast  []frames.Frame
+}
+
+func newSpy() *spy { return &spy{} }
+
+func (s *spy) env() strategyEnv {
+	return strategyEnv{
+		mu:                 &s.mu,
+		started:            func(p UserTurnStartedParams) { s.started = append(s.started, p) },
+		stopped:            func(p UserTurnStoppedParams) { s.stopped = append(s.stopped, p) },
+		resetAggregation:   func() { s.resets++ },
+		inferenceTriggered: func() { s.inferences++ },
+		push:               func(_ frames.Frame, d processor.Direction) { s.pushed = append(s.pushed, d) },
+		broadcast:          func(f frames.Frame) { s.broadcast = append(s.broadcast, f) },
+	}
+}
+
+// send drives one frame through a start strategy the way the controller does:
+// under the shared mutex.
+func (s *spy) send(str StartStrategy, f frames.Frame) ProcessFrameResult {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return str.Process(f)
+}
+
+// sendStop is send for stop strategies.
+func (s *spy) sendStop(str StopStrategy, f frames.Frame) ProcessFrameResult {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return str.Process(f)
+}
+
+// starts returns how many turn-starts have been signaled so far.
+func (s *spy) starts() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.started)
+}
+
+// stops returns how many turn-ends have been signaled so far.
+func (s *spy) stops() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.stopped)
+}
+
+// attachStart wires a start strategy to a fresh spy.
+func attachStart(str StartStrategy) *spy {
+	s := newSpy()
+	str.attach(s.env())
+	return s
+}
+
+// attachStop wires a stop strategy to a fresh spy.
+func attachStop(str StopStrategy) *spy {
+	s := newSpy()
+	str.attach(s.env())
+	return s
+}
+
+func transcript(text string) *frames.TranscriptionFrame {
+	return frames.NewTranscriptionFrame(text, "user", "")
+}
+
+func interim(text string) *frames.InterimTranscriptionFrame {
+	return frames.NewInterimTranscriptionFrame(text, "user", "")
+}
+
+// eventually polls cond until it holds or the deadline passes. Strategies arm
+// real timers, so the wake-phrase and external-stop timeouts have to be awaited
+// rather than asserted synchronously.
+func eventually(t *testing.T, cond func() bool, within time.Duration, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("condition never held: %s", msg)
+}
+
+func TestVADStart(t *testing.T) {
+	s := NewVADStart()
+	spy := attachStart(s)
+
+	if got := spy.send(s, transcript("hello")); got != Continue {
+		t.Errorf("Process(transcript) = %v, want Continue", got)
+	}
+	if spy.starts() != 0 {
+		t.Error("a transcript must not open a VAD-gated turn")
+	}
+
+	if got := spy.send(s, frames.NewVADUserStartedSpeakingFrame(0)); got != Stop {
+		t.Errorf("Process(vad start) = %v, want Stop", got)
+	}
+	if spy.starts() != 1 {
+		t.Fatalf("starts = %d, want 1", spy.starts())
+	}
+	got := spy.started[0]
+	if !got.EnableInterruptions || !got.EnableUserSpeakingFrames {
+		t.Errorf("params = %+v, want both enabled", got)
+	}
+}
+
+func TestTranscriptionStart(t *testing.T) {
+	tests := []struct {
+		name       string
+		useInterim *bool
+		frame      frames.Frame
+		wantStart  bool
+	}{
+		{"final transcript", nil, transcript("hi"), true},
+		{"interim by default", nil, interim("hi"), true},
+		{"interim disabled", new(false), interim("hi"), false},
+		{"interim enabled", new(true), interim("hi"), true},
+		{"unrelated frame", nil, frames.NewBotSpeakingFrame(), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewTranscriptionStart(TranscriptionStartConfig{UseInterim: tt.useInterim})
+			spy := attachStart(s)
+
+			got := spy.send(s, tt.frame)
+			if started := spy.starts() == 1; started != tt.wantStart {
+				t.Errorf("started = %v, want %v", started, tt.wantStart)
+			}
+			want := Continue
+			if tt.wantStart {
+				want = Stop
+			}
+			if got != want {
+				t.Errorf("Process = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+// TestMinWordsStartThreshold covers the barge-in gate: one word is enough while
+// the bot is silent, but MinWords are required to interrupt it.
+func TestMinWordsStartThreshold(t *testing.T) {
+	tests := []struct {
+		name        string
+		botSpeaking bool
+		text        string
+		wantStart   bool
+	}{
+		{"bot silent, one word", false, "hey", true},
+		{"bot silent, empty", false, "", false},
+		{"bot speaking, too few", true, "uh huh", false},
+		{"bot speaking, enough", true, "wait stop for a second", true},
+		{"bot speaking, exactly enough", true, "one two three", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewMinWordsStart(MinWordsStartConfig{MinWords: 3})
+			spy := attachStart(s)
+
+			if tt.botSpeaking {
+				spy.send(s, frames.NewBotStartedSpeakingFrame())
+			}
+			got := spy.send(s, transcript(tt.text))
+
+			if started := spy.starts() == 1; started != tt.wantStart {
+				t.Errorf("started = %v, want %v", started, tt.wantStart)
+			}
+			if tt.wantStart {
+				if got != Stop {
+					t.Errorf("Process = %v, want Stop", got)
+				}
+			} else {
+				if got != Continue {
+					t.Errorf("Process = %v, want Continue", got)
+				}
+				// Speech below the bar is dropped so it can't pollute the context.
+				if spy.resets != 1 {
+					t.Errorf("resetAggregation calls = %d, want 1", spy.resets)
+				}
+			}
+		})
+	}
+}
+
+// TestMinWordsStartBotStopsSpeaking checks the threshold drops back to one word
+// once the bot falls silent.
+func TestMinWordsStartBotStopsSpeaking(t *testing.T) {
+	s := NewMinWordsStart(MinWordsStartConfig{MinWords: 5})
+	spy := attachStart(s)
+
+	spy.send(s, frames.NewBotStartedSpeakingFrame())
+	spy.send(s, transcript("no"))
+	if spy.starts() != 0 {
+		t.Fatal("one word must not interrupt a speaking bot with MinWords=5")
+	}
+
+	spy.send(s, frames.NewBotStoppedSpeakingFrame())
+	spy.send(s, transcript("no"))
+	if spy.starts() != 1 {
+		t.Errorf("starts = %d, want 1 once the bot is silent", spy.starts())
+	}
+}
+
+func TestMinWordsStartInterim(t *testing.T) {
+	t.Run("counted by default", func(t *testing.T) {
+		s := NewMinWordsStart(MinWordsStartConfig{MinWords: 2})
+		spy := attachStart(s)
+		if got := spy.send(s, interim("hello")); got != Stop {
+			t.Errorf("Process(interim) = %v, want Stop", got)
+		}
+		if spy.starts() != 1 {
+			t.Error("interim transcript should open the turn by default")
+		}
+	})
+
+	t.Run("ignored when disabled", func(t *testing.T) {
+		s := NewMinWordsStart(MinWordsStartConfig{MinWords: 2, UseInterim: new(false)})
+		spy := attachStart(s)
+		if got := spy.send(s, interim("hello")); got != Continue {
+			t.Errorf("Process(interim) = %v, want Continue", got)
+		}
+		if spy.starts() != 0 || spy.resets != 0 {
+			t.Error("a disabled interim must be ignored entirely, not reset")
+		}
+	})
+}
+
+// TestWakePhraseStartGates is the core wake-phrase contract: asleep it blocks the
+// rest of the start chain, the phrase wakes it, and it stays awake afterwards.
+func TestWakePhraseStartGates(t *testing.T) {
+	s := NewWakePhraseStart(WakePhraseStartConfig{Phrases: []string{"hey jargo"}, Timeout: time.Minute})
+	spy := attachStart(s)
+	defer s.Cleanup()
+
+	if got := spy.send(s, transcript("what is the weather")); got != Stop {
+		t.Errorf("asleep: Process = %v, want Stop (blocks the chain)", got)
+	}
+	if spy.starts() != 0 {
+		t.Fatal("non-wake speech must not open a turn")
+	}
+	if spy.resets != 1 {
+		t.Errorf("pre-wake speech should be dropped: resets = %d, want 1", spy.resets)
+	}
+
+	if got := spy.send(s, transcript("ok Hey   Jargo please")); got != Stop {
+		t.Errorf("waking: Process = %v, want Stop", got)
+	}
+	if spy.starts() != 1 {
+		t.Fatalf("the wake phrase should open a turn: starts = %d", spy.starts())
+	}
+
+	// Awake, the strategy defers to the rest of the chain.
+	if got := spy.send(s, transcript("and the traffic")); got != Continue {
+		t.Errorf("awake: Process = %v, want Continue", got)
+	}
+	if got := spy.send(s, frames.NewUserSpeakingFrame()); got != Continue {
+		t.Errorf("awake: Process(user speaking) = %v, want Continue", got)
+	}
+	if spy.starts() != 1 {
+		t.Errorf("awake speech must not re-trigger a start: starts = %d", spy.starts())
+	}
+}
+
+// TestWakePhraseStartMatchesAcrossTranscripts checks the accumulator: a phrase
+// split over two transcripts still matches.
+func TestWakePhraseStartMatchesAcrossTranscripts(t *testing.T) {
+	s := NewWakePhraseStart(WakePhraseStartConfig{Phrases: []string{"hey jargo"}, Timeout: time.Minute})
+	spy := attachStart(s)
+	defer s.Cleanup()
+
+	spy.send(s, transcript("hey"))
+	if spy.starts() != 0 {
+		t.Fatal("half a phrase must not wake the session")
+	}
+	spy.send(s, transcript("jargo are you there"))
+	if spy.starts() != 1 {
+		t.Errorf("phrase split across transcripts should match: starts = %d", spy.starts())
+	}
+}
+
+// TestWakePhraseStartAccumCap checks the accumulator stays bounded and that a
+// phrase still matches once older speech has been trimmed away.
+func TestWakePhraseStartAccumCap(t *testing.T) {
+	s := NewWakePhraseStart(WakePhraseStartConfig{Phrases: []string{"hey jargo"}, Timeout: time.Minute})
+	spy := attachStart(s)
+	defer s.Cleanup()
+
+	for range 20 {
+		spy.send(s, transcript("filler words that will overflow the accumulator"))
+	}
+	if len(s.accum) > wakeAccumLimit {
+		t.Errorf("accum grew to %d bytes, want <= %d", len(s.accum), wakeAccumLimit)
+	}
+	if spy.starts() != 0 {
+		t.Fatal("filler must not wake the session")
+	}
+	spy.send(s, transcript("hey jargo"))
+	if spy.starts() != 1 {
+		t.Error("wake phrase should still match after the accumulator was trimmed")
+	}
+}
+
+func TestWakePhraseStartSingleActivation(t *testing.T) {
+	s := NewWakePhraseStart(WakePhraseStartConfig{
+		Phrases:          []string{"hey jargo"},
+		Timeout:          time.Minute,
+		SingleActivation: true,
+	})
+	spy := attachStart(s)
+	defer s.Cleanup()
+
+	spy.send(s, transcript("hey jargo"))
+	if spy.starts() != 1 {
+		t.Fatal("wake phrase should open the first turn")
+	}
+
+	// The controller calls TurnStarted once the turn opens; single-activation
+	// puts the session straight back to sleep.
+	spy.mu.Lock()
+	s.TurnStarted()
+	spy.mu.Unlock()
+
+	if got := spy.send(s, transcript("follow up question")); got != Stop {
+		t.Errorf("after single activation: Process = %v, want Stop (asleep again)", got)
+	}
+	if spy.starts() != 1 {
+		t.Errorf("single-activation must require the phrase again: starts = %d", spy.starts())
+	}
+}
+
+// TestWakePhraseStartTimeout checks the inactivity timer puts the session back
+// to sleep.
+func TestWakePhraseStartTimeout(t *testing.T) {
+	s := NewWakePhraseStart(WakePhraseStartConfig{Phrases: []string{"hey jargo"}, Timeout: 20 * time.Millisecond})
+	spy := attachStart(s)
+	defer s.Cleanup()
+
+	spy.send(s, transcript("hey jargo"))
+	if spy.starts() != 1 {
+		t.Fatal("wake phrase should wake the session")
+	}
+
+	eventually(t, func() bool {
+		spy.mu.Lock()
+		defer spy.mu.Unlock()
+		return !s.awake
+	}, 2*time.Second, "session should fall asleep after the inactivity timeout")
+
+	if got := spy.send(s, transcript("still there")); got != Stop {
+		t.Errorf("after timeout: Process = %v, want Stop", got)
+	}
+}
+
+// TestWakePhraseStartDefaultTimeout pins the documented 10s default.
+func TestWakePhraseStartDefaultTimeout(t *testing.T) {
+	s := NewWakePhraseStart(WakePhraseStartConfig{Phrases: []string{"hey"}})
+	if s.timeout != wakePhraseDefaultTimeout {
+		t.Errorf("timeout = %v, want %v", s.timeout, wakePhraseDefaultTimeout)
+	}
+}
+
+func TestCompileWakePatterns(t *testing.T) {
+	tests := []struct {
+		name     string
+		phrases  []string
+		text     string
+		want     bool
+		wantPats int
+	}{
+		{"case insensitive", []string{"hey jargo"}, "HEY JARGO", true, 1},
+		{"flexible whitespace", []string{"hey jargo"}, "hey    jargo", true, 1},
+		{"word boundary", []string{"hey jargo"}, "theyjargo", false, 1},
+		{"regex metacharacters are literal", []string{"a.b"}, "axb", false, 1},
+		{"regex metacharacters match literally", []string{"a.b"}, "a.b", true, 1},
+		{"blank phrases are skipped", []string{"", "   "}, "anything", false, 0},
+		{"any phrase matches", []string{"hey jargo", "ok jargo"}, "ok jargo", true, 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pats := compileWakePatterns(tt.phrases)
+			if len(pats) != tt.wantPats {
+				t.Fatalf("compiled %d patterns, want %d", len(pats), tt.wantPats)
+			}
+			s := &WakePhraseStart{patterns: pats}
+			if got := s.matches(tt.text); got != tt.want {
+				t.Errorf("matches(%q) = %v, want %v", tt.text, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCompileWakePatternsDoesNotMutateInput guards the caller's slice: the
+// compiler quotes words in place while building each pattern.
+func TestCompileWakePatternsDoesNotMutateInput(t *testing.T) {
+	phrases := []string{"a.b c"}
+	compileWakePatterns(phrases)
+	if phrases[0] != "a.b c" {
+		t.Errorf("caller's phrase was mutated to %q", phrases[0])
+	}
+}
+
+// TestExternalStart covers the relay case: another processor already decided the
+// turn, so no interruption or speaking frames are re-emitted.
+func TestExternalStart(t *testing.T) {
+	s := NewExternalStart()
+	spy := attachStart(s)
+
+	if got := spy.send(s, frames.NewVADUserStartedSpeakingFrame(0)); got != Continue {
+		t.Errorf("Process(vad) = %v, want Continue", got)
+	}
+	if spy.starts() != 0 {
+		t.Error("ExternalStart must ignore VAD")
+	}
+
+	if got := spy.send(s, frames.NewUserStartedSpeakingFrame()); got != Stop {
+		t.Errorf("Process(user started) = %v, want Stop", got)
+	}
+	if spy.starts() != 1 {
+		t.Fatalf("starts = %d, want 1", spy.starts())
+	}
+	if p := spy.started[0]; p.EnableInterruptions || p.EnableUserSpeakingFrames {
+		t.Errorf("params = %+v, want both disabled (the external processor emits them)", p)
+	}
+}
+
+// TestExternalStopDebounce checks the stop is held back for a late transcript
+// and then fires once one arrives.
+func TestExternalStopDebounce(t *testing.T) {
+	s := NewExternalStop(ExternalStopConfig{Timeout: 20 * time.Millisecond})
+	spy := attachStop(s)
+	defer s.Cleanup()
+
+	spy.sendStop(s, frames.NewUserStartedSpeakingFrame())
+	spy.sendStop(s, transcript("book me a table"))
+	spy.sendStop(s, frames.NewUserStoppedSpeakingFrame())
+
+	if spy.stops() != 0 {
+		t.Fatal("stop must be debounced, not immediate")
+	}
+	eventually(t, func() bool { return spy.stops() == 1 }, 2*time.Second, "debounced stop should fire")
+
+	spy.mu.Lock()
+	defer spy.mu.Unlock()
+	if spy.inferences != 1 {
+		t.Errorf("inference triggers = %d, want 1", spy.inferences)
+	}
+	if p := spy.stopped[0]; p.EnableUserSpeakingFrames {
+		t.Error("ExternalStop must not re-emit user speaking frames")
+	}
+}
+
+// TestExternalStopWaitsForTranscript checks the default: no text yet means no
+// turn end, and a pending interim keeps the turn open.
+func TestExternalStopWaitsForTranscript(t *testing.T) {
+	t.Run("no transcript", func(t *testing.T) {
+		s := NewExternalStop(ExternalStopConfig{Timeout: 10 * time.Millisecond})
+		spy := attachStop(s)
+		defer s.Cleanup()
+
+		spy.sendStop(s, frames.NewUserStoppedSpeakingFrame())
+		time.Sleep(100 * time.Millisecond)
+		if spy.stops() != 0 {
+			t.Error("must not end the turn without a transcript")
+		}
+	})
+
+	t.Run("interim still pending", func(t *testing.T) {
+		s := NewExternalStop(ExternalStopConfig{Timeout: 10 * time.Millisecond})
+		spy := attachStop(s)
+		defer s.Cleanup()
+
+		spy.sendStop(s, transcript("hello"))
+		spy.sendStop(s, interim("and also"))
+		spy.sendStop(s, frames.NewUserStoppedSpeakingFrame())
+		time.Sleep(100 * time.Millisecond)
+		if spy.stops() != 0 {
+			t.Error("a pending interim means more speech is coming; the turn must stay open")
+		}
+
+		// The final transcript clears the interim and lets the next stop through.
+		spy.sendStop(s, transcript("and also this"))
+		spy.sendStop(s, frames.NewUserStoppedSpeakingFrame())
+		eventually(t, func() bool { return spy.stops() == 1 }, 2*time.Second, "stop after the final transcript")
+	})
+
+	t.Run("empty transcript does not count", func(t *testing.T) {
+		s := NewExternalStop(ExternalStopConfig{Timeout: 10 * time.Millisecond})
+		spy := attachStop(s)
+		defer s.Cleanup()
+
+		spy.sendStop(s, transcript(""))
+		spy.sendStop(s, frames.NewUserStoppedSpeakingFrame())
+		time.Sleep(100 * time.Millisecond)
+		if spy.stops() != 0 {
+			t.Error("an empty transcript is not text")
+		}
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		s := NewExternalStop(ExternalStopConfig{
+			Timeout:           10 * time.Millisecond,
+			WaitForTranscript: new(false),
+		})
+		spy := attachStop(s)
+		defer s.Cleanup()
+
+		spy.sendStop(s, frames.NewUserStoppedSpeakingFrame())
+		eventually(t, func() bool { return spy.stops() == 1 }, 2*time.Second,
+			"with WaitForTranscript off the stop should fire regardless")
+	})
+}
+
+// TestExternalStopUserResumed checks that speech resuming inside the debounce
+// window cancels the pending stop.
+func TestExternalStopUserResumed(t *testing.T) {
+	s := NewExternalStop(ExternalStopConfig{Timeout: 30 * time.Millisecond})
+	spy := attachStop(s)
+	defer s.Cleanup()
+
+	spy.sendStop(s, transcript("hold on"))
+	spy.sendStop(s, frames.NewUserStoppedSpeakingFrame())
+	spy.sendStop(s, frames.NewUserStartedSpeakingFrame()) // resumed before the timer
+
+	time.Sleep(150 * time.Millisecond)
+	if spy.stops() != 0 {
+		t.Error("resumed speech must cancel the pending stop")
+	}
+}
+
+// TestExternalStopResetsPerTurn checks TurnStarted/TurnStopped clear the
+// transcript evidence so it can't leak into the next turn.
+func TestExternalStopResetsPerTurn(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		reset func(s *ExternalStop)
+	}{
+		{"TurnStarted", func(s *ExternalStop) { s.TurnStarted() }},
+		{"TurnStopped", func(s *ExternalStop) { s.TurnStopped() }},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewExternalStop(ExternalStopConfig{Timeout: 10 * time.Millisecond})
+			spy := attachStop(s)
+			defer s.Cleanup()
+
+			spy.sendStop(s, transcript("previous turn"))
+			spy.mu.Lock()
+			tt.reset(s)
+			spy.mu.Unlock()
+
+			spy.sendStop(s, frames.NewUserStoppedSpeakingFrame())
+			time.Sleep(100 * time.Millisecond)
+			if spy.stops() != 0 {
+				t.Error("transcript evidence from the previous turn must not end this one")
+			}
+		})
+	}
+}
+
+// TestExternalStopDefaultTimeout pins the documented 500ms default.
+func TestExternalStopDefaultTimeout(t *testing.T) {
+	s := NewExternalStop(ExternalStopConfig{})
+	if s.timeout != 500*time.Millisecond {
+		t.Errorf("timeout = %v, want 500ms", s.timeout)
+	}
+	if !s.waitForTx {
+		t.Error("WaitForTranscript should default to true")
+	}
+}
+
+// TestMuteStrategies drives each strategy over a frame sequence and checks the
+// muted state it reports at every step.
+func TestMuteStrategies(t *testing.T) {
+	botStart := func() frames.Frame { return frames.NewBotStartedSpeakingFrame() }
+	botStop := func() frames.Frame { return frames.NewBotStoppedSpeakingFrame() }
+	other := func() frames.Frame { return frames.NewUserSpeakingFrame() }
+
+	type step struct {
+		frame frames.Frame
+		want  bool
+	}
+	tests := []struct {
+		name  string
+		build func() MuteStrategy
+		steps []step
+	}{
+		{
+			name:  "AlwaysUserMute mutes for every bot turn",
+			build: func() MuteStrategy { return NewAlwaysUserMute() },
+			steps: []step{
+				{other(), false},
+				{botStart(), true},
+				{other(), true},
+				{botStop(), false},
+				{botStart(), true}, // and again on the second turn
+				{botStop(), false},
+			},
+		},
+		{
+			name:  "FirstSpeechUserMute mutes only the first bot turn",
+			build: func() MuteStrategy { return NewFirstSpeechUserMute() },
+			steps: []step{
+				{other(), false}, // pre-speech input is allowed
+				{botStart(), true},
+				{other(), true},
+				{botStop(), false},
+				{botStart(), false}, // never again
+				{other(), false},
+				{botStop(), false},
+			},
+		},
+		{
+			name:  "MuteUntilFirstBotComplete mutes from session start",
+			build: func() MuteStrategy { return NewMuteUntilFirstBotComplete() },
+			steps: []step{
+				{other(), true}, // muted before the bot has even spoken
+				{botStart(), true},
+				{botStop(), false},
+				{other(), false},
+				{botStart(), false},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := tt.build()
+			for i, st := range tt.steps {
+				if got := s.ShouldMute(st.frame); got != st.want {
+					t.Errorf("step %d (%s): ShouldMute = %v, want %v", i, st.frame.Name(), got, st.want)
+				}
+			}
+		})
+	}
+}
+
+// TestFunctionCallUserMute checks the strategy stays muted until every in-flight
+// call has settled, whether by result or cancellation.
+func TestFunctionCallUserMute(t *testing.T) {
+	s := NewFunctionCallUserMute()
+
+	if s.ShouldMute(frames.NewUserSpeakingFrame()) {
+		t.Error("no calls in flight: want unmuted")
+	}
+
+	started := frames.NewFunctionCallsStartedFrame("", []frames.ToolCall{
+		{ID: "a", Name: "lookup"},
+		{ID: "b", Name: "book"},
+	})
+	if !s.ShouldMute(started) {
+		t.Error("calls in flight: want muted")
+	}
+
+	if !s.ShouldMute(frames.NewFunctionCallResultFrame("a", "lookup", "ok", false)) {
+		t.Error("one call still in flight: want muted")
+	}
+	if s.ShouldMute(frames.NewFunctionCallCancelFrame("b", "book")) {
+		t.Error("all calls settled: want unmuted")
+	}
+
+	// An unknown ID must not unmute anything or corrupt the set.
+	s.ShouldMute(started)
+	if s.ShouldMute(frames.NewFunctionCallResultFrame("zzz", "other", "ok", false)) != true {
+		t.Error("an unrelated result must leave the in-flight calls muted")
+	}
+}
+
+func TestDefaultStrategyChains(t *testing.T) {
+	t.Run("start defaults", func(t *testing.T) {
+		got := DefaultStartStrategies()
+		if len(got) != 2 {
+			t.Fatalf("len = %d, want 2", len(got))
+		}
+		if _, ok := got[0].(*VADStart); !ok {
+			t.Errorf("first = %T, want *VADStart", got[0])
+		}
+		if _, ok := got[1].(*TranscriptionStart); !ok {
+			t.Errorf("second = %T, want *TranscriptionStart", got[1])
+		}
+	})
+
+	t.Run("stop defaults", func(t *testing.T) {
+		got := DefaultStopStrategies()
+		if len(got) != 1 {
+			t.Fatalf("len = %d, want 1", len(got))
+		}
+		if _, ok := got[0].(*SpeechTimeoutStop); !ok {
+			t.Errorf("first = %T, want *SpeechTimeoutStop", got[0])
+		}
+	})
+
+	t.Run("fillDefaults only fills empty chains", func(t *testing.T) {
+		custom := NewExternalStart()
+		s := UserTurnStrategies{Start: []StartStrategy{custom}}
+		s.fillDefaults()
+		if len(s.Start) != 1 || s.Start[0] != custom {
+			t.Error("a provided start chain must be left alone")
+		}
+		if len(s.Stop) == 0 {
+			t.Error("an empty stop chain must be filled")
+		}
+	})
+}
+
+func TestExternalStrategies(t *testing.T) {
+	s := ExternalStrategies()
+	if len(s.Start) != 1 {
+		t.Fatalf("start len = %d, want 1", len(s.Start))
+	}
+	if _, ok := s.Start[0].(*ExternalStart); !ok {
+		t.Errorf("start = %T, want *ExternalStart", s.Start[0])
+	}
+	if len(s.Stop) != 1 {
+		t.Fatalf("stop len = %d, want 1", len(s.Stop))
+	}
+	if _, ok := s.Stop[0].(*ExternalStop); !ok {
+		t.Errorf("stop = %T, want *ExternalStop", s.Stop[0])
+	}
+}
+
+// TestFilterIncompleteUserTurnStrategies checks the detectors are wrapped as
+// deferred (they may only trigger inference) and the LLM decides the turn end.
+func TestFilterIncompleteUserTurnStrategies(t *testing.T) {
+	t.Run("wraps supplied detectors", func(t *testing.T) {
+		got := FilterIncompleteUserTurnStrategies([]StopStrategy{NewExternalStop(ExternalStopConfig{})})
+		if len(got.Stop) != 2 {
+			t.Fatalf("stop len = %d, want detector + completion", len(got.Stop))
+		}
+		if _, ok := got.Stop[0].(*deferredStop); !ok {
+			t.Errorf("detector = %T, want *deferredStop", got.Stop[0])
+		}
+		if _, ok := got.Stop[1].(*ExternalCompletionStop); !ok {
+			t.Errorf("finalizer = %T, want *ExternalCompletionStop", got.Stop[1])
+		}
+		if len(got.Start) != 0 {
+			t.Error("the start chain should be left to fillDefaults")
+		}
+	})
+
+	t.Run("empty detectors use the defaults", func(t *testing.T) {
+		got := FilterIncompleteUserTurnStrategies(nil)
+		if len(got.Stop) != len(DefaultStopStrategies())+1 {
+			t.Errorf("stop len = %d, want defaults + completion", len(got.Stop))
+		}
+	})
+}
+
+// TestDeferredStopSuppressesFinalization is the point of Deferred: the inner
+// strategy may start inference but must not end the turn itself.
+func TestDeferredStopSuppressesFinalization(t *testing.T) {
+	inner := NewExternalStop(ExternalStopConfig{Timeout: 10 * time.Millisecond})
+	d := Deferred(inner)
+	spy := attachStop(d)
+	defer d.Cleanup()
+
+	spy.sendStop(d, transcript("done"))
+	spy.sendStop(d, frames.NewUserStoppedSpeakingFrame())
+
+	eventually(t, func() bool {
+		spy.mu.Lock()
+		defer spy.mu.Unlock()
+		return spy.inferences == 1
+	}, 2*time.Second, "deferred strategy should still trigger inference")
+
+	spy.mu.Lock()
+	defer spy.mu.Unlock()
+	if len(spy.stopped) != 0 {
+		t.Errorf("deferred strategy must not finalize the turn: stops = %d", len(spy.stopped))
+	}
+}
+
+// TestDeferredStopDelegates checks the per-turn hooks reach the inner strategy.
+func TestDeferredStopDelegates(t *testing.T) {
+	inner := NewExternalStop(ExternalStopConfig{Timeout: time.Minute})
+	d := Deferred(inner)
+	spy := attachStop(d)
+
+	spy.sendStop(d, transcript("text"))
+	spy.mu.Lock()
+	if !inner.haveText {
+		spy.mu.Unlock()
+		t.Fatal("Process should reach the inner strategy")
+	}
+	d.TurnStarted()
+	if inner.haveText {
+		spy.mu.Unlock()
+		t.Error("TurnStarted should reach the inner strategy")
+	}
+
+	inner.haveText = true
+	d.TurnStopped()
+	if inner.haveText {
+		spy.mu.Unlock()
+		t.Error("TurnStopped should reach the inner strategy")
+	}
+	spy.mu.Unlock()
+	d.Cleanup()
+}
+
+func TestNewLLMTurnCompletionStop(t *testing.T) {
+	if _, ok := NewLLMTurnCompletionStop().(*ExternalCompletionStop); !ok {
+		t.Error("NewLLMTurnCompletionStop should build an *ExternalCompletionStop")
+	}
+}
+
+func TestCompletionInstructions(t *testing.T) {
+	if got := CompletionInstructions(UserTurnCompletionConfig{}); got != defaultCompletionInstructions {
+		t.Error("an empty config should yield the default marker-protocol instructions")
+	}
+	const custom = "answer only in haiku"
+	if got := CompletionInstructions(UserTurnCompletionConfig{Instructions: custom}); got != custom {
+		t.Errorf("CompletionInstructions = %q, want the override", got)
+	}
+}
+
+func TestDefaultTurnParams(t *testing.T) {
+	if got := DefaultStartedParams(); !got.EnableInterruptions || !got.EnableUserSpeakingFrames {
+		t.Errorf("DefaultStartedParams = %+v, want both enabled", got)
+	}
+	if got := DefaultStoppedParams(); !got.EnableUserSpeakingFrames {
+		t.Errorf("DefaultStoppedParams = %+v, want speaking frames enabled", got)
+	}
+}
+
+// TestStrategyBaseNoOps checks the embedded defaults are safe to call, including
+// on a strategy that was never attached to a controller.
+func TestStrategyBaseNoOps(t *testing.T) {
+	t.Run("start base without an env", func(t *testing.T) {
+		var b StartStrategyBase
+		b.TurnStarted()
+		b.TurnStopped()
+		b.Cleanup()
+		b.TriggerStarted()
+		b.TriggerResetAggregation()
+	})
+
+	t.Run("stop base without an env", func(t *testing.T) {
+		var b StopStrategyBase
+		b.TurnStarted()
+		b.TurnStopped()
+		b.Cleanup()
+		b.TriggerStopped()
+		b.Push(frames.NewUserSpeakingFrame(), processor.Downstream)
+		b.Broadcast(frames.NewUserSpeakingFrame())
+	})
+}
+
+// TestStopStrategyBaseEmits covers the frame-emitting helpers a stop strategy
+// uses to reach the pipeline.
+func TestStopStrategyBaseEmits(t *testing.T) {
+	var b StopStrategyBase
+	b.EnableUserSpeakingFrames = true
+	spy := newSpy()
+	b.attach(spy.env())
+
+	b.Push(frames.NewUserSpeakingFrame(), processor.Upstream)
+	b.Broadcast(frames.NewBotSpeakingFrame())
+	b.TriggerStopped()
+
+	if len(spy.pushed) != 1 || spy.pushed[0] != processor.Upstream {
+		t.Errorf("pushed = %v, want one Upstream push", spy.pushed)
+	}
+	if len(spy.broadcast) != 1 {
+		t.Errorf("broadcast = %d frames, want 1", len(spy.broadcast))
+	}
+	// TriggerStopped is inference-then-finalize, in that order.
+	if spy.inferences != 1 || len(spy.stopped) != 1 {
+		t.Errorf("inferences = %d, stops = %d, want 1 and 1", spy.inferences, len(spy.stopped))
+	}
+	if !spy.stopped[0].EnableUserSpeakingFrames {
+		t.Error("the base's EnableUserSpeakingFrames should reach the stop params")
+	}
+}
+
+// TestStrategyEnvAfterCancel checks a canceled timeout never runs its callback.
+func TestStrategyEnvAfterCancel(t *testing.T) {
+	spy := newSpy()
+	env := spy.env()
+
+	fired := false
+	spy.mu.Lock()
+	cancel := env.after(10*time.Millisecond, func() { fired = true })
+	cancel()
+	spy.mu.Unlock()
+
+	time.Sleep(100 * time.Millisecond)
+	spy.mu.Lock()
+	defer spy.mu.Unlock()
+	if fired {
+		t.Error("a canceled timeout must not run")
+	}
+}
+
+// TestStrategyEnvAfterRuns checks the callback runs with the shared mutex held,
+// which is the contract strategies rely on instead of locking themselves.
+func TestStrategyEnvAfterRuns(t *testing.T) {
+	spy := newSpy()
+	env := spy.env()
+
+	done := make(chan struct{})
+	env.after(5*time.Millisecond, func() {
+		if spy.mu.TryLock() {
+			spy.mu.Unlock()
+			t.Error("callback should run with the shared mutex already held")
+		}
+		close(done)
+	})
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout callback never ran")
+	}
+}
+
+// errEmit is the failure a fakeEmitter reports.
+//
+//nolint:gochecknoglobals // sentinel error
+var errEmit = errors.New("emit failed")
+
+// fakeEmitter records what the idle controller's callback sends into the
+// pipeline.
+type fakeEmitter struct {
+	pushed    []processor.Direction
+	broadcast int
+	err       error
+}
+
+func (e *fakeEmitter) Push(_ context.Context, _ frames.Frame, dir processor.Direction) error {
+	e.pushed = append(e.pushed, dir)
+	return e.err
+}
+
+func (e *fakeEmitter) Broadcast(_ context.Context, _ frames.Frame) error {
+	e.broadcast++
+	return e.err
+}
+
+// TestUserIdleControllerEmit covers the frame-sending helpers an idle callback
+// uses, including the guard for a controller that was never set up.
+func TestUserIdleControllerEmit(t *testing.T) {
+	t.Run("without an emitter", func(t *testing.T) {
+		c := NewUserIdleController(IdleConfig{})
+		if err := c.Push(t.Context(), frames.NewUserSpeakingFrame(), processor.Downstream); err != nil {
+			t.Errorf("Push before Setup: %v", err)
+		}
+		if err := c.Broadcast(t.Context(), frames.NewUserSpeakingFrame()); err != nil {
+			t.Errorf("Broadcast before Setup: %v", err)
+		}
+	})
+
+	t.Run("with an emitter", func(t *testing.T) {
+		emit := &fakeEmitter{}
+		c := NewUserIdleController(IdleConfig{})
+		c.Setup(t.Context(), emit)
+
+		if err := c.Push(t.Context(), frames.NewUserSpeakingFrame(), processor.Upstream); err != nil {
+			t.Errorf("Push: %v", err)
+		}
+		if err := c.Broadcast(t.Context(), frames.NewUserSpeakingFrame()); err != nil {
+			t.Errorf("Broadcast: %v", err)
+		}
+		if len(emit.pushed) != 1 || emit.pushed[0] != processor.Upstream {
+			t.Errorf("pushed = %v, want one Upstream push", emit.pushed)
+		}
+		if emit.broadcast != 1 {
+			t.Errorf("broadcast = %d, want 1", emit.broadcast)
+		}
+		c.Cleanup()
+	})
+
+	t.Run("emitter errors propagate", func(t *testing.T) {
+		emit := &fakeEmitter{err: errEmit}
+		c := NewUserIdleController(IdleConfig{})
+		c.Setup(t.Context(), emit)
+
+		if err := c.Push(t.Context(), frames.NewUserSpeakingFrame(), processor.Downstream); !errors.Is(err, errEmit) {
+			t.Errorf("Push error = %v, want errEmit", err)
+		}
+		if err := c.Broadcast(t.Context(), frames.NewUserSpeakingFrame()); !errors.Is(err, errEmit) {
+			t.Errorf("Broadcast error = %v, want errEmit", err)
+		}
+	})
+}

--- a/processor/voicemail/voicemail_test.go
+++ b/processor/voicemail/voicemail_test.go
@@ -1,0 +1,279 @@
+package voicemail_test
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gojargo/jargo/frames"
+	"github.com/gojargo/jargo/pipeline"
+	"github.com/gojargo/jargo/processor/voicemail"
+)
+
+// harness runs a voicemail processor in a pipeline and records the text that
+// reaches the far end.
+type harness struct {
+	task *pipeline.Task
+	done chan error
+	stop sync.Once
+
+	mu   sync.Mutex
+	text strings.Builder
+}
+
+func run(t *testing.T, cfg voicemail.Config) *harness {
+	t.Helper()
+	h := &harness{done: make(chan error, 1)}
+	p := voicemail.New(cfg)
+	h.task = pipeline.NewTask(pipeline.New(p), pipeline.TaskParams{
+		OnReachedDownstream: func(f frames.Frame) {
+			if tf, ok := f.(*frames.LLMTextFrame); ok {
+				h.mu.Lock()
+				h.text.WriteString(tf.Text)
+				h.mu.Unlock()
+			}
+		},
+	})
+	go func() { h.done <- h.task.Run(context.Background()) }()
+	t.Cleanup(func() { h.shutdown(t) })
+	return h
+}
+
+// shutdown ends the pipeline and waits for Run to return. It is idempotent so a
+// test may drain the pipeline itself and still be cleaned up safely.
+func (h *harness) shutdown(t *testing.T) {
+	t.Helper()
+	h.stop.Do(func() {
+		h.task.StopWhenDone()
+		select {
+		case <-h.done:
+		case <-time.After(3 * time.Second):
+			t.Error("pipeline did not finish")
+		}
+	})
+}
+
+// say streams text as LLM deltas and closes the response, the way an LLM
+// service drives this processor.
+func (h *harness) say(chunks ...string) {
+	for _, c := range chunks {
+		h.task.QueueFrame(frames.NewLLMTextFrame(c))
+	}
+	h.task.QueueFrame(frames.NewLLMFullResponseEndFrame())
+}
+
+// spoken waits for the forwarded text to settle and returns it.
+func (h *harness) spoken(t *testing.T) string {
+	t.Helper()
+	h.shutdown(t)
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.text.String()
+}
+
+// signal is a one-shot callback recorder.
+type signal struct {
+	ch chan struct{}
+}
+
+func newSignal() *signal { return &signal{ch: make(chan struct{}, 8)} }
+
+func (s *signal) fire() { s.ch <- struct{}{} }
+
+// wait reports whether the callback fired within d.
+func (s *signal) wait(d time.Duration) bool {
+	select {
+	case <-s.ch:
+		return true
+	case <-time.After(d):
+		return false
+	}
+}
+
+// count drains and reports how many times the callback fired, after allowing d
+// for stragglers.
+func (s *signal) count(d time.Duration) int {
+	time.Sleep(d)
+	n := 0
+	for {
+		select {
+		case <-s.ch:
+			n++
+		default:
+			return n
+		}
+	}
+}
+
+func TestDetectsVoicemail(t *testing.T) {
+	vm, human := newSignal(), newSignal()
+	h := run(t, voicemail.Config{
+		OnVoicemailDetected:    vm.fire,
+		OnConversationDetected: human.fire,
+	})
+
+	h.say("<voicemail></voicemail>")
+	if !vm.wait(2 * time.Second) {
+		t.Fatal("voicemail callback never fired")
+	}
+	if human.wait(100 * time.Millisecond) {
+		t.Error("the conversation callback must not fire for a voicemail verdict")
+	}
+}
+
+// TestDetectsHuman covers both tags that mean a person answered.
+func TestDetectsHuman(t *testing.T) {
+	for _, tag := range []string{"human", "conversation"} {
+		t.Run(tag, func(t *testing.T) {
+			vm, human := newSignal(), newSignal()
+			h := run(t, voicemail.Config{
+				OnVoicemailDetected:    vm.fire,
+				OnConversationDetected: human.fire,
+			})
+
+			h.say("<" + tag + "></" + tag + ">")
+			if !human.wait(2 * time.Second) {
+				t.Fatal("conversation callback never fired")
+			}
+			if vm.wait(100 * time.Millisecond) {
+				t.Error("the voicemail callback must not fire for a human verdict")
+			}
+		})
+	}
+}
+
+// TestStripsDecisionTags checks the classification markers never reach the TTS.
+func TestStripsDecisionTags(t *testing.T) {
+	h := run(t, voicemail.Config{OnConversationDetected: func() {}})
+	h.say("Hi there.", " <human></human>", " How can I help?")
+
+	got := h.spoken(t)
+	if strings.Contains(got, "<human>") || strings.Contains(got, "</human>") {
+		t.Errorf("spoken text = %q, want the decision tags stripped", got)
+	}
+	if !strings.Contains(got, "Hi there.") || !strings.Contains(got, "How can I help?") {
+		t.Errorf("spoken text = %q, want the surrounding speech kept", got)
+	}
+}
+
+// TestTagSplitAcrossDeltas checks a tag broken across LLM tokens is still
+// recognized — the normal case, since the model streams a few characters at a
+// time.
+func TestTagSplitAcrossDeltas(t *testing.T) {
+	vm := newSignal()
+	h := run(t, voicemail.Config{OnVoicemailDetected: vm.fire})
+
+	h.say("Please leave a message", " <voice", "mail></voice", "mail>")
+	if !vm.wait(2 * time.Second) {
+		t.Fatal("a tag split across deltas was not detected")
+	}
+}
+
+// TestDecidesOnce checks the verdict is final: a second tag in the same call
+// must not fire another callback, since the app has already acted on the first.
+func TestDecidesOnce(t *testing.T) {
+	vm, human := newSignal(), newSignal()
+	h := run(t, voicemail.Config{
+		OnVoicemailDetected:    vm.fire,
+		OnConversationDetected: human.fire,
+	})
+
+	h.say("<voicemail></voicemail>", "<voicemail></voicemail>", "<human></human>")
+
+	if n := vm.count(500 * time.Millisecond); n != 1 {
+		t.Errorf("voicemail callback fired %d times, want exactly 1", n)
+	}
+	if n := human.count(0); n != 0 {
+		t.Errorf("conversation callback fired %d times after a voicemail verdict, want 0", n)
+	}
+}
+
+// TestVoicemailDelay checks the callback is held back so the answering machine's
+// greeting can finish before the bot starts leaving a message.
+func TestVoicemailDelay(t *testing.T) {
+	vm := newSignal()
+	h := run(t, voicemail.Config{
+		OnVoicemailDetected: vm.fire,
+		VoicemailDelay:      300 * time.Millisecond,
+	})
+
+	h.say("<voicemail></voicemail>")
+	if vm.wait(100 * time.Millisecond) {
+		t.Error("the callback fired before the configured delay elapsed")
+	}
+	if !vm.wait(3 * time.Second) {
+		t.Fatal("the delayed callback never fired")
+	}
+}
+
+// TestFlushesIncompleteTag checks that text held back as a possible tag is
+// released when the response ends, rather than being swallowed.
+func TestFlushesIncompleteTag(t *testing.T) {
+	h := run(t, voicemail.Config{})
+	h.say("hello <voicem")
+
+	if got := h.spoken(t); !strings.Contains(got, "<voicem") {
+		t.Errorf("spoken text = %q, want the incomplete tag flushed rather than dropped", got)
+	}
+}
+
+// TestNilCallbacks checks a config with no callbacks is safe — the processor is
+// usable purely as a tag stripper.
+func TestNilCallbacks(t *testing.T) {
+	h := run(t, voicemail.Config{})
+	h.say("<voicemail></voicemail>ok")
+
+	if got := h.spoken(t); strings.Contains(got, "<voicemail>") {
+		t.Errorf("spoken text = %q, want the tag stripped", got)
+	}
+}
+
+// TestNonTextFramesPassThrough checks unrelated frames are forwarded untouched.
+func TestNonTextFramesPassThrough(t *testing.T) {
+	got := make(chan struct{}, 1)
+	p := voicemail.New(voicemail.Config{})
+	task := pipeline.NewTask(pipeline.New(p), pipeline.TaskParams{
+		OnReachedDownstream: func(f frames.Frame) {
+			if _, ok := f.(*frames.TTSSpeakFrame); ok {
+				select {
+				case got <- struct{}{}:
+				default:
+				}
+			}
+		},
+	})
+	done := make(chan error, 1)
+	go func() { done <- task.Run(context.Background()) }()
+
+	task.QueueFrame(frames.NewTTSSpeakFrame("hello"))
+	select {
+	case <-got:
+	case <-time.After(3 * time.Second):
+		t.Fatal("an unrelated frame was not forwarded")
+	}
+	task.StopWhenDone()
+	<-done
+}
+
+// TestCleanupStopsPendingTimer checks tearing the pipeline down cancels a
+// pending delayed callback, so a hung-up call cannot fire it later.
+func TestCleanupStopsPendingTimer(t *testing.T) {
+	vm := newSignal()
+	p := voicemail.New(voicemail.Config{
+		OnVoicemailDetected: vm.fire,
+		VoicemailDelay:      time.Second,
+	})
+	task := pipeline.NewTask(pipeline.New(p), pipeline.TaskParams{})
+	done := make(chan error, 1)
+	go func() { done <- task.Run(context.Background()) }()
+
+	task.QueueFrame(frames.NewLLMTextFrame("<voicemail></voicemail>"))
+	task.StopWhenDone()
+	<-done
+
+	if n := vm.count(1500 * time.Millisecond); n != 0 {
+		t.Errorf("the delayed callback fired %d times after cleanup, want 0", n)
+	}
+}

--- a/provider/assemblyai/assemblyai_config_test.go
+++ b/provider/assemblyai/assemblyai_config_test.go
@@ -1,0 +1,22 @@
+package assemblyai_test
+
+import (
+	"testing"
+
+	"github.com/gojargo/jargo/internal/providertest"
+	"github.com/gojargo/jargo/provider/assemblyai"
+)
+
+// TestConfigValidate pins which Config fields the provider requires.
+func TestConfigValidate(t *testing.T) {
+	providertest.Configs(t, []providertest.ConfigCase{
+		{Name: "missing API key", Cfg: assemblyai.Config{}, Valid: false},
+		{Name: "API key only", Cfg: assemblyai.Config{APIKey: "k"}, Valid: true},
+	})
+}
+
+// TestNewServices checks each constructor returns a service under the label
+// that identifies it in logs, metrics and traces.
+func TestNewServices(t *testing.T) {
+	providertest.Service(t, "AssemblyAISTT", assemblyai.NewSTT(assemblyai.Config{APIKey: "k"}))
+}

--- a/provider/azurespeech/azurespeech_config_test.go
+++ b/provider/azurespeech/azurespeech_config_test.go
@@ -1,0 +1,22 @@
+package azurespeech_test
+
+import (
+	"testing"
+
+	"github.com/gojargo/jargo/internal/providertest"
+	"github.com/gojargo/jargo/provider/azurespeech"
+)
+
+// TestConfigValidateTTS pins which TTSConfig fields the provider requires.
+func TestConfigValidateTTS(t *testing.T) {
+	providertest.Configs(t, []providertest.ConfigCase{
+		{Name: "missing API key", Cfg: azurespeech.TTSConfig{}, Valid: false},
+		{Name: "API key only", Cfg: azurespeech.TTSConfig{APIKey: "k"}, Valid: true},
+	})
+}
+
+// TestNewServices checks each constructor returns a service under the label
+// that identifies it in logs, metrics and traces.
+func TestNewServices(t *testing.T) {
+	providertest.Service(t, "AzureTTS", azurespeech.NewTTS(azurespeech.TTSConfig{APIKey: "k"}))
+}

--- a/provider/camb/camb_config_test.go
+++ b/provider/camb/camb_config_test.go
@@ -1,0 +1,22 @@
+package camb_test
+
+import (
+	"testing"
+
+	"github.com/gojargo/jargo/internal/providertest"
+	"github.com/gojargo/jargo/provider/camb"
+)
+
+// TestConfigValidate pins which Config fields the provider requires.
+func TestConfigValidate(t *testing.T) {
+	providertest.Configs(t, []providertest.ConfigCase{
+		{Name: "missing API key", Cfg: camb.Config{}, Valid: false},
+		{Name: "API key only", Cfg: camb.Config{APIKey: "k"}, Valid: true},
+	})
+}
+
+// TestNewServices checks each constructor returns a service under the label
+// that identifies it in logs, metrics and traces.
+func TestNewServices(t *testing.T) {
+	providertest.Service(t, "CambTTS", camb.NewTTS(camb.Config{APIKey: "k"}))
+}

--- a/provider/cerebras/cerebras_test.go
+++ b/provider/cerebras/cerebras_test.go
@@ -1,0 +1,14 @@
+package cerebras_test
+
+import (
+	"testing"
+
+	"github.com/gojargo/jargo/internal/providertest"
+	"github.com/gojargo/jargo/provider/cerebras"
+)
+
+// TestNewLLM checks the Cerebras shim wires the right service name and
+// default model into the shared OpenAI-compatible client.
+func TestNewLLM(t *testing.T) {
+	providertest.CompatLLM(t, "CerebrasLLM", "gpt-oss-120b", cerebras.NewLLM)
+}

--- a/provider/deepseek/deepseek_test.go
+++ b/provider/deepseek/deepseek_test.go
@@ -1,0 +1,14 @@
+package deepseek_test
+
+import (
+	"testing"
+
+	"github.com/gojargo/jargo/internal/providertest"
+	"github.com/gojargo/jargo/provider/deepseek"
+)
+
+// TestNewLLM checks the DeepSeek shim wires the right service name and
+// default model into the shared OpenAI-compatible client.
+func TestNewLLM(t *testing.T) {
+	providertest.CompatLLM(t, "DeepSeekLLM", "deepseek-chat", deepseek.NewLLM)
+}

--- a/provider/elevenlabs/elevenlabs_config_test.go
+++ b/provider/elevenlabs/elevenlabs_config_test.go
@@ -1,0 +1,31 @@
+package elevenlabs_test
+
+import (
+	"testing"
+
+	"github.com/gojargo/jargo/internal/providertest"
+	"github.com/gojargo/jargo/provider/elevenlabs"
+)
+
+// TestConfigValidateTTS pins which Config fields the provider requires.
+func TestConfigValidateTTS(t *testing.T) {
+	providertest.Configs(t, []providertest.ConfigCase{
+		{Name: "missing API key", Cfg: elevenlabs.Config{}, Valid: false},
+		{Name: "API key only", Cfg: elevenlabs.Config{APIKey: "k"}, Valid: true},
+	})
+}
+
+// TestConfigValidateSTT pins which STTConfig fields the provider requires.
+func TestConfigValidateSTT(t *testing.T) {
+	providertest.Configs(t, []providertest.ConfigCase{
+		{Name: "missing API key", Cfg: elevenlabs.STTConfig{}, Valid: false},
+		{Name: "API key only", Cfg: elevenlabs.STTConfig{APIKey: "k"}, Valid: true},
+	})
+}
+
+// TestNewServices checks each constructor returns a service under the label
+// that identifies it in logs, metrics and traces.
+func TestNewServices(t *testing.T) {
+	providertest.Service(t, "ElevenLabsTTS", elevenlabs.NewTTS(elevenlabs.Config{APIKey: "k"}))
+	providertest.Service(t, "ElevenLabsSTT", elevenlabs.NewSTT(elevenlabs.STTConfig{APIKey: "k"}))
+}

--- a/provider/fireworks/fireworks_test.go
+++ b/provider/fireworks/fireworks_test.go
@@ -1,0 +1,14 @@
+package fireworks_test
+
+import (
+	"testing"
+
+	"github.com/gojargo/jargo/internal/providertest"
+	"github.com/gojargo/jargo/provider/fireworks"
+)
+
+// TestNewLLM checks the Fireworks AI shim wires the right service name and
+// default model into the shared OpenAI-compatible client.
+func TestNewLLM(t *testing.T) {
+	providertest.CompatLLM(t, "FireworksLLM", "accounts/fireworks/models/firefunction-v2", fireworks.NewLLM)
+}

--- a/provider/fish/fish_config_test.go
+++ b/provider/fish/fish_config_test.go
@@ -1,0 +1,22 @@
+package fish_test
+
+import (
+	"testing"
+
+	"github.com/gojargo/jargo/internal/providertest"
+	"github.com/gojargo/jargo/provider/fish"
+)
+
+// TestConfigValidate pins which Config fields the provider requires.
+func TestConfigValidate(t *testing.T) {
+	providertest.Configs(t, []providertest.ConfigCase{
+		{Name: "missing API key", Cfg: fish.Config{}, Valid: false},
+		{Name: "API key only", Cfg: fish.Config{APIKey: "k"}, Valid: true},
+	})
+}
+
+// TestNewServices checks each constructor returns a service under the label
+// that identifies it in logs, metrics and traces.
+func TestNewServices(t *testing.T) {
+	providertest.Service(t, "FishTTS", fish.NewTTS(fish.Config{APIKey: "k"}))
+}

--- a/provider/gladia/gladia_config_test.go
+++ b/provider/gladia/gladia_config_test.go
@@ -1,0 +1,22 @@
+package gladia_test
+
+import (
+	"testing"
+
+	"github.com/gojargo/jargo/internal/providertest"
+	"github.com/gojargo/jargo/provider/gladia"
+)
+
+// TestConfigValidate pins which Config fields the provider requires.
+func TestConfigValidate(t *testing.T) {
+	providertest.Configs(t, []providertest.ConfigCase{
+		{Name: "missing API key", Cfg: gladia.Config{}, Valid: false},
+		{Name: "API key only", Cfg: gladia.Config{APIKey: "k"}, Valid: true},
+	})
+}
+
+// TestNewServices checks each constructor returns a service under the label
+// that identifies it in logs, metrics and traces.
+func TestNewServices(t *testing.T) {
+	providertest.Service(t, "GladiaSTT", gladia.NewSTT(gladia.Config{APIKey: "k"}))
+}

--- a/provider/gradium/gradium_config_test.go
+++ b/provider/gradium/gradium_config_test.go
@@ -1,0 +1,33 @@
+package gradium_test
+
+import (
+	"testing"
+
+	"github.com/gojargo/jargo/internal/providertest"
+	"github.com/gojargo/jargo/provider/gradium"
+)
+
+// TestConfigValidateSTT pins which STTConfig fields the provider requires.
+func TestConfigValidateSTT(t *testing.T) {
+	providertest.Configs(t, []providertest.ConfigCase{
+		{Name: "missing API key", Cfg: gradium.STTConfig{}, Valid: false},
+		{Name: "API key only", Cfg: gradium.STTConfig{APIKey: "k"}, Valid: true},
+		{Name: "supported frame delay", Cfg: gradium.STTConfig{APIKey: "k", DelayInFrames: new(24)}, Valid: true},
+		{Name: "unsupported frame delay", Cfg: gradium.STTConfig{APIKey: "k", DelayInFrames: new(25)}, Valid: false},
+	})
+}
+
+// TestConfigValidateTTS pins which TTSConfig fields the provider requires.
+func TestConfigValidateTTS(t *testing.T) {
+	providertest.Configs(t, []providertest.ConfigCase{
+		{Name: "missing API key", Cfg: gradium.TTSConfig{}, Valid: false},
+		{Name: "API key only", Cfg: gradium.TTSConfig{APIKey: "k"}, Valid: true},
+	})
+}
+
+// TestNewServices checks each constructor returns a service under the label
+// that identifies it in logs, metrics and traces.
+func TestNewServices(t *testing.T) {
+	providertest.Service(t, "GradiumSTT", gradium.NewSTT(gradium.STTConfig{APIKey: "k"}))
+	providertest.Service(t, "GradiumTTS", gradium.NewTTS(gradium.TTSConfig{APIKey: "k"}))
+}

--- a/provider/groq/groq_config_test.go
+++ b/provider/groq/groq_config_test.go
@@ -1,0 +1,37 @@
+package groq_test
+
+import (
+	"testing"
+
+	"github.com/gojargo/jargo/internal/providertest"
+	"github.com/gojargo/jargo/provider/groq"
+)
+
+// TestConfigValidateSTT pins which STTConfig fields the provider requires.
+func TestConfigValidateSTT(t *testing.T) {
+	providertest.Configs(t, []providertest.ConfigCase{
+		{Name: "missing API key", Cfg: groq.STTConfig{}, Valid: false},
+		{Name: "API key only", Cfg: groq.STTConfig{APIKey: "k"}, Valid: true},
+	})
+}
+
+// TestConfigValidateTTS pins which TTSConfig fields the provider requires.
+func TestConfigValidateTTS(t *testing.T) {
+	providertest.Configs(t, []providertest.ConfigCase{
+		{Name: "missing API key", Cfg: groq.TTSConfig{}, Valid: false},
+		{Name: "API key only", Cfg: groq.TTSConfig{APIKey: "k"}, Valid: true},
+	})
+}
+
+// TestNewServices checks each constructor returns a service under the label
+// that identifies it in logs, metrics and traces.
+func TestNewServices(t *testing.T) {
+	providertest.Service(t, "GroqSTT", groq.NewSTT(groq.STTConfig{APIKey: "k"}))
+	providertest.Service(t, "GroqTTS", groq.NewTTS(groq.TTSConfig{APIKey: "k"}))
+}
+
+// TestNewLLM checks the Groq OpenAI-compatible LLM shim wires the right
+// service name and default model into the shared client.
+func TestNewLLM(t *testing.T) {
+	providertest.CompatLLM(t, "GroqLLM", "llama-3.3-70b-versatile", groq.NewLLM)
+}

--- a/provider/hume/hume_config_test.go
+++ b/provider/hume/hume_config_test.go
@@ -1,0 +1,22 @@
+package hume_test
+
+import (
+	"testing"
+
+	"github.com/gojargo/jargo/internal/providertest"
+	"github.com/gojargo/jargo/provider/hume"
+)
+
+// TestConfigValidate pins which Config fields the provider requires.
+func TestConfigValidate(t *testing.T) {
+	providertest.Configs(t, []providertest.ConfigCase{
+		{Name: "missing API key", Cfg: hume.Config{}, Valid: false},
+		{Name: "API key only", Cfg: hume.Config{APIKey: "k"}, Valid: true},
+	})
+}
+
+// TestNewServices checks each constructor returns a service under the label
+// that identifies it in logs, metrics and traces.
+func TestNewServices(t *testing.T) {
+	providertest.Service(t, "HumeTTS", hume.NewTTS(hume.Config{APIKey: "k"}))
+}

--- a/provider/inception/inception_test.go
+++ b/provider/inception/inception_test.go
@@ -1,0 +1,14 @@
+package inception_test
+
+import (
+	"testing"
+
+	"github.com/gojargo/jargo/internal/providertest"
+	"github.com/gojargo/jargo/provider/inception"
+)
+
+// TestNewLLM checks the Inception shim wires the right service name and
+// default model into the shared OpenAI-compatible client.
+func TestNewLLM(t *testing.T) {
+	providertest.CompatLLM(t, "InceptionLLM", "mercury-2", inception.NewLLM)
+}

--- a/provider/inworld/inworld_config_test.go
+++ b/provider/inworld/inworld_config_test.go
@@ -1,0 +1,22 @@
+package inworld_test
+
+import (
+	"testing"
+
+	"github.com/gojargo/jargo/internal/providertest"
+	"github.com/gojargo/jargo/provider/inworld"
+)
+
+// TestConfigValidate pins which Config fields the provider requires.
+func TestConfigValidate(t *testing.T) {
+	providertest.Configs(t, []providertest.ConfigCase{
+		{Name: "missing API key", Cfg: inworld.Config{}, Valid: false},
+		{Name: "API key only", Cfg: inworld.Config{APIKey: "k"}, Valid: true},
+	})
+}
+
+// TestNewServices checks each constructor returns a service under the label
+// that identifies it in logs, metrics and traces.
+func TestNewServices(t *testing.T) {
+	providertest.Service(t, "InworldTTS", inworld.NewTTS(inworld.Config{APIKey: "k"}))
+}

--- a/provider/lmnt/lmnt_config_test.go
+++ b/provider/lmnt/lmnt_config_test.go
@@ -1,0 +1,22 @@
+package lmnt_test
+
+import (
+	"testing"
+
+	"github.com/gojargo/jargo/internal/providertest"
+	"github.com/gojargo/jargo/provider/lmnt"
+)
+
+// TestConfigValidate pins which Config fields the provider requires.
+func TestConfigValidate(t *testing.T) {
+	providertest.Configs(t, []providertest.ConfigCase{
+		{Name: "missing API key", Cfg: lmnt.Config{}, Valid: false},
+		{Name: "API key only", Cfg: lmnt.Config{APIKey: "k"}, Valid: true},
+	})
+}
+
+// TestNewServices checks each constructor returns a service under the label
+// that identifies it in logs, metrics and traces.
+func TestNewServices(t *testing.T) {
+	providertest.Service(t, "LMNTTTS", lmnt.NewTTS(lmnt.Config{APIKey: "k"}))
+}

--- a/provider/minimax/minimax_config_test.go
+++ b/provider/minimax/minimax_config_test.go
@@ -1,0 +1,24 @@
+package minimax_test
+
+import (
+	"testing"
+
+	"github.com/gojargo/jargo/internal/providertest"
+	"github.com/gojargo/jargo/provider/minimax"
+)
+
+// TestConfigValidate pins which Config fields the provider requires.
+func TestConfigValidate(t *testing.T) {
+	providertest.Configs(t, []providertest.ConfigCase{
+		{Name: "empty", Cfg: minimax.Config{}, Valid: false},
+		{Name: "missing group id", Cfg: minimax.Config{APIKey: "k"}, Valid: false},
+		{Name: "missing API key", Cfg: minimax.Config{GroupID: "g"}, Valid: false},
+		{Name: "both credentials", Cfg: minimax.Config{APIKey: "k", GroupID: "g"}, Valid: true},
+	})
+}
+
+// TestNewServices checks each constructor returns a service under the label
+// that identifies it in logs, metrics and traces.
+func TestNewServices(t *testing.T) {
+	providertest.Service(t, "MiniMaxTTS", minimax.NewTTS(minimax.Config{APIKey: "k", GroupID: "g"}))
+}

--- a/provider/mistral/mistral_config_test.go
+++ b/provider/mistral/mistral_config_test.go
@@ -1,0 +1,37 @@
+package mistral_test
+
+import (
+	"testing"
+
+	"github.com/gojargo/jargo/internal/providertest"
+	"github.com/gojargo/jargo/provider/mistral"
+)
+
+// TestConfigValidateSTT pins which STTConfig fields the provider requires.
+func TestConfigValidateSTT(t *testing.T) {
+	providertest.Configs(t, []providertest.ConfigCase{
+		{Name: "missing API key", Cfg: mistral.STTConfig{}, Valid: false},
+		{Name: "API key only", Cfg: mistral.STTConfig{APIKey: "k"}, Valid: true},
+	})
+}
+
+// TestConfigValidateTTS pins which TTSConfig fields the provider requires.
+func TestConfigValidateTTS(t *testing.T) {
+	providertest.Configs(t, []providertest.ConfigCase{
+		{Name: "missing API key", Cfg: mistral.TTSConfig{}, Valid: false},
+		{Name: "API key only", Cfg: mistral.TTSConfig{APIKey: "k"}, Valid: true},
+	})
+}
+
+// TestNewServices checks each constructor returns a service under the label
+// that identifies it in logs, metrics and traces.
+func TestNewServices(t *testing.T) {
+	providertest.Service(t, "MistralSTT", mistral.NewSTT(mistral.STTConfig{APIKey: "k"}))
+	providertest.Service(t, "MistralTTS", mistral.NewTTS(mistral.TTSConfig{APIKey: "k"}))
+}
+
+// TestNewLLM checks the Mistral OpenAI-compatible LLM shim wires the right
+// service name and default model into the shared client.
+func TestNewLLM(t *testing.T) {
+	providertest.CompatLLM(t, "MistralLLM", "mistral-small-latest", mistral.NewLLM)
+}

--- a/provider/nebius/nebius_test.go
+++ b/provider/nebius/nebius_test.go
@@ -1,0 +1,14 @@
+package nebius_test
+
+import (
+	"testing"
+
+	"github.com/gojargo/jargo/internal/providertest"
+	"github.com/gojargo/jargo/provider/nebius"
+)
+
+// TestNewLLM checks the Nebius AI Studio shim wires the right service name and
+// default model into the shared OpenAI-compatible client.
+func TestNewLLM(t *testing.T) {
+	providertest.CompatLLM(t, "NebiusLLM", "meta-llama/Llama-3.3-70B-Instruct", nebius.NewLLM)
+}

--- a/provider/neuphonic/neuphonic_config_test.go
+++ b/provider/neuphonic/neuphonic_config_test.go
@@ -1,0 +1,22 @@
+package neuphonic_test
+
+import (
+	"testing"
+
+	"github.com/gojargo/jargo/internal/providertest"
+	"github.com/gojargo/jargo/provider/neuphonic"
+)
+
+// TestConfigValidate pins which Config fields the provider requires.
+func TestConfigValidate(t *testing.T) {
+	providertest.Configs(t, []providertest.ConfigCase{
+		{Name: "missing API key", Cfg: neuphonic.Config{}, Valid: false},
+		{Name: "API key only", Cfg: neuphonic.Config{APIKey: "k"}, Valid: true},
+	})
+}
+
+// TestNewServices checks each constructor returns a service under the label
+// that identifies it in logs, metrics and traces.
+func TestNewServices(t *testing.T) {
+	providertest.Service(t, "NeuphonicTTS", neuphonic.NewTTS(neuphonic.Config{APIKey: "k"}))
+}

--- a/provider/novasonic/novasonic_config_test.go
+++ b/provider/novasonic/novasonic_config_test.go
@@ -1,0 +1,26 @@
+package novasonic_test
+
+import (
+	"testing"
+
+	"github.com/gojargo/jargo/internal/providertest"
+	"github.com/gojargo/jargo/provider/novasonic"
+)
+
+// TestConfigValidate pins which Config fields the provider requires.
+func TestConfigValidate(t *testing.T) {
+	providertest.Configs(t, []providertest.ConfigCase{
+		{Name: "empty config falls back to the AWS credential chain", Cfg: novasonic.Config{}, Valid: true},
+		{
+			Name:  "static credentials",
+			Cfg:   novasonic.Config{Region: "us-east-1", AccessKeyID: "id", SecretAccessKey: "secret"},
+			Valid: true,
+		},
+	})
+}
+
+// TestNewServices checks each constructor returns a service under the label
+// that identifies it in logs, metrics and traces.
+func TestNewServices(t *testing.T) {
+	providertest.Service(t, "NovaSonic", novasonic.New(novasonic.Config{}))
+}

--- a/provider/novita/novita_test.go
+++ b/provider/novita/novita_test.go
@@ -1,0 +1,14 @@
+package novita_test
+
+import (
+	"testing"
+
+	"github.com/gojargo/jargo/internal/providertest"
+	"github.com/gojargo/jargo/provider/novita"
+)
+
+// TestNewLLM checks the Novita AI shim wires the right service name and
+// default model into the shared OpenAI-compatible client.
+func TestNewLLM(t *testing.T) {
+	providertest.CompatLLM(t, "NovitaLLM", "moonshotai/kimi-k2.5", novita.NewLLM)
+}

--- a/provider/ollama/ollama_test.go
+++ b/provider/ollama/ollama_test.go
@@ -1,0 +1,14 @@
+package ollama_test
+
+import (
+	"testing"
+
+	"github.com/gojargo/jargo/internal/providertest"
+	"github.com/gojargo/jargo/provider/ollama"
+)
+
+// TestNewLLM checks the Ollama shim wires the right service name and
+// default model into the shared OpenAI-compatible client.
+func TestNewLLM(t *testing.T) {
+	providertest.CompatLLM(t, "OllamaLLM", "llama2", ollama.NewLLM)
+}

--- a/provider/openrouter/openrouter_test.go
+++ b/provider/openrouter/openrouter_test.go
@@ -1,0 +1,14 @@
+package openrouter_test
+
+import (
+	"testing"
+
+	"github.com/gojargo/jargo/internal/providertest"
+	"github.com/gojargo/jargo/provider/openrouter"
+)
+
+// TestNewLLM checks the OpenRouter shim wires the right service name and
+// default model into the shared OpenAI-compatible client.
+func TestNewLLM(t *testing.T) {
+	providertest.CompatLLM(t, "OpenRouterLLM", "openai/gpt-4.1", openrouter.NewLLM)
+}

--- a/provider/perplexity/perplexity_test.go
+++ b/provider/perplexity/perplexity_test.go
@@ -1,0 +1,14 @@
+package perplexity_test
+
+import (
+	"testing"
+
+	"github.com/gojargo/jargo/internal/providertest"
+	"github.com/gojargo/jargo/provider/perplexity"
+)
+
+// TestNewLLM checks the Perplexity shim wires the right service name and
+// default model into the shared OpenAI-compatible client.
+func TestNewLLM(t *testing.T) {
+	providertest.CompatLLM(t, "PerplexityLLM", "sonar", perplexity.NewLLM)
+}

--- a/provider/polly/polly_config_test.go
+++ b/provider/polly/polly_config_test.go
@@ -1,0 +1,25 @@
+package polly_test
+
+import (
+	"testing"
+
+	"github.com/gojargo/jargo/internal/providertest"
+	"github.com/gojargo/jargo/provider/polly"
+)
+
+// TestConfigValidate pins which Config fields the provider requires.
+func TestConfigValidate(t *testing.T) {
+	providertest.Configs(t, []providertest.ConfigCase{
+		{Name: "empty config falls back to the AWS credential chain", Cfg: polly.Config{}, Valid: true},
+		{Name: "known engine", Cfg: polly.Config{Engine: "generative"}, Valid: true},
+		{Name: "unknown engine", Cfg: polly.Config{Engine: "experimental"}, Valid: false},
+		{Name: "supported PCM rate", Cfg: polly.Config{SampleRate: 16000}, Valid: true},
+		{Name: "unsupported PCM rate", Cfg: polly.Config{SampleRate: 24000}, Valid: false},
+	})
+}
+
+// TestNewServices checks each constructor returns a service under the label
+// that identifies it in logs, metrics and traces.
+func TestNewServices(t *testing.T) {
+	providertest.Service(t, "PollyTTS", polly.NewTTS(polly.Config{}))
+}

--- a/provider/qwen/qwen_test.go
+++ b/provider/qwen/qwen_test.go
@@ -1,0 +1,14 @@
+package qwen_test
+
+import (
+	"testing"
+
+	"github.com/gojargo/jargo/internal/providertest"
+	"github.com/gojargo/jargo/provider/qwen"
+)
+
+// TestNewLLM checks the Qwen (DashScope) shim wires the right service name and
+// default model into the shared OpenAI-compatible client.
+func TestNewLLM(t *testing.T) {
+	providertest.CompatLLM(t, "QwenLLM", "qwen-plus", qwen.NewLLM)
+}

--- a/provider/rime/rime_config_test.go
+++ b/provider/rime/rime_config_test.go
@@ -1,0 +1,22 @@
+package rime_test
+
+import (
+	"testing"
+
+	"github.com/gojargo/jargo/internal/providertest"
+	"github.com/gojargo/jargo/provider/rime"
+)
+
+// TestConfigValidate pins which Config fields the provider requires.
+func TestConfigValidate(t *testing.T) {
+	providertest.Configs(t, []providertest.ConfigCase{
+		{Name: "missing API key", Cfg: rime.Config{}, Valid: false},
+		{Name: "API key only", Cfg: rime.Config{APIKey: "k"}, Valid: true},
+	})
+}
+
+// TestNewServices checks each constructor returns a service under the label
+// that identifies it in logs, metrics and traces.
+func TestNewServices(t *testing.T) {
+	providertest.Service(t, "RimeTTS", rime.NewTTS(rime.Config{APIKey: "k"}))
+}

--- a/provider/sambanova/sambanova_test.go
+++ b/provider/sambanova/sambanova_test.go
@@ -1,0 +1,14 @@
+package sambanova_test
+
+import (
+	"testing"
+
+	"github.com/gojargo/jargo/internal/providertest"
+	"github.com/gojargo/jargo/provider/sambanova"
+)
+
+// TestNewLLM checks the SambaNova Cloud shim wires the right service name and
+// default model into the shared OpenAI-compatible client.
+func TestNewLLM(t *testing.T) {
+	providertest.CompatLLM(t, "SambaNovaLLM", "Meta-Llama-3.3-70B-Instruct", sambanova.NewLLM)
+}

--- a/provider/sarvam/sarvam_config_test.go
+++ b/provider/sarvam/sarvam_config_test.go
@@ -1,0 +1,43 @@
+package sarvam_test
+
+import (
+	"testing"
+
+	"github.com/gojargo/jargo/internal/providertest"
+	"github.com/gojargo/jargo/provider/sarvam"
+)
+
+// TestConfigValidateSTT pins which STTConfig fields the provider requires.
+func TestConfigValidateSTT(t *testing.T) {
+	providertest.Configs(t, []providertest.ConfigCase{
+		{Name: "missing API key", Cfg: sarvam.STTConfig{}, Valid: false},
+		{Name: "API key only", Cfg: sarvam.STTConfig{APIKey: "k"}, Valid: true},
+		{Name: "known model", Cfg: sarvam.STTConfig{APIKey: "k", Model: "saaras:v3"}, Valid: true},
+		{Name: "unknown model", Cfg: sarvam.STTConfig{APIKey: "k", Model: "saaras:v9"}, Valid: false},
+		{Name: "known mode", Cfg: sarvam.STTConfig{APIKey: "k", Mode: "translate"}, Valid: true},
+		{Name: "unknown mode", Cfg: sarvam.STTConfig{APIKey: "k", Mode: "paraphrase"}, Valid: false},
+	})
+}
+
+// TestConfigValidateTTS pins which TTSConfig fields the provider requires.
+func TestConfigValidateTTS(t *testing.T) {
+	providertest.Configs(t, []providertest.ConfigCase{
+		{Name: "missing API key", Cfg: sarvam.TTSConfig{}, Valid: false},
+		{Name: "API key only", Cfg: sarvam.TTSConfig{APIKey: "k"}, Valid: true},
+		{Name: "known model", Cfg: sarvam.TTSConfig{APIKey: "k", Model: "bulbul:v3"}, Valid: true},
+		{Name: "unknown model", Cfg: sarvam.TTSConfig{APIKey: "k", Model: "bulbul:v9"}, Valid: false},
+	})
+}
+
+// TestNewServices checks each constructor returns a service under the label
+// that identifies it in logs, metrics and traces.
+func TestNewServices(t *testing.T) {
+	providertest.Service(t, "SarvamSTT", sarvam.NewSTT(sarvam.STTConfig{APIKey: "k"}))
+	providertest.Service(t, "SarvamTTS", sarvam.NewTTS(sarvam.TTSConfig{APIKey: "k"}))
+}
+
+// TestNewLLM checks the Sarvam OpenAI-compatible LLM shim wires the right
+// service name and default model into the shared client.
+func TestNewLLM(t *testing.T) {
+	providertest.CompatLLM(t, "SarvamLLM", "sarvam-30b", sarvam.NewLLM)
+}

--- a/provider/soniox/soniox_config_test.go
+++ b/provider/soniox/soniox_config_test.go
@@ -1,0 +1,22 @@
+package soniox_test
+
+import (
+	"testing"
+
+	"github.com/gojargo/jargo/internal/providertest"
+	"github.com/gojargo/jargo/provider/soniox"
+)
+
+// TestConfigValidate pins which Config fields the provider requires.
+func TestConfigValidate(t *testing.T) {
+	providertest.Configs(t, []providertest.ConfigCase{
+		{Name: "missing API key", Cfg: soniox.Config{}, Valid: false},
+		{Name: "API key only", Cfg: soniox.Config{APIKey: "k"}, Valid: true},
+	})
+}
+
+// TestNewServices checks each constructor returns a service under the label
+// that identifies it in logs, metrics and traces.
+func TestNewServices(t *testing.T) {
+	providertest.Service(t, "SonioxSTT", soniox.NewSTT(soniox.Config{APIKey: "k"}))
+}

--- a/provider/speechmatics/speechmatics_config_test.go
+++ b/provider/speechmatics/speechmatics_config_test.go
@@ -1,0 +1,31 @@
+package speechmatics_test
+
+import (
+	"testing"
+
+	"github.com/gojargo/jargo/internal/providertest"
+	"github.com/gojargo/jargo/provider/speechmatics"
+)
+
+// TestConfigValidateSTT pins which Config fields the provider requires.
+func TestConfigValidateSTT(t *testing.T) {
+	providertest.Configs(t, []providertest.ConfigCase{
+		{Name: "missing API key", Cfg: speechmatics.Config{}, Valid: false},
+		{Name: "API key only", Cfg: speechmatics.Config{APIKey: "k"}, Valid: true},
+	})
+}
+
+// TestConfigValidateTTS pins which TTSConfig fields the provider requires.
+func TestConfigValidateTTS(t *testing.T) {
+	providertest.Configs(t, []providertest.ConfigCase{
+		{Name: "missing API key", Cfg: speechmatics.TTSConfig{}, Valid: false},
+		{Name: "API key only", Cfg: speechmatics.TTSConfig{APIKey: "k"}, Valid: true},
+	})
+}
+
+// TestNewServices checks each constructor returns a service under the label
+// that identifies it in logs, metrics and traces.
+func TestNewServices(t *testing.T) {
+	providertest.Service(t, "SpeechmaticsSTT", speechmatics.NewSTT(speechmatics.Config{APIKey: "k"}))
+	providertest.Service(t, "SpeechmaticsTTS", speechmatics.NewTTS(speechmatics.TTSConfig{APIKey: "k"}))
+}

--- a/provider/together/together_config_test.go
+++ b/provider/together/together_config_test.go
@@ -1,0 +1,37 @@
+package together_test
+
+import (
+	"testing"
+
+	"github.com/gojargo/jargo/internal/providertest"
+	"github.com/gojargo/jargo/provider/together"
+)
+
+// TestConfigValidateSTT pins which STTConfig fields the provider requires.
+func TestConfigValidateSTT(t *testing.T) {
+	providertest.Configs(t, []providertest.ConfigCase{
+		{Name: "missing API key", Cfg: together.STTConfig{}, Valid: false},
+		{Name: "API key only", Cfg: together.STTConfig{APIKey: "k"}, Valid: true},
+	})
+}
+
+// TestConfigValidateTTS pins which TTSConfig fields the provider requires.
+func TestConfigValidateTTS(t *testing.T) {
+	providertest.Configs(t, []providertest.ConfigCase{
+		{Name: "missing API key", Cfg: together.TTSConfig{}, Valid: false},
+		{Name: "API key only", Cfg: together.TTSConfig{APIKey: "k"}, Valid: true},
+	})
+}
+
+// TestNewServices checks each constructor returns a service under the label
+// that identifies it in logs, metrics and traces.
+func TestNewServices(t *testing.T) {
+	providertest.Service(t, "TogetherSTT", together.NewSTT(together.STTConfig{APIKey: "k"}))
+	providertest.Service(t, "TogetherTTS", together.NewTTS(together.TTSConfig{APIKey: "k"}))
+}
+
+// TestNewLLM checks the Together AI OpenAI-compatible LLM shim wires the right
+// service name and default model into the shared client.
+func TestNewLLM(t *testing.T) {
+	providertest.CompatLLM(t, "TogetherLLM", "zai-org/GLM-5.1", together.NewLLM)
+}

--- a/provider/transcribe/transcribe_config_test.go
+++ b/provider/transcribe/transcribe_config_test.go
@@ -1,0 +1,28 @@
+package transcribe_test
+
+import (
+	"testing"
+
+	"github.com/gojargo/jargo/internal/providertest"
+	"github.com/gojargo/jargo/provider/transcribe"
+)
+
+// TestConfigValidate pins which Config fields the provider requires.
+func TestConfigValidate(t *testing.T) {
+	providertest.Configs(t, []providertest.ConfigCase{
+		{Name: "empty config falls back to the AWS credential chain", Cfg: transcribe.Config{}, Valid: true},
+		{
+			Name:  "static credentials",
+			Cfg:   transcribe.Config{Region: "us-east-1", AccessKeyID: "id", SecretAccessKey: "secret"},
+			Valid: true,
+		},
+		{Name: "known stability level", Cfg: transcribe.Config{PartialResultsStability: "medium"}, Valid: true},
+		{Name: "unknown stability level", Cfg: transcribe.Config{PartialResultsStability: "highest"}, Valid: false},
+	})
+}
+
+// TestNewServices checks each constructor returns a service under the label
+// that identifies it in logs, metrics and traces.
+func TestNewServices(t *testing.T) {
+	providertest.Service(t, "TranscribeSTT", transcribe.NewSTT(transcribe.Config{}))
+}

--- a/provider/xai/xai_test.go
+++ b/provider/xai/xai_test.go
@@ -1,0 +1,14 @@
+package xai_test
+
+import (
+	"testing"
+
+	"github.com/gojargo/jargo/internal/providertest"
+	"github.com/gojargo/jargo/provider/xai"
+)
+
+// TestNewLLM checks the xAI (Grok) shim wires the right service name and
+// default model into the shared OpenAI-compatible client.
+func TestNewLLM(t *testing.T) {
+	providertest.CompatLLM(t, "XAILLM", "grok-4.20-non-reasoning", xai.NewLLM)
+}

--- a/service/wsutil/wsutil_test.go
+++ b/service/wsutil/wsutil_test.go
@@ -1,0 +1,141 @@
+package wsutil_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/coder/websocket"
+	"github.com/gojargo/jargo/service/wsutil"
+)
+
+// wsURL turns an httptest server URL into a WebSocket one.
+func wsURL(srv *httptest.Server) string {
+	return "ws" + strings.TrimPrefix(srv.URL, "http")
+}
+
+// echoServer accepts a WebSocket and echoes each message back, recording the
+// headers of the handshake request.
+func echoServer(t *testing.T, got *http.Header) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got != nil {
+			*got = r.Header.Clone()
+		}
+		c, err := websocket.Accept(w, r, &websocket.AcceptOptions{OriginPatterns: []string{"*"}})
+		if err != nil {
+			return
+		}
+		defer func() { _ = c.CloseNow() }()
+		for {
+			typ, data, err := c.Read(r.Context())
+			if err != nil {
+				return
+			}
+			if err := c.Write(r.Context(), typ, data); err != nil {
+				return
+			}
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestDialSendsHeaders checks the vendor headers a provider supplies — in
+// practice its API key — reach the handshake.
+func TestDialSendsHeaders(t *testing.T) {
+	var seen http.Header
+	srv := echoServer(t, &seen)
+
+	h := http.Header{}
+	h.Set("Authorization", "Token secret")
+	conn, err := wsutil.Dial(t.Context(), wsURL(srv), h, 0)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer func() { _ = conn.CloseNow() }()
+
+	if got := seen.Get("Authorization"); got != "Token secret" {
+		t.Errorf("Authorization = %q, want the supplied header", got)
+	}
+}
+
+// TestDialRoundTrip checks the returned connection is usable.
+func TestDialRoundTrip(t *testing.T) {
+	srv := echoServer(t, nil)
+
+	conn, err := wsutil.Dial(t.Context(), wsURL(srv), nil, wsutil.DefaultReadLimit)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer func() { _ = conn.CloseNow() }()
+
+	if err := conn.Write(t.Context(), websocket.MessageText, []byte("ping")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, data, err := conn.Read(t.Context())
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(data) != "ping" {
+		t.Errorf("echo = %q, want %q", data, "ping")
+	}
+}
+
+// TestDialAppliesReadLimit checks a positive limit is enforced, so a vendor
+// cannot exhaust memory with an oversized message.
+func TestDialAppliesReadLimit(t *testing.T) {
+	srv := echoServer(t, nil)
+
+	conn, err := wsutil.Dial(t.Context(), wsURL(srv), nil, 16)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer func() { _ = conn.CloseNow() }()
+
+	if err := conn.Write(t.Context(), websocket.MessageText, make([]byte, 64)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, _, err := conn.Read(t.Context()); err == nil {
+		t.Error("reading a message past the limit should fail")
+	}
+}
+
+// TestDialZeroReadLimitLeavesDefault checks a non-positive limit is not applied,
+// leaving the library default in place rather than pinning it to zero.
+func TestDialZeroReadLimitLeavesDefault(t *testing.T) {
+	srv := echoServer(t, nil)
+
+	conn, err := wsutil.Dial(t.Context(), wsURL(srv), nil, 0)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer func() { _ = conn.CloseNow() }()
+
+	if err := conn.Write(t.Context(), websocket.MessageText, make([]byte, 4096)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, _, err := conn.Read(t.Context()); err != nil {
+		t.Errorf("read: %v; a zero limit should not restrict message size", err)
+	}
+}
+
+// TestDialFailure checks a failed handshake reports the error and no connection,
+// rather than a half-open one.
+func TestDialFailure(t *testing.T) {
+	// A plain HTTP handler never upgrades, so the handshake fails.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	conn, err := wsutil.Dial(t.Context(), wsURL(srv), nil, 0)
+	if err == nil {
+		_ = conn.CloseNow()
+		t.Fatal("Dial succeeded against a non-WebSocket endpoint, want an error")
+	}
+	if conn != nil {
+		t.Error("Dial returned a connection alongside an error")
+	}
+}

--- a/transport/wsserver/twilio/twilio_test.go
+++ b/transport/wsserver/twilio/twilio_test.go
@@ -1,0 +1,355 @@
+package twilio
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/gojargo/jargo/audio/g711"
+	"github.com/gojargo/jargo/frames"
+)
+
+// pcm builds a deterministic 16-bit PCM buffer to push through the codec.
+func pcm() []byte {
+	b := make([]byte, 160*2)
+	for i := range b {
+		b[i] = byte(i)
+	}
+	return b
+}
+
+// startMsg is the handshake that teaches the serializer both SIDs.
+const startMsg = `{"event":"start","start":{"streamSid":"stream-1","callSid":"call-1"}}`
+
+// started returns a serializer that has seen the "start" message.
+func started(t *testing.T, cfg Config) *Serializer {
+	t.Helper()
+	s := New(cfg)
+	f, err := s.Deserialize([]byte(startMsg))
+	if err != nil {
+		t.Fatalf("deserialize start: %v", err)
+	}
+	if f != nil {
+		t.Errorf("start message should carry no frame, got %T", f)
+	}
+	return s
+}
+
+func TestSetup(t *testing.T) {
+	// Twilio audio is always 8 kHz, so Setup has nothing to negotiate.
+	if err := New(Config{}).Setup(frames.NewStartFrame()); err != nil {
+		t.Errorf("Setup: %v", err)
+	}
+}
+
+func TestDeserializeMediaDecodesULaw(t *testing.T) {
+	s := New(Config{})
+	ulaw := g711.EncodeULaw(pcm())
+	payload := base64.StdEncoding.EncodeToString(ulaw)
+
+	f, err := s.Deserialize([]byte(`{"event":"media","media":{"payload":"` + payload + `"}}`))
+	if err != nil {
+		t.Fatalf("deserialize media: %v", err)
+	}
+	af, ok := f.(*frames.InputAudioRawFrame)
+	if !ok {
+		t.Fatalf("media frame type = %T, want *frames.InputAudioRawFrame", f)
+	}
+	if af.SampleRate != sampleRate {
+		t.Errorf("sample rate = %d, want %d", af.SampleRate, sampleRate)
+	}
+	if af.NumChannels != 1 {
+		t.Errorf("channels = %d, want 1", af.NumChannels)
+	}
+	// μ-law is lossy, so the check is against the codec, not the original PCM.
+	if !bytes.Equal(af.Audio, g711.DecodeULaw(ulaw)) {
+		t.Error("audio was not μ-law decoded")
+	}
+}
+
+func TestDeserializeMediaBadBase64(t *testing.T) {
+	if _, err := New(Config{}).Deserialize([]byte(`{"event":"media","media":{"payload":"!!not base64!!"}}`)); err == nil {
+		t.Error("want an error for an undecodable payload")
+	}
+}
+
+func TestDeserializeMalformedJSON(t *testing.T) {
+	if _, err := New(Config{}).Deserialize([]byte(`{`)); err == nil {
+		t.Error("want an error for malformed JSON")
+	}
+}
+
+func TestDeserializeDTMF(t *testing.T) {
+	tests := []struct {
+		name  string
+		msg   string
+		want  frames.KeypadEntry
+		frame bool
+	}{
+		{"digit", `{"event":"dtmf","dtmf":{"digit":"5"}}`, frames.KeypadFive, true},
+		{"pound", `{"event":"dtmf","dtmf":{"digit":"#"}}`, frames.KeypadPound, true},
+		{"empty keypress is dropped", `{"event":"dtmf","dtmf":{"digit":""}}`, "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, err := New(Config{}).Deserialize([]byte(tt.msg))
+			if err != nil {
+				t.Fatalf("deserialize dtmf: %v", err)
+			}
+			if !tt.frame {
+				if f != nil {
+					t.Errorf("want no frame, got %T", f)
+				}
+				return
+			}
+			df, ok := f.(*frames.InputDTMFFrame)
+			if !ok {
+				t.Fatalf("frame type = %T, want *frames.InputDTMFFrame", f)
+			}
+			if df.Button != tt.want {
+				t.Errorf("button = %q, want %q", df.Button, tt.want)
+			}
+		})
+	}
+}
+
+// TestDeserializeIgnoredEvents covers the messages Twilio sends that carry no
+// audio or input.
+func TestDeserializeIgnoredEvents(t *testing.T) {
+	for _, msg := range []string{
+		`{"event":"connected"}`,
+		`{"event":"mark"}`,
+		`{"event":"stop"}`,
+	} {
+		f, err := New(Config{}).Deserialize([]byte(msg))
+		if err != nil {
+			t.Errorf("deserialize %s: %v", msg, err)
+		}
+		if f != nil {
+			t.Errorf("deserialize %s produced %T, want no frame", msg, f)
+		}
+	}
+}
+
+func TestSerializeAudio(t *testing.T) {
+	tests := []struct {
+		name  string
+		frame frames.Frame
+	}{
+		{"tts audio", frames.NewTTSAudioRawFrame(pcm(), sampleRate, 1)},
+		{"output audio", frames.NewOutputAudioRawFrame(pcm(), sampleRate, 1)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := started(t, Config{})
+			msg, err := s.Serialize(tt.frame)
+			if err != nil {
+				t.Fatalf("serialize: %v", err)
+			}
+			var out mediaOut
+			if err := json.Unmarshal(msg, &out); err != nil {
+				t.Fatalf("unmarshal media: %v", err)
+			}
+			if out.Event != "media" {
+				t.Errorf("event = %q, want media", out.Event)
+			}
+			if out.StreamSID != "stream-1" {
+				t.Errorf("streamSid = %q, want the SID from the start message", out.StreamSID)
+			}
+			raw, err := base64.StdEncoding.DecodeString(out.Media.Payload)
+			if err != nil {
+				t.Fatalf("decode payload: %v", err)
+			}
+			if !bytes.Equal(raw, g711.EncodeULaw(pcm())) {
+				t.Error("payload was not μ-law encoded")
+			}
+		})
+	}
+}
+
+// TestSerializeBeforeStart checks audio and clears are dropped until the start
+// message supplies a stream SID, since Twilio rejects messages without one.
+func TestSerializeBeforeStart(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		frame frames.Frame
+	}{
+		{"audio", frames.NewTTSAudioRawFrame(pcm(), sampleRate, 1)},
+		{"interruption", frames.NewInterruptionFrame()},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			msg, err := New(Config{}).Serialize(tt.frame)
+			if err != nil {
+				t.Fatalf("serialize: %v", err)
+			}
+			if msg != nil {
+				t.Errorf("want the frame dropped before start, got %q", msg)
+			}
+		})
+	}
+}
+
+func TestSerializeInterruption(t *testing.T) {
+	s := started(t, Config{})
+	msg, err := s.Serialize(frames.NewInterruptionFrame())
+	if err != nil {
+		t.Fatalf("serialize interruption: %v", err)
+	}
+	var out clearOut
+	if err := json.Unmarshal(msg, &out); err != nil {
+		t.Fatalf("unmarshal clear: %v", err)
+	}
+	if out.Event != "clear" || out.StreamSID != "stream-1" {
+		t.Errorf("clear = %+v, want a clear for stream-1", out)
+	}
+}
+
+// TestSerializeUnhandledFrame checks frames Twilio has no representation for are
+// silently skipped rather than erroring the connection.
+func TestSerializeUnhandledFrame(t *testing.T) {
+	s := started(t, Config{})
+	msg, err := s.Serialize(frames.NewUserSpeakingFrame())
+	if err != nil {
+		t.Fatalf("serialize: %v", err)
+	}
+	if msg != nil {
+		t.Errorf("want no wire message, got %q", msg)
+	}
+}
+
+// hangupServer stands in for Twilio's REST API and reports each hang-up it
+// receives.
+func hangupServer(t *testing.T) (*httptest.Server, chan *http.Request) {
+	t.Helper()
+	got := make(chan *http.Request, 4)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("parse hang-up form: %v", err)
+		}
+		got <- r
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, got
+}
+
+// redirectToServer rewrites Twilio's REST host to the test server, since the
+// endpoint is built from a package constant.
+func redirectToServer(srv *httptest.Server) *http.Client {
+	return &http.Client{
+		Transport: rewriteHost{target: srv.URL, base: srv.Client().Transport},
+	}
+}
+
+type rewriteHost struct {
+	target string
+	base   http.RoundTripper
+}
+
+func (r rewriteHost) RoundTrip(req *http.Request) (*http.Response, error) {
+	u, err := url.Parse(r.target)
+	if err != nil {
+		return nil, err
+	}
+	req = req.Clone(req.Context())
+	req.URL.Scheme, req.URL.Host, req.Host = u.Scheme, u.Host, u.Host
+	return r.base.RoundTrip(req)
+}
+
+// TestAutoHangUp checks the REST hang-up: it targets the call SID learned from
+// the start message, authorizes with the account credentials, and fires once.
+func TestAutoHangUp(t *testing.T) {
+	srv, got := hangupServer(t)
+	s := started(t, Config{
+		AccountSID: "AC123",
+		AuthToken:  "token",
+		AutoHangUp: true,
+		HTTPClient: redirectToServer(srv),
+	})
+
+	if _, err := s.Serialize(frames.NewEndFrame()); err != nil {
+		t.Fatalf("serialize end: %v", err)
+	}
+
+	var req *http.Request
+	select {
+	case req = <-got:
+	case <-time.After(2 * time.Second):
+		t.Fatal("no hang-up request arrived")
+	}
+
+	if req.Method != http.MethodPost {
+		t.Errorf("method = %s, want POST", req.Method)
+	}
+	if want := "/2010-04-01/Accounts/AC123/Calls/call-1.json"; req.URL.Path != want {
+		t.Errorf("path = %q, want %q", req.URL.Path, want)
+	}
+	user, pass, ok := req.BasicAuth()
+	if !ok || user != "AC123" || pass != "token" {
+		t.Errorf("basic auth = (%q, %q, %v), want the account credentials", user, pass, ok)
+	}
+	if got := req.PostFormValue("Status"); got != "completed" {
+		t.Errorf("Status = %q, want completed", got)
+	}
+
+	// A CancelFrame after the EndFrame must not hang the call up twice.
+	if _, err := s.Serialize(frames.NewCancelFrame()); err != nil {
+		t.Fatalf("serialize cancel: %v", err)
+	}
+	select {
+	case <-got:
+		t.Error("hang-up fired twice")
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+// TestAutoHangUpSkipped covers every reason the serializer declines to call the
+// REST API. Each must be silent rather than an error, because the pipeline is
+// already shutting down.
+func TestAutoHangUpSkipped(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      Config
+		sawStart bool // whether the start message (and so the call SID) arrived
+	}{
+		{"disabled", Config{AccountSID: "AC123", AuthToken: "token"}, true},
+		{"no account SID", Config{AuthToken: "token", AutoHangUp: true}, true},
+		{"no auth token", Config{AccountSID: "AC123", AutoHangUp: true}, true},
+		{"no call SID", Config{AccountSID: "AC123", AuthToken: "token", AutoHangUp: true}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv, got := hangupServer(t)
+			cfg := tt.cfg
+			cfg.HTTPClient = redirectToServer(srv)
+
+			s := New(cfg)
+			if tt.sawStart {
+				if _, err := s.Deserialize([]byte(startMsg)); err != nil {
+					t.Fatalf("deserialize start: %v", err)
+				}
+			}
+			if _, err := s.Serialize(frames.NewEndFrame()); err != nil {
+				t.Fatalf("serialize end: %v", err)
+			}
+			select {
+			case <-got:
+				t.Error("hang-up should not have been attempted")
+			case <-time.After(200 * time.Millisecond):
+			}
+		})
+	}
+}
+
+// TestNewDefaultsHTTPClient checks a caller that supplies no client still gets a
+// usable one.
+func TestNewDefaultsHTTPClient(t *testing.T) {
+	if New(Config{}).http != http.DefaultClient {
+		t.Error("a nil HTTPClient should fall back to http.DefaultClient")
+	}
+}

--- a/transport/wsserver/wsserver.go
+++ b/transport/wsserver/wsserver.go
@@ -95,10 +95,24 @@ func (s *Session) write(ctx context.Context, msg []byte) error {
 }
 
 // Close closes the socket and signals Done. It is idempotent.
+//
+// It performs the WebSocket close handshake, which waits up to five seconds for
+// the peer to reply, so it belongs on the read goroutine and not on a
+// frame-processing one. Use abort where the caller cannot afford to wait.
 func (s *Session) Close() {
 	s.closeOnce.Do(func() {
 		close(s.done)
 		_ = s.conn.Close(websocket.StatusNormalClosure, "")
+	})
+}
+
+// abort tears the socket down without the close handshake and signals Done. It
+// is for a session that never started: there is no conversation to end politely,
+// and the caller is a frame-processing goroutine that must not block.
+func (s *Session) abort() {
+	s.closeOnce.Do(func() {
+		close(s.done)
+		_ = s.conn.CloseNow()
 	})
 }
 
@@ -119,6 +133,7 @@ type inputTransport struct {
 	readWG     sync.WaitGroup
 	mu         sync.Mutex
 	readCancel context.CancelFunc
+	start      *frames.StartFrame
 }
 
 func newInput(sess *Session, ser Serializer, params transport.Params) *inputTransport {
@@ -127,19 +142,43 @@ func newInput(sess *Session, ser Serializer, params transport.Params) *inputTran
 	return in
 }
 
-// ProcessFrame sets the serializer up from the StartFrame before the base starts
-// reading, then defers to the base.
+// ProcessFrame records the StartFrame for the serializer and defers to the base.
+//
+// The serializer is set up in StartReading rather than here, because the base
+// pushes the StartFrame downstream before it calls StartReading. Configuring the
+// serializer first would mean a failure swallowed the StartFrame, leaving every
+// processor downstream uninitialized and the pipeline unable to finish.
 func (in *inputTransport) ProcessFrame(ctx context.Context, f frames.Frame, dir processor.Direction) error {
 	if sf, ok := f.(*frames.StartFrame); ok {
-		if err := in.ser.Setup(sf); err != nil {
-			return err
-		}
+		in.mu.Lock()
+		in.start = sf
+		in.mu.Unlock()
 	}
 	return in.BaseInput.ProcessFrame(ctx, f, dir)
 }
 
-// StartReading launches the socket read loop.
+// StartReading configures the serializer and launches the socket read loop. It
+// runs after the StartFrame has reached the rest of the pipeline and before any
+// inbound message is deserialized, so the serializer always sees the pipeline's
+// configuration before the first frame it must decode.
+//
+// A serializer that cannot configure itself leaves the session unable to speak
+// the provider's wire format at all, so the failure is fatal: it ends the
+// pipeline and closes the socket rather than holding a call open that can
+// neither hear nor answer.
 func (in *inputTransport) StartReading(ctx context.Context) error {
+	in.mu.Lock()
+	sf := in.start
+	in.mu.Unlock()
+
+	if sf != nil {
+		if err := in.ser.Setup(sf); err != nil {
+			in.PushError(ctx, "wsserver: serializer setup failed", err, true)
+			in.sess.abort()
+			return nil // reported as a fatal error frame; do not report it twice
+		}
+	}
+
 	readCtx, cancel := context.WithCancel(ctx)
 	in.mu.Lock()
 	in.readCancel = cancel

--- a/transport/wsserver/wsserver.go
+++ b/transport/wsserver/wsserver.go
@@ -96,9 +96,11 @@ func (s *Session) write(ctx context.Context, msg []byte) error {
 
 // Close closes the socket and signals Done. It is idempotent.
 //
-// It performs the WebSocket close handshake, which waits up to five seconds for
-// the peer to reply, so it belongs on the read goroutine and not on a
-// frame-processing one. Use abort where the caller cannot afford to wait.
+// It is safe on the read path, where it is deferred by readLoop: a read that
+// fails or is canceled has already closed the connection underneath, so Close
+// finds it closed and returns at once. Called on a live connection it instead
+// performs the close handshake and waits up to five seconds for the peer to
+// reply, which must never happen on a frame-processing goroutine — see abort.
 func (s *Session) Close() {
 	s.closeOnce.Do(func() {
 		close(s.done)

--- a/transport/wsserver/wsserver_test.go
+++ b/transport/wsserver/wsserver_test.go
@@ -1,0 +1,569 @@
+package wsserver_test
+
+// End-to-end tests for the telephony WebSocket transport. This is the shared
+// machinery under every provider serializer (Twilio, Telnyx, Plivo, Exotel,
+// rtviws), so a fault here is a fault on every phone call the framework serves.
+//
+// Each test stands up a real HTTP server, dials it with a real WebSocket client,
+// and drives a real pipeline; only the wire format is faked, through a test
+// Serializer. Nothing is mocked below the socket.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/gojargo/jargo/frames"
+	"github.com/gojargo/jargo/pipeline"
+	"github.com/gojargo/jargo/processor"
+	"github.com/gojargo/jargo/transport"
+	"github.com/gojargo/jargo/transport/wsserver"
+)
+
+// errSerialize is the failure the test serializer reports on demand.
+//
+//nolint:gochecknoglobals // sentinel error
+var errSerialize = errors.New("serialize failed")
+
+// message is the test wire format: a kind and an opaque payload, which is enough
+// to tell audio, clears and hang-ups apart without importing a real provider.
+type message struct {
+	Kind    string `json:"kind"`
+	Payload string `json:"payload"`
+}
+
+// testSerializer is a minimal Serializer that records what it was asked to do
+// and can be made to fail.
+type testSerializer struct {
+	mu sync.Mutex
+
+	setupCalled  bool
+	setupRate    int
+	setupErr     error
+	serializeErr error
+	// dropAudio makes Serialize return (nil, nil) for audio, the way a provider
+	// does before its handshake completes.
+	dropAudio bool
+	// badMessages counts inbound messages that failed to deserialize.
+	badMessages int
+	// serialized records the kind of every message Serialize produced.
+	serialized []string
+}
+
+func (s *testSerializer) Setup(f *frames.StartFrame) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.setupCalled = true
+	s.setupRate = f.AudioOutSampleRate
+	return s.setupErr
+}
+
+func (s *testSerializer) Serialize(f frames.Frame) ([]byte, error) {
+	s.mu.Lock()
+	serErr, drop := s.serializeErr, s.dropAudio
+	s.mu.Unlock()
+
+	var m message
+	switch fr := f.(type) {
+	case *frames.OutputAudioRawFrame:
+		if drop {
+			return nil, nil //nolint:nilnil // provider not ready for audio yet
+		}
+		if serErr != nil {
+			return nil, serErr
+		}
+		m = message{Kind: "audio", Payload: string(fr.Audio)}
+	case *frames.InterruptionFrame:
+		m = message{Kind: "clear"}
+	case *frames.EndFrame:
+		m = message{Kind: "end"}
+	case *frames.CancelFrame:
+		m = message{Kind: "cancel"}
+	default:
+		return nil, nil //nolint:nilnil // frame not sent on this transport
+	}
+	s.mu.Lock()
+	s.serialized = append(s.serialized, m.Kind)
+	s.mu.Unlock()
+	return json.Marshal(m)
+}
+
+// sent reports whether a message of the given kind was produced.
+func (s *testSerializer) sent(kind string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return slices.Contains(s.serialized, kind)
+}
+
+func (s *testSerializer) Deserialize(data []byte) (frames.Frame, error) {
+	var m message
+	if err := json.Unmarshal(data, &m); err != nil {
+		s.mu.Lock()
+		s.badMessages++
+		s.mu.Unlock()
+		return nil, err
+	}
+	switch m.Kind {
+	case "audio":
+		return frames.NewInputAudioRawFrame([]byte(m.Payload), 8000, 1), nil
+	case "text":
+		return frames.NewTranscriptionFrame(m.Payload, "caller", ""), nil
+	default:
+		return nil, nil //nolint:nilnil // handshake or keepalive; no frame
+	}
+}
+
+func (s *testSerializer) snapshot() (setupCalled bool, rate, bad int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.setupCalled, s.setupRate, s.badMessages
+}
+
+// tap sits between the transport input and output and records every frame that
+// passes through, since frames consumed by the output processor never reach the
+// pipeline's downstream end.
+type tap struct {
+	*processor.Base
+	mu   sync.Mutex
+	seen []frames.Frame
+}
+
+func newTap() *tap {
+	t := &tap{}
+	t.Base = processor.New("Tap", t)
+	return t
+}
+
+func (t *tap) ProcessFrame(ctx context.Context, f frames.Frame, dir processor.Direction) error {
+	if err := t.Base.ProcessFrame(ctx, f, dir); err != nil {
+		return err
+	}
+	t.mu.Lock()
+	t.seen = append(t.seen, f)
+	t.mu.Unlock()
+	return t.PushFrame(ctx, f, dir)
+}
+
+func (t *tap) frames() []frames.Frame {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return append([]frames.Frame(nil), t.seen...)
+}
+
+// call is one live WebSocket session bridged to a pipeline.
+type call struct {
+	client *websocket.Conn
+	task   *pipeline.Task
+	done   chan error
+	tr     *wsserver.Transport
+	tap    *tap
+	cancel context.CancelFunc
+
+	stop sync.Once
+}
+
+// dial serves the transport over httptest, dials it, and runs a pipeline whose
+// head is the transport input and tail is its output.
+func dial(t *testing.T, ser wsserver.Serializer, params transport.Params) *call {
+	t.Helper()
+
+	c := &call{done: make(chan error, 1)}
+	ready := make(chan struct{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	c.cancel = cancel
+	t.Cleanup(cancel)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tr, err := wsserver.Accept(w, r, ser, params)
+		if err != nil {
+			t.Errorf("Accept: %v", err)
+			close(ready)
+			return
+		}
+		c.tr = tr
+		c.tap = newTap()
+		c.task = pipeline.NewTask(
+			pipeline.New(tr.Input(), c.tap, tr.Output()),
+			pipeline.TaskParams{AudioInSampleRate: 8000, AudioOutSampleRate: 8000},
+		)
+		close(ready)
+		c.done <- c.task.Run(ctx)
+	}))
+	t.Cleanup(srv.Close)
+
+	conn, resp, err := websocket.Dial(t.Context(), "ws"+strings.TrimPrefix(srv.URL, "http"), nil)
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	c.client = conn
+	t.Cleanup(func() { _ = conn.CloseNow() })
+
+	select {
+	case <-ready:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the server never accepted the connection")
+	}
+	return c
+}
+
+// send writes one client message onto the socket.
+func (c *call) send(t *testing.T, m message) {
+	t.Helper()
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := c.client.Write(t.Context(), websocket.MessageText, b); err != nil {
+		t.Fatalf("client write: %v", err)
+	}
+}
+
+// sendRaw writes arbitrary bytes, for the malformed-message cases.
+func (c *call) sendRaw(t *testing.T, b []byte) {
+	t.Helper()
+	if err := c.client.Write(t.Context(), websocket.MessageText, b); err != nil {
+		t.Fatalf("client write: %v", err)
+	}
+}
+
+// expect reads one message from the socket and decodes it.
+func (c *call) expect(t *testing.T) message {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	_, data, err := c.client.Read(ctx)
+	if err != nil {
+		t.Fatalf("client read: %v", err)
+	}
+	var m message
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal %q: %v", data, err)
+	}
+	return m
+}
+
+// ready blocks until the transport has begun reading the socket, which the task's
+// own StartFrame triggers — the test must not queue a second one, or the input
+// starts a competing read loop.
+func (c *call) ready(t *testing.T) {
+	t.Helper()
+	c.send(t, message{Kind: "text", Payload: readyProbe})
+	c.waitFor(t, "the read loop to start", func(fs []frames.Frame) bool {
+		tf := findTranscription(fs)
+		return tf != nil && tf.Text == readyProbe
+	})
+}
+
+// readyProbe is the sentinel message ready sends to observe the read loop.
+const readyProbe = "__ready__"
+
+// waitFor polls the frames that reached the pipeline tail until pred is
+// satisfied.
+func (c *call) waitFor(t *testing.T, what string, pred func([]frames.Frame) bool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if pred(c.tap.frames()) {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+func (c *call) shutdown(t *testing.T) {
+	t.Helper()
+	c.stop.Do(func() {
+		c.task.StopWhenDone()
+		select {
+		case <-c.done:
+			return
+		case <-time.After(5 * time.Second):
+		}
+		// The socket may already be gone; cancel the run rather than hanging.
+		c.cancel()
+		select {
+		case <-c.done:
+		case <-time.After(5 * time.Second):
+			t.Error("pipeline did not finish")
+		}
+	})
+}
+
+// params returns telephony-shaped transport params: 8 kHz mono, both directions.
+func params() transport.Params {
+	p := transport.DefaultParams()
+	p.AudioInSampleRate = 8000
+	p.AudioOutSampleRate = 8000
+	p.AudioOut10msChunks = 1
+	return p
+}
+
+// TestSetupRunsBeforeReading checks the serializer is configured from the
+// StartFrame before any socket traffic is deserialized — it is where a provider
+// learns the sample rate it must encode at.
+func TestSetupRunsBeforeReading(t *testing.T) {
+	ser := &testSerializer{}
+	c := dial(t, ser, params())
+	defer c.shutdown(t)
+
+	c.send(t, message{Kind: "text", Payload: "hello"})
+	c.waitFor(t, "the transcription to arrive", func(fs []frames.Frame) bool {
+		return findTranscription(fs) != nil
+	})
+
+	called, rate, _ := ser.snapshot()
+	if !called {
+		t.Error("Setup was never called")
+	}
+	if rate != 8000 {
+		t.Errorf("Setup saw AudioOutSampleRate = %d, want 8000", rate)
+	}
+}
+
+// TestSetupErrorStallsTheStart documents what happens when a serializer cannot
+// configure itself from the StartFrame. The failure is reported as a non-fatal
+// error frame, but the StartFrame never reaches the end of the pipeline, so the
+// run neither starts streaming nor returns; canceling the context is the only
+// way out. Done() does not help, because the read loop never started.
+//
+// No shipped serializer returns an error from Setup — the error return exists
+// but is unused — so this is a latent shape rather than a live fault. Anyone who
+// adds a Setup that can genuinely fail needs a fatal error path, or the pipeline
+// hangs instead of failing fast. This test is the record of that.
+func TestSetupErrorStallsTheStart(t *testing.T) {
+	ser := &testSerializer{setupErr: errSerialize}
+	c := dial(t, ser, params())
+
+	c.task.StopWhenDone()
+	select {
+	case <-c.done:
+		t.Fatal("Run returned; the stall documented here has been fixed, so update this test")
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	c.cancel()
+	select {
+	case err := <-c.done:
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("Run error = %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return even after the context was canceled")
+	}
+	c.stop.Do(func() {}) // already drained
+
+	if called, _, _ := ser.snapshot(); !called {
+		t.Error("Setup was never called")
+	}
+}
+
+// TestInboundAudioBecomesFrames is the read path: provider media messages must
+// arrive downstream as input audio for VAD, STT and turn detection.
+func TestInboundAudioBecomesFrames(t *testing.T) {
+	c := dial(t, &testSerializer{}, params())
+	defer c.shutdown(t)
+
+	c.send(t, message{Kind: "audio", Payload: "caller-speech"})
+
+	c.waitFor(t, "inbound audio", func(fs []frames.Frame) bool {
+		for _, f := range fs {
+			if af, ok := f.(*frames.InputAudioRawFrame); ok && string(af.Audio) == "caller-speech" {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+// TestInboundNonAudioFrames checks messages that deserialize to something other
+// than audio still reach the pipeline.
+func TestInboundNonAudioFrames(t *testing.T) {
+	c := dial(t, &testSerializer{}, params())
+	defer c.shutdown(t)
+
+	c.send(t, message{Kind: "text", Payload: "press one"})
+
+	c.waitFor(t, "the transcription", func(fs []frames.Frame) bool {
+		tf := findTranscription(fs)
+		return tf != nil && tf.Text == "press one"
+	})
+}
+
+// TestMalformedMessagesDoNotKillTheCall is the important resilience property: a
+// provider sending one bad message must not end a live phone call. The read loop
+// logs and continues.
+func TestMalformedMessagesDoNotKillTheCall(t *testing.T) {
+	ser := &testSerializer{}
+	c := dial(t, ser, params())
+	defer c.shutdown(t)
+
+	c.sendRaw(t, []byte("{not json"))
+	c.send(t, message{Kind: "keepalive"}) // deserializes to no frame
+	c.send(t, message{Kind: "text", Payload: "still here"})
+
+	c.waitFor(t, "traffic after a malformed message", func(fs []frames.Frame) bool {
+		tf := findTranscription(fs)
+		return tf != nil && tf.Text == "still here"
+	})
+
+	if _, _, bad := ser.snapshot(); bad != 1 {
+		t.Errorf("deserialize failures = %d, want 1", bad)
+	}
+}
+
+// TestOutboundAudio is the write path: TTS audio must reach the socket as a
+// provider media message.
+func TestOutboundAudio(t *testing.T) {
+	c := dial(t, &testSerializer{}, params())
+	defer c.shutdown(t)
+
+	// One 10 ms chunk at 8 kHz mono 16-bit is 160 bytes.
+	c.task.QueueFrame(frames.NewTTSAudioRawFrame(make([]byte, 160), 8000, 1))
+
+	if got := c.expect(t); got.Kind != "audio" {
+		t.Errorf("message kind = %q, want audio", got.Kind)
+	}
+}
+
+// TestOutboundAudioDropped checks a serializer returning no message (the
+// provider is not ready) writes nothing rather than an empty frame.
+func TestOutboundAudioDropped(t *testing.T) {
+	c := dial(t, &testSerializer{dropAudio: true}, params())
+	defer c.shutdown(t)
+
+	c.task.QueueFrame(frames.NewTTSAudioRawFrame(make([]byte, 160), 8000, 1))
+	c.task.QueueFrame(frames.NewInterruptionFrame())
+
+	// The clear arrives first because the audio produced no wire message at all.
+	if got := c.expect(t); got.Kind != "clear" {
+		t.Errorf("message kind = %q, want clear; the dropped audio should not be sent", got.Kind)
+	}
+}
+
+// TestInterruptionSendsClear covers barge-in: the provider must be told to
+// discard the audio it has already buffered, or the bot keeps talking over the
+// caller.
+func TestInterruptionSendsClear(t *testing.T) {
+	c := dial(t, &testSerializer{}, params())
+	defer c.shutdown(t)
+
+	c.task.QueueFrame(frames.NewInterruptionFrame())
+
+	if got := c.expect(t); got.Kind != "clear" {
+		t.Errorf("message kind = %q, want clear", got.Kind)
+	}
+}
+
+// TestEndFrameReachesSerializer checks the serializer sees the end of the
+// pipeline, which is its cue to hang the call up. The assertion is on what the
+// serializer produced rather than what arrived on the socket, because the
+// transport closes the connection immediately afterwards.
+func TestEndFrameReachesSerializer(t *testing.T) {
+	ser := &testSerializer{}
+	c := dial(t, ser, params())
+
+	c.ready(t)
+	c.shutdown(t)
+
+	if !ser.sent("end") {
+		t.Error("the serializer never saw the EndFrame; it cannot hang the call up")
+	}
+}
+
+// TestClientDisconnectClosesDone checks the caller hanging up closes Done, which
+// is the signal an app cancels the pipeline context on.
+func TestClientDisconnectClosesDone(t *testing.T) {
+	c := dial(t, &testSerializer{}, params())
+
+	c.ready(t)
+
+	_ = c.client.Close(websocket.StatusNormalClosure, "caller hung up")
+
+	select {
+	case <-c.tr.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("Done was not closed when the client disconnected")
+	}
+	c.shutdown(t)
+}
+
+// TestDoneClosedOnce checks Done is closed exactly once even when the client
+// disconnects and the pipeline stops — a double close would panic.
+func TestDoneClosedOnce(t *testing.T) {
+	c := dial(t, &testSerializer{}, params())
+
+	c.ready(t)
+
+	_ = c.client.Close(websocket.StatusNormalClosure, "caller hung up")
+	<-c.tr.Done()
+	c.shutdown(t) // stopping the pipeline closes the session a second time
+
+	select {
+	case <-c.tr.Done():
+	default:
+		t.Error("Done should stay closed")
+	}
+}
+
+// TestInputOutputProcessors checks the transport exposes both ends of the
+// pipeline it is meant to sit at.
+func TestInputOutputProcessors(t *testing.T) {
+	c := dial(t, &testSerializer{}, params())
+	defer c.shutdown(t)
+
+	if c.tr.Input() == nil {
+		t.Error("Input() is nil")
+	}
+	if c.tr.Output() == nil {
+		t.Error("Output() is nil")
+	}
+	if !strings.HasPrefix(c.tr.Input().Name(), "WSInput#") {
+		t.Errorf("Input().Name() = %q, want the WSInput label", c.tr.Input().Name())
+	}
+	if !strings.HasPrefix(c.tr.Output().Name(), "WSOutput#") {
+		t.Errorf("Output().Name() = %q, want the WSOutput label", c.tr.Output().Name())
+	}
+}
+
+// TestAcceptRejectsPlainHTTP checks a request that is not a WebSocket upgrade is
+// refused rather than producing a half-built transport.
+func TestAcceptRejectsPlainHTTP(t *testing.T) {
+	var acceptErr error
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, acceptErr = wsserver.Accept(w, r, &testSerializer{}, params())
+	}))
+	defer srv.Close()
+
+	resp, err := srv.Client().Get(srv.URL) //nolint:noctx // httptest client, no timeout needed
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if acceptErr == nil {
+		t.Error("Accept accepted a plain HTTP request, want an error")
+	}
+}
+
+func findTranscription(fs []frames.Frame) *frames.TranscriptionFrame {
+	for _, f := range fs {
+		if tf, ok := f.(*frames.TranscriptionFrame); ok {
+			return tf
+		}
+	}
+	return nil
+}

--- a/transport/wsserver/wsserver_test.go
+++ b/transport/wsserver/wsserver_test.go
@@ -590,3 +590,42 @@ func findTranscription(fs []frames.Frame) *frames.TranscriptionFrame {
 	}
 	return nil
 }
+
+// teardownBudget is far below the five seconds a WebSocket close handshake may
+// spend waiting on a peer, so a regression that starts performing the handshake
+// during teardown fails here instead of merely running slowly.
+const teardownBudget = time.Second
+
+// TestTeardownIsPromptWhenPeerIsSilent checks ending a call does not wait on the
+// close handshake. Stopping the read cancels its context, and the WebSocket
+// library closes the connection itself when a read fails, so the deferred Close
+// finds the socket already closed and returns immediately rather than sending a
+// close frame and waiting for a reply that a silent peer will never send.
+func TestTeardownIsPromptWhenPeerIsSilent(t *testing.T) {
+	c := dial(t, &testSerializer{}, params())
+	c.ready(t)
+
+	// The client never reads, so it never auto-replies to a close frame.
+	start := time.Now()
+	c.shutdown(t)
+
+	if elapsed := time.Since(start); elapsed > teardownBudget {
+		t.Errorf("teardown took %v, want under %v; the close handshake is being waited on", elapsed, teardownBudget)
+	}
+}
+
+// TestTeardownIsPromptWhenPeerVanished is the telephony case that matters: the
+// provider tore the call down on its side, so nothing will ever answer a close
+// frame. Teardown must not stall on it.
+func TestTeardownIsPromptWhenPeerVanished(t *testing.T) {
+	c := dial(t, &testSerializer{}, params())
+	c.ready(t)
+	_ = c.client.CloseNow()
+
+	start := time.Now()
+	c.shutdown(t)
+
+	if elapsed := time.Since(start); elapsed > teardownBudget {
+		t.Errorf("teardown took %v, want under %v", elapsed, teardownBudget)
+	}
+}

--- a/transport/wsserver/wsserver_test.go
+++ b/transport/wsserver/wsserver_test.go
@@ -174,6 +174,13 @@ type call struct {
 // head is the transport input and tail is its output.
 func dial(t *testing.T, ser wsserver.Serializer, params transport.Params) *call {
 	t.Helper()
+	return dialTuned(t, ser, params, nil)
+}
+
+// dialTuned is dial with a hook to adjust the task params, for tests that need
+// to observe upstream traffic.
+func dialTuned(t *testing.T, ser wsserver.Serializer, params transport.Params, tune func(*pipeline.TaskParams)) *call {
+	t.Helper()
 
 	c := &call{done: make(chan error, 1)}
 	ready := make(chan struct{})
@@ -191,10 +198,11 @@ func dial(t *testing.T, ser wsserver.Serializer, params transport.Params) *call 
 		}
 		c.tr = tr
 		c.tap = newTap()
-		c.task = pipeline.NewTask(
-			pipeline.New(tr.Input(), c.tap, tr.Output()),
-			pipeline.TaskParams{AudioInSampleRate: 8000, AudioOutSampleRate: 8000},
-		)
+		tp := pipeline.TaskParams{AudioInSampleRate: 8000, AudioOutSampleRate: 8000}
+		if tune != nil {
+			tune(&tp)
+		}
+		c.task = pipeline.NewTask(pipeline.New(tr.Input(), c.tap, tr.Output()), tp)
 		close(ready)
 		c.done <- c.task.Run(ctx)
 	}))
@@ -334,40 +342,55 @@ func TestSetupRunsBeforeReading(t *testing.T) {
 	}
 }
 
-// TestSetupErrorStallsTheStart documents what happens when a serializer cannot
-// configure itself from the StartFrame. The failure is reported as a non-fatal
-// error frame, but the StartFrame never reaches the end of the pipeline, so the
-// run neither starts streaming nor returns; canceling the context is the only
-// way out. Done() does not help, because the read loop never started.
+// TestSetupErrorEndsTheCall checks a serializer that cannot configure itself
+// ends the session instead of stalling it.
 //
-// No shipped serializer returns an error from Setup — the error return exists
-// but is unused — so this is a latent shape rather than a live fault. Anyone who
-// adds a Setup that can genuinely fail needs a fatal error path, or the pipeline
-// hangs instead of failing fast. This test is the record of that.
-func TestSetupErrorStallsTheStart(t *testing.T) {
+// The ordering is the point. The StartFrame must reach the rest of the pipeline
+// before the serializer is set up; configuring first and failing would swallow
+// the StartFrame, leaving every processor downstream uninitialized and the run
+// unable to finish. Setup therefore runs in StartReading, after the push and
+// before the first inbound message is decoded.
+//
+// The failure is fatal rather than logged and shrugged off: a session that
+// cannot speak the provider's wire format can neither hear nor answer, so the
+// pipeline ends and the socket closes.
+func TestSetupErrorEndsTheCall(t *testing.T) {
 	ser := &testSerializer{setupErr: errSerialize}
 	c := dial(t, ser, params())
 
-	c.task.StopWhenDone()
+	// The budget is deliberately tight. Tearing the session down with the normal
+	// close handshake would block the frame-processing goroutine for up to five
+	// seconds waiting on the peer, wedging the pipeline; aborting takes
+	// microseconds. A regression to the handshake fails here rather than passing
+	// slowly.
 	select {
 	case <-c.done:
-		t.Fatal("Run returned; the stall documented here has been fixed, so update this test")
-	case <-time.After(500 * time.Millisecond):
-	}
-
-	c.cancel()
-	select {
-	case err := <-c.done:
-		if !errors.Is(err, context.Canceled) {
-			t.Errorf("Run error = %v, want context.Canceled", err)
-		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("Run did not return even after the context was canceled")
+	case <-time.After(2 * time.Second):
+		t.Fatal("the pipeline neither started nor finished after a Setup failure")
 	}
 	c.stop.Do(func() {}) // already drained
 
 	if called, _, _ := ser.snapshot(); !called {
 		t.Error("Setup was never called")
+	}
+
+	// Done must close, or an app waiting on it to tear the call down would leak
+	// the session: the read loop never started, so nothing else closes it.
+	select {
+	case <-c.tr.Done():
+	case <-time.After(2 * time.Second):
+		t.Error("Done was not closed after the Setup failure")
+	}
+
+	// The StartFrame reached the pipeline despite the failure.
+	var sawStart bool
+	for _, f := range c.tap.frames() {
+		if _, ok := f.(*frames.StartFrame); ok {
+			sawStart = true
+		}
+	}
+	if !sawStart {
+		t.Error("the StartFrame never reached the pipeline; Setup must not run before the push")
 	}
 }
 


### PR DESCRIPTION
Library coverage goes from **51.7% to 58.1%**. Every library package now has tests except `internal/validate`, a one-statement wrapper around go-playground/validator that the 22 provider config tests already exercise.

Fourteen commits, one per topic, each reviewable on its own.

## The one behavior change

`fix(wsserver): set the serializer up after the StartFrame is pushed` is not a test.

A serializer whose `Setup` failed hung the pipeline. The input transport configured the serializer *before* delegating to the base, so a failure returned early and the StartFrame was never pushed downstream. The task waits for the StartFrame to reach the end of the pipeline before processing anything else, so the run neither started nor returned — and `Done()` never closed either, because the read loop had not begun. Only canceling the context recovered it.

The base input already documents the correct order (push the StartFrame so every processor downstream is initialized, then start streaming) and every other transport follows it. This one did not. `Setup` now runs in `StartReading`, which the base calls after the push and before any inbound message is decoded, so the serializer still sees the pipeline's configuration before the first frame it must decode.

Two smaller decisions inside that change, both worth a look during review:

- **A `Setup` failure is now fatal.** A session that cannot speak the provider's wire format can neither hear the caller nor answer, so holding the call open serves nobody. This matches how the realtime LLM services already report a connection they could not establish.
- **Teardown uses a new `Session.abort` rather than `Close`.** `Close` performs the WebSocket close handshake, which waits up to five seconds for the peer — fine on the read goroutine where it normally runs, but the caller here is a frame-processing goroutine, and blocking it wedges the pipeline exactly as before.

Found while writing this transport's tests.

## Coverage scoping

`chore(ci): scope Codecov to library code` adds a `codecov.yml`. Coverage was measured but never enforced: CI uploaded a profile with no target and no threshold, so a regression produced no signal. It now has `target: auto` with a 1% threshold.

It also ignores `examples/` (2,298 statements of runnable demo `main()` programs at 0.8%, which are documentation and will never carry unit tests), generated protobuf, and the shared test harness. That alone moves the reported number from 38.5% to 51.7% without a single test — same tests, honest denominator.

## What the tests cover

| Package | Before | After |
|---|---|---|
| `frames` | 50.7% | 98.6% |
| `processor/voicemail` | 0% | 95.1% |
| `transport/wsserver` | 0% | 94.4% |
| `transport/wsserver/twilio` | 0% | 94.1% |
| `processor/langchain` | 0% | 92% |
| `processor/turns` | 58.6% | 86.2% |
| `internal/tagscan`, `audio/mixer`, `audio/noise/gate`, `audio`, `internal/query`, `clock`, `service/wsutil` | 0% | 100% |
| 12 OpenAI-compatible LLM shims | 0% | 100% |
| 22 other providers | 0% | 8–50% |
| `internal/onnxrt` | 0% | 23.6% |

Highlights rather than a full list:

- **`processor/turns`** — the strategies that decide when the bot listens had no coverage at all: the whole of `start.go`, `mute.go` and `ExternalStop`. Now driven frame by frame, including the wake phrase's bounded accumulator and inactivity timeout, and the barge-in word threshold that only applies while the bot speaks.
- **`transport/wsserver`** — the shared machinery under all five telephony serializers. Real HTTP server, real WebSocket client, real pipeline; only the wire format is faked. The property most worth having is that a malformed inbound message does not end a live call.
- **`frames`** — every constructible frame is listed once in a catalog and checked for the invariants that hold for all of them. The valuable one is category membership, which decides whether an interruption may drop a frame and is set by which base struct a frame embeds.
- **The 22 provider config tables** — nothing verified that a `validate` tag matched its field comment, so a missing `required` on a credential would have surfaced only as an auth failure against a live API.

## Scope and limits, stated plainly

- The 22 provider packages cover **configuration and construction only**. Their websocket and HTTP streaming needs a fake endpoint each, which is why they land at 8–50% rather than higher.
- `internal/onnxrt` stops at the native boundary on purpose. Most of it is purego FFI into `libonnxruntime`; exercising it needs the shared library, which CI does not guarantee. A test that skips when it is missing buys nothing, and one that fakes the library tests the fake.
- Two pre-existing lint findings are untouched and unrelated: `provider/anthropic/anthropic.go:104` (cyclop) and `provider/geminilive/geminilive.go:160` (goconst).

## Verification

`go build ./...`, `go test ./... -race`, `gofmt` and `golangci-lint` all clean on everything touched.