### PR TITLE
Pipeline lifecycle frames, runtime LLM context changes, and frame package cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,78 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- **Pipeline lifecycle frames.** A processor with no handle on the `Task` can now
+  ask it to change the run's lifecycle, and the `Task` converts the request into
+  the matching pipeline-wide frame: `frames.CancelWorkerFrame` becomes a
+  `CancelFrame`, `frames.StopWorkerFrame` a new `frames.StopFrame` (stop the run
+  but leave processors running), and `frames.InterruptionWorkerFrame` an
+  `InterruptionFrame`. `frames.EndWorkerFrame` already did this. The four now
+  live together in `frames/worker.go`; push them downstream so frames queued
+  ahead are processed first, and the `Task` sink returns them upstream.
+- **`Task.Flush`**, a drain barrier. It queues a `frames.PipelineFlushFrame`
+  probe that travels to the sink, is bounced back to the source, and closes its
+  `Done` channel on arrival. When `Flush` returns, every frame queued ahead of
+  the probe has been processed — useful to let a pipeline settle after an
+  interruption before injecting new work. The probe is uninterruptible, so it
+  always completes its round trip and a waiter cannot be stranded.
+- **`frames.CancelWorkerFrame` separates cancellation from failure.** Stopping a
+  healthy run (the caller hung up, a supervisor asked to stop) no longer has to
+  be dressed as a fatal error, and carries a `Reason` instead of surfacing as an
+  `ErrorFrame` to observers and clients. `frames.FatalErrorFrame` is its
+  counterpart for genuine unrecoverable failures.
+- **Runtime LLM context changes.** `frames.LLMSetToolsFrame`,
+  `frames.LLMSetToolChoiceFrame` and `frames.LLMMessagesUpdateFrame` change the
+  toolset, the tool-choice policy and the whole conversation on a running
+  pipeline. The context aggregator applies each to the shared `LLMContext` and
+  forwards it downstream. Backing them, `LLMContext` gains `SetMessages`,
+  `ToolChoice` and `SetToolChoice`.
+- **`frames.DefaultAudioInSampleRate` / `DefaultAudioOutSampleRate`**, the rates
+  `NewStartFrame` applies, exported so applications can refer to them.
+
+### Changed
+
+- **Speech-to-speech services are told when tools change.** A realtime model
+  generates continuously and never re-reads the shared context between turns, so
+  a toolset changed with `LLMContext.SetTools` never reached it. Tool changes now
+  travel as `frames.LLMSetToolsFrame`, and the OpenAI Realtime service renders
+  tools into its initial session configuration and sends a fresh `session.update`
+  whenever they change. `SetTools` and `SetToolChoice` remain for seeding a
+  context before the pipeline starts.
+- **`frames.OutputTransportMessageFrame` is a data frame again**, delivered in
+  order with the surrounding audio, for messages that must land in step with what
+  the bot is saying. The new `frames.OutputTransportMessageUrgentFrame` is the
+  system-frame variant that goes out immediately, ahead of queued audio; the RTVI
+  processor uses it. Previously the single frame had urgent semantics under the
+  ordered name and the ordered variant was unavailable.
+- **`frames.MixerControlFrame` is now the interface for the mixer control
+  family**, with `frames.MixerUpdateSettingsFrame` carrying the settings map and
+  `frames.MixerEnableFrame` carrying an `Enable` flag, replacing the single
+  settings-carrying frame.
+- **`frames.EndWorkerFrame` is a control frame** (uninterruptible) rather than a
+  system frame, so it is ordered behind the work already queued.
+- **`turns.Emitter.Broadcast` takes a frame constructor** rather than a frame,
+  and builds one instance per direction, cross-linked by `BroadcastSiblingID`.
+  The two directions are processed on separate goroutines, so sharing a single
+  frame between them was a latent data race. Observers ignore the upstream half
+  of a pair, so a broadcast event is still reported once.
+- **`frames.Frame` is a four-method interface** (`String`, `ID`, `Name`,
+  `Base`). The optional per-frame state — presentation timestamp, metadata,
+  transport source and destination, broadcast sibling id — lives on `BaseFrame`
+  and is reached through `Base()`; the accessors are still promoted onto every
+  concrete frame, so code holding a concrete type is unaffected.
+- `CancelFrame.Reason`, `EndFrame.Reason` and `EndWorkerFrame.Reason` are
+  `string` rather than `any`.
+- `frames.STTMetadataFrame` embeds `ServiceMetadataFrame`, as
+  `LLMServiceMetadataFrame` already did, and moves to `frames/metadata.go`
+  alongside it. `FunctionCallCancelFrame` moves to `frames/function.go` with the
+  other function-call frames.
+- `AudioRawData.NumFrames` is derived on each call instead of cached at
+  construction, so it stays correct when `Audio` is replaced.
+- The `frames` package documents its ownership rule: a frame has a single owner
+  at a time and must not be mutated after it is pushed.
+
+### Added
+
 - **Word-aligned TTS text and interruption-accurate context.** A new
   `frames.TTSTextFrame` carries each spoken word aligned to audio playback, with
   the original written form of transformed spans (e.g. `"$42.50"` for a token

--- a/README.md
+++ b/README.md
@@ -10,17 +10,19 @@
 ![Go version](https://img.shields.io/github/go-mod/go-version/gojargo/jargo)
 [![Release](https://img.shields.io/github/v/release/gojargo/jargo?sort=semver)](https://github.com/gojargo/jargo/releases)
 [![License: BSD-2-Clause](https://img.shields.io/badge/license-BSD--2--Clause-blue.svg)](LICENSE)
+[![Status: early WIP](https://img.shields.io/badge/status-early%20WIP-orange)](#project-status)
 
 </div>
 
 ---
 
-**jargo** builds real-time voice agents in Go: audio in over WebRTC, a streaming
-transcription → reasoning → speech pipeline with turn-taking and barge-in, and
-audio back out — over [RTVI](https://docs.pipecat.ai/client/introduction) so
-existing clients interoperate.
+**jargo** is a framework for real-time voice agents in Go: audio in over WebRTC,
+a streaming transcription → reasoning → speech pipeline with turn-taking and
+barge-in, and audio back out.
 
-> **Status:** early work in progress. APIs are unstable and will change.
+> [!WARNING]
+> **Early work in progress. Not ready for production.** The public API is
+> unstable and changes in any release. See [Project status](#project-status).
 
 ## Why?
 
@@ -146,6 +148,25 @@ go run ./examples/echo                 # then open http://localhost:8080
 ## Documentation
 
 See **[docs/index.md](docs/index.md)** for the full documentation.
+
+## Project status
+
+jargo is **early work in progress**, in the `0.0.x` series. It runs real
+conversations end to end, but it has not been hardened by production use.
+
+What that means in practice:
+
+- **The API will break.** Anything exported may be renamed, resliced or removed
+  in any release, with no deprecation period. Pin an exact version and read
+  [`CHANGELOG.md`](CHANGELOG.md) before upgrading.
+- **Coverage is uneven.** The core pipeline, WebRTC transport and turn-taking get
+  the most use; some of the 50+ providers are thinly exercised. Bug reports about
+  a specific provider are especially useful.
+- **What is not settled yet:** the frame catalog is still growing, and several
+  subsystems that exist upstream are not ported yet, including images and vision.
+
+Issues and pull requests are welcome, particularly ones that come with a failing
+test.
 
 ## License & attribution
 

--- a/audio/mixer/mixer.go
+++ b/audio/mixer/mixer.go
@@ -1,7 +1,7 @@
 // Package mixer mixes background audio into a transport's outgoing audio. Loop
 // plays a PCM buffer on a loop, blending it under the bot's speech at a
 // configurable volume; its volume and mute state can be changed at runtime
-// through a frames.MixerControlFrame. It plugs into an output transport via
+// through a frames.MixerUpdateSettingsFrame. It plugs into an output transport via
 // Params.AudioOutMixer.
 package mixer
 
@@ -24,7 +24,7 @@ type LoopConfig struct {
 	// Volume scales the background (0..1); 0 uses 0.3.
 	Volume float64
 	// Enabled starts the mixer active; a disabled mixer passes audio through
-	// until a MixerControlFrame enables it.
+	// until a MixerEnableFrame enables it.
 	Enabled bool
 }
 

--- a/frames/audio.go
+++ b/frames/audio.go
@@ -12,27 +12,21 @@ type AudioRawData struct {
 	SampleRate int
 	// NumChannels is the number of interleaved audio channels.
 	NumChannels int
-
-	numFrames int
 }
 
-// newAudioRawData builds an AudioRawData and derives its frame count from the
-// buffer length.
+// newAudioRawData builds an AudioRawData from PCM audio.
 func newAudioRawData(audio []byte, sampleRate, numChannels int) AudioRawData {
-	d := AudioRawData{Audio: audio, SampleRate: sampleRate, NumChannels: numChannels}
-	d.recountFrames()
-	return d
+	return AudioRawData{Audio: audio, SampleRate: sampleRate, NumChannels: numChannels}
 }
 
 // NumFrames is the number of audio frames (samples per channel) in the buffer:
 // len(Audio) / (NumChannels * 2) for 16-bit PCM. It is 0 when NumChannels is
-// unset.
-func (a *AudioRawData) NumFrames() int { return a.numFrames }
-
-func (a *AudioRawData) recountFrames() {
-	if a.NumChannels > 0 {
-		a.numFrames = len(a.Audio) / (a.NumChannels * 2)
+// unset. It is derived on each call, so it stays correct when Audio is replaced.
+func (a *AudioRawData) NumFrames() int {
+	if a.NumChannels <= 0 {
+		return 0
 	}
+	return len(a.Audio) / (a.NumChannels * 2)
 }
 
 // InputAudioRawFrame is a chunk of audio coming from an input transport. When a

--- a/frames/catalog_test.go
+++ b/frames/catalog_test.go
@@ -56,7 +56,7 @@ type catalogEntry struct {
 // catalog lists every frame a caller can construct. Adding a frame type means
 // adding a line here.
 //
-//nolint:funlen // a flat catalog of every frame type; length is the point
+//nolint:funlen,maintidx // a flat catalog of every frame type; length is the point
 func catalog() []catalogEntry {
 	return []catalogEntry{
 		// System frames: priority delivery, unaffected by interruptions.
@@ -69,12 +69,20 @@ func catalog() []catalogEntry {
 			build: func() frames.Frame { return frames.NewCancelFrame() },
 		},
 		{
-			label: "EndWorkerFrame", cat: system, wantString: "reason:",
-			build: func() frames.Frame { return frames.NewEndWorkerFrame() },
-		},
-		{
 			label: "ErrorFrame", cat: system, wantString: "boom",
 			build: func() frames.Frame { return frames.NewErrorFrame("boom") },
+		},
+		{
+			label: "FatalErrorFrame", cat: system, wantString: "fatal: true",
+			build: func() frames.Frame { return frames.NewFatalErrorFrame("boom") },
+		},
+		{
+			label: "CancelWorkerFrame", cat: system, wantString: "reason:",
+			build: func() frames.Frame { return frames.NewCancelWorkerFrame() },
+		},
+		{
+			label: "InterruptionWorkerFrame", cat: system,
+			build: func() frames.Frame { return frames.NewInterruptionWorkerFrame() },
 		},
 		{
 			label: "InterruptionFrame", cat: system,
@@ -153,8 +161,10 @@ func catalog() []catalogEntry {
 			build: func() frames.Frame { return frames.NewInputTransportMessageFrame([]byte("abc")) },
 		},
 		{
-			label: "OutputTransportMessageFrame", cat: system,
-			build: func() frames.Frame { return frames.NewOutputTransportMessageFrame(map[string]any{"a": 1}) },
+			label: "OutputTransportMessageUrgentFrame", cat: system, wantString: "message:",
+			build: func() frames.Frame {
+				return frames.NewOutputTransportMessageUrgentFrame(map[string]any{"a": 1})
+			},
 		},
 		{
 			label: "MetricsFrame", cat: system, wantString: "processor: tts-1",
@@ -206,11 +216,49 @@ func catalog() []catalogEntry {
 			label: "LLMRunFrame", cat: data,
 			build: func() frames.Frame { return frames.NewLLMRunFrame() },
 		},
+		{
+			label: "OutputTransportMessageFrame", cat: data, wantString: "message:",
+			build: func() frames.Frame { return frames.NewOutputTransportMessageFrame(map[string]any{"a": 1}) },
+		},
+		{
+			label: "LLMSetToolsFrame", cat: data, wantString: "tools: 1",
+			build: func() frames.Frame {
+				return frames.NewLLMSetToolsFrame([]frames.Tool{{Name: "get_weather"}})
+			},
+		},
+		{
+			label: "LLMSetToolChoiceFrame", cat: data, wantString: "choice: required",
+			build: func() frames.Frame {
+				return frames.NewLLMSetToolChoiceFrame(frames.ToolChoiceRequired)
+			},
+		},
+		{
+			label: "LLMMessagesUpdateFrame", cat: data, wantString: "messages: 1",
+			build: func() frames.Frame {
+				return frames.NewLLMMessagesUpdateFrame([]frames.Message{{Role: frames.RoleUser, Text: "hi"}})
+			},
+		},
 
 		// Control frames: in order like data frames, but carrying instructions.
 		{
 			label: "EndFrame", cat: control, uninterruptible: true,
 			build: func() frames.Frame { return frames.NewEndFrame() },
+		},
+		{
+			label: "StopFrame", cat: control, uninterruptible: true,
+			build: func() frames.Frame { return frames.NewStopFrame() },
+		},
+		{
+			label: "StopWorkerFrame", cat: control, uninterruptible: true,
+			build: func() frames.Frame { return frames.NewStopWorkerFrame() },
+		},
+		{
+			label: "EndWorkerFrame", cat: control, uninterruptible: true, wantString: "reason:",
+			build: func() frames.Frame { return frames.NewEndWorkerFrame() },
+		},
+		{
+			label: "PipelineFlushFrame", cat: control, uninterruptible: true,
+			build: func() frames.Frame { return frames.NewPipelineFlushFrame() },
 		},
 		{
 			label: "LLMFullResponseStartFrame", cat: control,
@@ -237,8 +285,14 @@ func catalog() []catalogEntry {
 			build: func() frames.Frame { return frames.NewOutputDTMFFrame(frames.KeypadSeven) },
 		},
 		{
-			label: "MixerControlFrame", cat: control,
-			build: func() frames.Frame { return frames.NewMixerControlFrame(map[string]any{"volume": 0.5}) },
+			label: "MixerUpdateSettingsFrame", cat: control, wantString: "settings: 1",
+			build: func() frames.Frame {
+				return frames.NewMixerUpdateSettingsFrame(map[string]any{"volume": 0.5})
+			},
+		},
+		{
+			label: "MixerEnableFrame", cat: control, wantString: "enable: true",
+			build: func() frames.Frame { return frames.NewMixerEnableFrame(true) },
 		},
 		{
 			label: "LLMMessagesAppendFrame", cat: control,
@@ -380,9 +434,12 @@ func TestConstructorFields(t *testing.T) {
 	})
 
 	t.Run("mixer settings", func(t *testing.T) {
-		f := frames.NewMixerControlFrame(map[string]any{"volume": 0.5})
+		f := frames.NewMixerUpdateSettingsFrame(map[string]any{"volume": 0.5})
 		if f.Settings["volume"] != 0.5 {
 			t.Errorf("Settings = %v", f.Settings)
+		}
+		if !frames.NewMixerEnableFrame(true).Enable {
+			t.Error("Enable should carry the constructor argument")
 		}
 	})
 

--- a/frames/control.go
+++ b/frames/control.go
@@ -1,6 +1,9 @@
 package frames
 
-import "fmt"
+import (
+	"fmt"
+	"sync"
+)
 
 // EndFrame indicates the pipeline has ended and processors should shut down. As
 // a control frame it is received in order, after preceding frames are flushed.
@@ -9,8 +12,8 @@ import "fmt"
 type EndFrame struct {
 	BaseControlFrame
 	UninterruptibleMixin
-	// Reason is an optional reason for ending the pipeline.
-	Reason any
+	// Reason describes why the pipeline is ending; "" when unset.
+	Reason string
 }
 
 // NewEndFrame builds an EndFrame.
@@ -20,7 +23,57 @@ func NewEndFrame() *EndFrame {
 
 // String implements fmt.Stringer.
 func (f *EndFrame) String() string {
-	return fmt.Sprintf("%s(reason: %v)", f.Name(), f.Reason)
+	return fmt.Sprintf("%s(reason: %s)", f.Name(), f.Reason)
+}
+
+// StopFrame indicates the pipeline should stop but that its processors are to be
+// kept running, ready for another run. Unlike EndFrame it does not shut
+// processors down. It is normally queued by the Task. It is uninterruptible so a
+// barge-in cannot drop it.
+type StopFrame struct {
+	BaseControlFrame
+	UninterruptibleMixin
+}
+
+// NewStopFrame builds a StopFrame.
+func NewStopFrame() *StopFrame {
+	return &StopFrame{BaseControlFrame: NewBaseControlFrame("StopFrame")}
+}
+
+// PipelineFlushFrame is a probe that reports when the pipeline has drained. It is
+// pushed downstream; the Task's sink bounces it back upstream, and when it
+// reaches the source the Task closes Done. Waiting on Done therefore means every
+// frame queued ahead of the probe has completed its round trip — useful to let
+// the pipeline settle after an interruption before injecting new work.
+//
+// It is uninterruptible so the probe survives an InterruptionFrame and still
+// completes its round trip; otherwise a waiter would block forever. Done is
+// carried on the frame so concurrent flushes stay isolated, each awaiting its
+// own probe.
+type PipelineFlushFrame struct {
+	BaseControlFrame
+	UninterruptibleMixin
+	// Done is closed by the Task once the probe has completed its round trip.
+	Done chan struct{}
+
+	closeOnce sync.Once
+}
+
+// NewPipelineFlushFrame builds a PipelineFlushFrame with a fresh Done channel.
+// Wait on Done (against a context) to know the pipeline has drained.
+func NewPipelineFlushFrame() *PipelineFlushFrame {
+	return &PipelineFlushFrame{
+		BaseControlFrame: NewBaseControlFrame("PipelineFlushFrame"),
+		Done:             make(chan struct{}),
+	}
+}
+
+// CloseDone closes Done, releasing whoever is waiting on the probe. The Task
+// calls it when the probe completes its round trip. Unlike the rest of a frame's
+// state this is safe to call from any goroutine, and more than once: the probe is
+// a deliberate handoff between the waiter and the pipeline.
+func (f *PipelineFlushFrame) CloseDone() {
+	f.closeOnce.Do(func() { close(f.Done) })
 }
 
 // LLMFullResponseStartFrame marks the beginning of an LLM response, followed by
@@ -85,6 +138,10 @@ func NewTTSStoppedFrame() *TTSStoppedFrame {
 var (
 	_ ControlFrame    = (*EndFrame)(nil)
 	_ Uninterruptible = (*EndFrame)(nil)
+	_ ControlFrame    = (*StopFrame)(nil)
+	_ Uninterruptible = (*StopFrame)(nil)
+	_ ControlFrame    = (*PipelineFlushFrame)(nil)
+	_ Uninterruptible = (*PipelineFlushFrame)(nil)
 	_ ControlFrame    = (*LLMFullResponseStartFrame)(nil)
 	_ ControlFrame    = (*LLMFullResponseEndFrame)(nil)
 	_ ControlFrame    = (*TTSStartedFrame)(nil)

--- a/frames/frames.go
+++ b/frames/frames.go
@@ -1,5 +1,37 @@
 // Package frames defines the Frame type and the core frame categories — system,
 // data and control — that flow through a jargo pipeline.
+//
+// # Categories
+//
+// Every frame belongs to exactly one category, which decides how the pipeline
+// schedules it and whether an interruption may drop it:
+//
+//   - [SystemFrame] is delivered ahead of queued work and is never dropped by an
+//     interruption. Lifecycle and out-of-band signals: [StartFrame],
+//     [CancelFrame], [InterruptionFrame], [MetricsFrame].
+//   - [DataFrame] is processed in order and is canceled by an interruption. The
+//     payload frames: [TextFrame], [OutputAudioRawFrame], [LLMContextFrame].
+//   - [ControlFrame] is processed in order like a data frame and is likewise
+//     canceled, but carries instructions rather than payload: [EndFrame],
+//     [TTSStartedFrame], [FunctionCallResultFrame].
+//
+// A frame joins a category by embedding [BaseSystemFrame], [BaseDataFrame] or
+// [BaseControlFrame]; assert the matching interface to test the category. The
+// [Uninterruptible] marker is orthogonal: embed [UninterruptibleMixin] alongside
+// a data or control base to keep a frame queued through an interruption.
+//
+// # Ownership
+//
+// A frame carries mutable state behind pointer receivers and is deliberately not
+// synchronized. Exactly one goroutine owns a frame at a time: a processor may
+// read and mutate a frame until it pushes the frame onward, and must not touch
+// it afterwards. Do not mutate a frame that is being pushed in both directions
+// at once — the two ends run on separate goroutines, so a shared frame must be
+// treated as read-only by both.
+//
+// [LLMContext] is the exception. It is a long-lived aggregate shared by the
+// aggregators and the LLM service rather than a frame, and it is safe for
+// concurrent use.
 package frames
 
 import (
@@ -19,7 +51,7 @@ func nextID() uint64 { return idCounter.Add(1) }
 // formatPTS renders a frame's presentation timestamp for String output,
 // returning the nanosecond value or "none" when the timestamp is unset.
 func formatPTS(f Frame) string {
-	if pts, ok := f.PTS(); ok {
+	if pts, ok := f.Base().PTS(); ok {
 		return strconv.FormatInt(pts, 10)
 	}
 	return "none"
@@ -27,11 +59,18 @@ func formatPTS(f Frame) string {
 
 // Frame is implemented by every frame that flows through a pipeline. Concrete
 // frames embed BaseFrame (directly or via BaseSystemFrame, BaseDataFrame or
-// BaseControlFrame), which supplies all of these methods.
+// BaseControlFrame), which supplies these methods.
 //
 // The unexported isFrame marker means a type must embed BaseFrame to satisfy
-// Frame; this guarantees every Frame has a valid id, name and metadata map.
-// Frames carry mutable state and are passed as pointers.
+// Frame; this guarantees every Frame has a valid id and name. Frames carry
+// mutable state and are passed as pointers.
+//
+// The interface is deliberately narrow: identity is all a pipeline needs to
+// route, log and correlate a frame. The optional per-frame state — presentation
+// timestamp, metadata, transport source and destination, broadcast sibling id —
+// lives on [BaseFrame] and is reached through Base. Those accessors are also
+// promoted onto every concrete frame, so a caller holding a concrete type can
+// keep calling them directly.
 type Frame interface {
 	fmt.Stringer
 
@@ -40,38 +79,19 @@ type Frame interface {
 	// Name is a human-readable label, "<TypeName>#<n>".
 	Name() string
 
-	// PTS is the presentation timestamp in nanoseconds; ok is false if unset.
-	PTS() (pts int64, ok bool)
-	// SetPTS sets the presentation timestamp in nanoseconds.
-	SetPTS(pts int64)
-
-	// BroadcastSiblingID is the id of the paired frame when this frame was
-	// broadcast in both directions; ok is false if unset.
-	BroadcastSiblingID() (id uint64, ok bool)
-	// SetBroadcastSiblingID records the paired frame id.
-	SetBroadcastSiblingID(id uint64)
-
-	// Metadata is an arbitrary, mutable per-frame metadata map.
-	Metadata() map[string]any
-
-	// TransportSource is the name of the transport that created this frame.
-	TransportSource() string
-	// SetTransportSource sets the transport source.
-	SetTransportSource(source string)
-	// TransportDestination is the name of the transport this frame targets.
-	TransportDestination() string
-	// SetTransportDestination sets the transport destination.
-	SetTransportDestination(dest string)
+	// Base exposes the embedded BaseFrame and the optional state it carries.
+	Base() *BaseFrame
 
 	isFrame()
 }
 
 // BaseFrame is embedded by every concrete frame and implements Frame. Construct
-// it with NewBaseFrame so the id, name and metadata map are initialized.
+// it with NewBaseFrame so the id and name are initialized.
 type BaseFrame struct {
 	id                 uint64
 	typeName           string
-	pts                *int64
+	pts                int64
+	hasPTS             bool
 	broadcastSiblingID *uint64
 	metadata           map[string]any
 	transportSource    string
@@ -82,12 +102,12 @@ type BaseFrame struct {
 // typeName (e.g. "TextFrame"). It assigns a unique id; the "<typeName>#<id>"
 // name is formatted on demand.
 func NewBaseFrame(typeName string) BaseFrame {
-	return BaseFrame{
-		id:       nextID(),
-		typeName: typeName,
-		metadata: map[string]any{},
-	}
+	return BaseFrame{id: nextID(), typeName: typeName}
 }
+
+// Base implements Frame, returning the BaseFrame itself so a caller holding the
+// Frame interface can reach the optional per-frame state.
+func (f *BaseFrame) Base() *BaseFrame { return f }
 
 // ID implements Frame.
 func (f *BaseFrame) ID() uint64 { return f.id }
@@ -99,15 +119,13 @@ func (f *BaseFrame) Name() string { return f.typeName + "#" + strconv.FormatUint
 func (f *BaseFrame) String() string { return f.Name() }
 
 // PTS implements Frame.
-func (f *BaseFrame) PTS() (int64, bool) {
-	if f.pts == nil {
-		return 0, false
-	}
-	return *f.pts, true
-}
+func (f *BaseFrame) PTS() (int64, bool) { return f.pts, f.hasPTS }
 
 // SetPTS implements Frame.
-func (f *BaseFrame) SetPTS(pts int64) { f.pts = &pts }
+func (f *BaseFrame) SetPTS(pts int64) {
+	f.pts = pts
+	f.hasPTS = true
+}
 
 // BroadcastSiblingID implements Frame.
 func (f *BaseFrame) BroadcastSiblingID() (uint64, bool) {
@@ -120,8 +138,9 @@ func (f *BaseFrame) BroadcastSiblingID() (uint64, bool) {
 // SetBroadcastSiblingID implements Frame.
 func (f *BaseFrame) SetBroadcastSiblingID(id uint64) { f.broadcastSiblingID = &id }
 
-// Metadata implements Frame. It lazily initializes the map so a zero BaseFrame
-// is still usable.
+// Metadata implements Frame. The map is allocated on first use, so a frame that
+// carries no metadata costs nothing. Like the rest of a frame's state it is
+// unsynchronized: only the goroutine that owns the frame may call this.
 func (f *BaseFrame) Metadata() map[string]any {
 	if f.metadata == nil {
 		f.metadata = map[string]any{}

--- a/frames/frames_test.go
+++ b/frames/frames_test.go
@@ -161,3 +161,23 @@ func TestTransportSourceDest(t *testing.T) {
 			f.TransportSource(), f.TransportDestination())
 	}
 }
+
+// TestPipelineFlushDone checks the probe's Done channel closes once and stays
+// safe to close again, since the Task may see the probe more than once.
+func TestPipelineFlushDone(t *testing.T) {
+	probe := frames.NewPipelineFlushFrame()
+	select {
+	case <-probe.Done:
+		t.Fatal("Done should be open on a fresh probe")
+	default:
+	}
+
+	probe.CloseDone()
+	probe.CloseDone() // must not panic
+
+	select {
+	case <-probe.Done:
+	default:
+		t.Error("Done should be closed after CloseDone")
+	}
+}

--- a/frames/function.go
+++ b/frames/function.go
@@ -89,9 +89,35 @@ func (f *FunctionCallResultFrame) String() string {
 	return fmt.Sprintf("%s(%s, error: %t)", f.Name(), f.ToolName, f.IsError)
 }
 
+// FunctionCallCancelFrame reports that a tool call was canceled (for example by
+// a barge-in) so trackers can decrement their in-flight count. It is a control
+// frame.
+type FunctionCallCancelFrame struct {
+	BaseControlFrame
+	// ToolCallID identifies the canceled call.
+	ToolCallID string
+	// ToolName is the tool's name.
+	ToolName string
+}
+
+// NewFunctionCallCancelFrame builds a FunctionCallCancelFrame.
+func NewFunctionCallCancelFrame(toolCallID, name string) *FunctionCallCancelFrame {
+	return &FunctionCallCancelFrame{
+		BaseControlFrame: NewBaseControlFrame("FunctionCallCancelFrame"),
+		ToolCallID:       toolCallID,
+		ToolName:         name,
+	}
+}
+
+// String implements fmt.Stringer.
+func (f *FunctionCallCancelFrame) String() string {
+	return fmt.Sprintf("%s(%s)", f.Name(), f.ToolName)
+}
+
 // Compile-time interface checks.
 var (
 	_ ControlFrame = (*FunctionCallsStartedFrame)(nil)
 	_ ControlFrame = (*FunctionCallInProgressFrame)(nil)
 	_ ControlFrame = (*FunctionCallResultFrame)(nil)
+	_ ControlFrame = (*FunctionCallCancelFrame)(nil)
 )

--- a/frames/llm_context.go
+++ b/frames/llm_context.go
@@ -62,12 +62,13 @@ type Message struct {
 // append to a shared context as the conversation proceeds, and the LLM service
 // reads it to generate each response. It is safe for concurrent use.
 type LLMContext struct {
-	mu       sync.Mutex
-	system   string
-	summary  string // rolling summary of compacted older turns; empty until the first Compact
-	recall   string // transient retrieved context (e.g. long-term memories) for the next generation
-	messages []Message
-	tools    []Tool
+	mu         sync.Mutex
+	system     string
+	summary    string // rolling summary of compacted older turns; empty until the first Compact
+	recall     string // transient retrieved context (e.g. long-term memories) for the next generation
+	messages   []Message
+	tools      []Tool
+	toolChoice ToolChoice
 }
 
 // summaryHeader introduces the rolling summary appended to the system prompt
@@ -148,11 +149,47 @@ func (c *LLMContext) Tools() []Tool {
 	return out
 }
 
-// SetTools replaces the set of tools the model may call. Used alongside
-// SetSystem to switch the available toolset mid-session.
+// SetTools replaces the set of tools the model may call.
+//
+// This mutates the context and notifies nobody. A text LLM reads the context on
+// its next run and so picks the change up, but a realtime (speech-to-speech)
+// service is generating continuously and will keep offering the old toolset. To
+// change tools on a running pipeline, push an [LLMSetToolsFrame] instead: the
+// aggregator applies it here and forwards it downstream so realtime services are
+// told. Use this directly only to seed the toolset before the pipeline starts.
 func (c *LLMContext) SetTools(tools []Tool) {
 	c.mu.Lock()
 	c.tools = tools
+	c.mu.Unlock()
+}
+
+// ToolChoice returns whether the model may or must call a tool. It is
+// ToolChoiceAuto unless set.
+func (c *LLMContext) ToolChoice() ToolChoice {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.toolChoice == "" {
+		return ToolChoiceAuto
+	}
+	return c.toolChoice
+}
+
+// SetToolChoice sets whether the model may or must call a tool. The same caveat
+// as SetTools applies: on a running pipeline push an [LLMSetToolChoiceFrame] so
+// realtime services learn of the change.
+func (c *LLMContext) SetToolChoice(choice ToolChoice) {
+	c.mu.Lock()
+	c.toolChoice = choice
+	c.mu.Unlock()
+}
+
+// SetMessages replaces the conversation messages, in contrast to the Add methods
+// which append. The system prompt, tools and rolling summary are left alone. On
+// a running pipeline push an [LLMMessagesUpdateFrame] so the replacement is
+// ordered against the conversation rather than racing an in-flight generation.
+func (c *LLMContext) SetMessages(messages []Message) {
+	c.mu.Lock()
+	c.messages = append([]Message(nil), messages...)
 	c.mu.Unlock()
 }
 
@@ -333,8 +370,98 @@ func NewLLMRunFrame() *LLMRunFrame {
 	return &LLMRunFrame{BaseDataFrame: NewBaseDataFrame("LLMRunFrame")}
 }
 
+// LLMSetToolsFrame changes the set of tools advertised to the model
+// mid-conversation. The context aggregator applies it to the shared context and
+// forwards it downstream: a text LLM picks the change up on its next run, but a
+// realtime (speech-to-speech) service is generating continuously and would never
+// see it, so it must be told. Always change tools through this frame rather than
+// calling LLMContext.SetTools directly, or realtime services will keep using the
+// old toolset. It is a data frame, so the change is ordered against the
+// surrounding conversation instead of racing an in-flight generation.
+type LLMSetToolsFrame struct {
+	BaseDataFrame
+	// Tools is the new toolset; nil or empty clears the tools.
+	Tools []Tool
+}
+
+// NewLLMSetToolsFrame builds an LLMSetToolsFrame advertising tools.
+func NewLLMSetToolsFrame(tools []Tool) *LLMSetToolsFrame {
+	return &LLMSetToolsFrame{
+		BaseDataFrame: NewBaseDataFrame("LLMSetToolsFrame"),
+		Tools:         tools,
+	}
+}
+
+// String implements fmt.Stringer.
+func (f *LLMSetToolsFrame) String() string {
+	return fmt.Sprintf("%s(tools: %d)", f.Name(), len(f.Tools))
+}
+
+// ToolChoice tells the model whether it may or must call a tool.
+type ToolChoice string
+
+const (
+	// ToolChoiceAuto lets the model decide whether to call a tool.
+	ToolChoiceAuto ToolChoice = "auto"
+	// ToolChoiceNone forbids tool calls.
+	ToolChoiceNone ToolChoice = "none"
+	// ToolChoiceRequired requires the model to call a tool.
+	ToolChoiceRequired ToolChoice = "required"
+)
+
+// LLMSetToolChoiceFrame changes whether the model may or must call a tool. Like
+// LLMSetToolsFrame it is applied to the shared context and forwarded downstream
+// so realtime services learn of the change. It is a data frame.
+type LLMSetToolChoiceFrame struct {
+	BaseDataFrame
+	// ToolChoice is the new setting.
+	ToolChoice ToolChoice
+}
+
+// NewLLMSetToolChoiceFrame builds an LLMSetToolChoiceFrame.
+func NewLLMSetToolChoiceFrame(choice ToolChoice) *LLMSetToolChoiceFrame {
+	return &LLMSetToolChoiceFrame{
+		BaseDataFrame: NewBaseDataFrame("LLMSetToolChoiceFrame"),
+		ToolChoice:    choice,
+	}
+}
+
+// String implements fmt.Stringer.
+func (f *LLMSetToolChoiceFrame) String() string {
+	return fmt.Sprintf("%s(choice: %s)", f.Name(), f.ToolChoice)
+}
+
+// LLMMessagesUpdateFrame replaces the conversation messages in the shared
+// context, in contrast to LLMMessagesAppendFrame which adds to them. Use it to
+// swap the conversation wholesale — restoring a saved session, or resetting the
+// conversation without rebuilding the pipeline. It is a data frame, so the
+// replacement is ordered against the surrounding conversation.
+type LLMMessagesUpdateFrame struct {
+	BaseDataFrame
+	// Messages replaces the context's current messages.
+	Messages []Message
+	// RunLLM reports whether the LLM should run on the updated context.
+	RunLLM bool
+}
+
+// NewLLMMessagesUpdateFrame builds an LLMMessagesUpdateFrame.
+func NewLLMMessagesUpdateFrame(messages []Message) *LLMMessagesUpdateFrame {
+	return &LLMMessagesUpdateFrame{
+		BaseDataFrame: NewBaseDataFrame("LLMMessagesUpdateFrame"),
+		Messages:      messages,
+	}
+}
+
+// String implements fmt.Stringer.
+func (f *LLMMessagesUpdateFrame) String() string {
+	return fmt.Sprintf("%s(messages: %d)", f.Name(), len(f.Messages))
+}
+
 // Compile-time interface checks.
 var (
 	_ DataFrame = (*LLMContextFrame)(nil)
 	_ DataFrame = (*LLMRunFrame)(nil)
+	_ DataFrame = (*LLMSetToolsFrame)(nil)
+	_ DataFrame = (*LLMSetToolChoiceFrame)(nil)
+	_ DataFrame = (*LLMMessagesUpdateFrame)(nil)
 )

--- a/frames/llm_context_test.go
+++ b/frames/llm_context_test.go
@@ -307,3 +307,40 @@ func TestEstimatedTokens(t *testing.T) {
 		t.Error("tool calls and results should count toward the estimate")
 	}
 }
+
+// TestContextToolChoice checks the default and the setter, which back the
+// LLMSetToolChoiceFrame the aggregator applies.
+func TestContextToolChoice(t *testing.T) {
+	c := frames.NewLLMContext("system")
+	if got := c.ToolChoice(); got != frames.ToolChoiceAuto {
+		t.Errorf("ToolChoice() = %q, want auto by default", got)
+	}
+	c.SetToolChoice(frames.ToolChoiceNone)
+	if got := c.ToolChoice(); got != frames.ToolChoiceNone {
+		t.Errorf("ToolChoice() = %q, want none", got)
+	}
+}
+
+// TestContextSetMessages checks SetMessages replaces the conversation, leaves the
+// system prompt alone, and copies its input so a later caller mutation cannot
+// reach into the context.
+func TestContextSetMessages(t *testing.T) {
+	c := frames.NewLLMContext("system")
+	c.AddUserMessage("old")
+
+	in := []frames.Message{{Role: frames.RoleUser, Text: "new"}}
+	c.SetMessages(in)
+
+	got := c.Messages()
+	if len(got) != 1 || got[0].Text != "new" {
+		t.Fatalf("Messages() = %+v, want the conversation replaced", got)
+	}
+	if c.System() != "system" {
+		t.Errorf("System() = %q, want it untouched", c.System())
+	}
+
+	in[0].Text = "mutated by the caller"
+	if again := c.Messages(); again[0].Text != "new" {
+		t.Error("SetMessages should copy its input, not alias the caller's slice")
+	}
+}

--- a/frames/metadata.go
+++ b/frames/metadata.go
@@ -1,6 +1,9 @@
 package frames
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 // UserTurnRecommendation is a turn-taking strategy a service recommends to the
 // user-turn aggregator through a metadata frame. The aggregator adopts the
@@ -28,7 +31,8 @@ func (r UserTurnRecommendation) String() string {
 
 // ServiceMetadata is implemented by every metadata frame a service broadcasts at
 // pipeline start. Downstream processors assert this interface to read the common
-// fields; a concrete STTMetadataFrame or LLMServiceMetadataFrame carries more.
+// fields; a concrete [STTMetadataFrame] or [LLMServiceMetadataFrame] carries
+// more.
 type ServiceMetadata interface {
 	SystemFrame
 	// Service is the name of the service that broadcast the metadata.
@@ -40,8 +44,8 @@ type ServiceMetadata interface {
 
 // ServiceMetadataFrame is broadcast by a service at pipeline start to share its
 // configuration and performance characteristics with downstream processors. It
-// is a system frame. LLMServiceMetadataFrame embeds it; STTMetadataFrame (see
-// turns.go) carries the same common fields to satisfy ServiceMetadata.
+// is a system frame. [STTMetadataFrame] and [LLMServiceMetadataFrame] embed it to
+// add their service-specific fields.
 type ServiceMetadataFrame struct {
 	BaseSystemFrame
 	// ServiceName names the broadcasting service.
@@ -89,9 +93,39 @@ func NewLLMServiceMetadataFrame(service string) *LLMServiceMetadataFrame {
 	}
 }
 
+// STTMetadataFrame is the metadata an STT service broadcasts. Turn-stop
+// strategies use the p99 time-to-final-speech latency to size their safety-net
+// timeouts, and a service that does its own server-side endpointing recommends
+// external turn strategies through UserTurns.
+type STTMetadataFrame struct {
+	ServiceMetadataFrame
+	// TTFSP99Latency is the p99 latency from end of speech to a finalized
+	// transcript. Zero means unknown; strategies fall back to a default.
+	TTFSP99Latency time.Duration
+}
+
+// NewSTTMetadataFrame builds an STTMetadataFrame reporting the p99
+// time-to-final-speech latency. Set ServiceName and UserTurns on the returned
+// frame to describe the service further.
+func NewSTTMetadataFrame(ttfsP99 time.Duration) *STTMetadataFrame {
+	return &STTMetadataFrame{
+		ServiceMetadataFrame: ServiceMetadataFrame{
+			BaseSystemFrame: NewBaseSystemFrame("STTMetadataFrame"),
+		},
+		TTFSP99Latency: ttfsP99,
+	}
+}
+
+// String implements fmt.Stringer.
+func (f *STTMetadataFrame) String() string {
+	return fmt.Sprintf("%s(ttfs_p99: %s)", f.Name(), f.TTFSP99Latency)
+}
+
 // Compile-time interface checks.
 var (
 	_ SystemFrame     = (*ServiceMetadataFrame)(nil)
 	_ ServiceMetadata = (*ServiceMetadataFrame)(nil)
 	_ ServiceMetadata = (*LLMServiceMetadataFrame)(nil)
+	_ SystemFrame     = (*STTMetadataFrame)(nil)
+	_ ServiceMetadata = (*STTMetadataFrame)(nil)
 )

--- a/frames/mixer.go
+++ b/frames/mixer.go
@@ -1,21 +1,66 @@
 package frames
 
-// MixerControlFrame updates an output transport's audio mixer at runtime — for
-// example to change the background track, adjust its volume, or mute it. The
-// Settings are interpreted by the mixer implementation. It is a control frame.
-type MixerControlFrame struct {
-	BaseControlFrame
-	// Settings are the mixer settings to apply (e.g. "volume", "enabled").
+import "fmt"
+
+// MixerControlFrame is the base for the frames that drive an output transport's
+// audio mixer at runtime. Assert this interface to test whether a frame is a
+// mixer control; embed MixerControlBase to define one. It is a control frame, so
+// a mixer change is ordered against the audio around it.
+type MixerControlFrame interface {
+	ControlFrame
+	isMixerControlFrame()
+}
+
+// MixerControlBase is embedded by mixer control frames.
+type MixerControlBase struct{ BaseControlFrame }
+
+func (*MixerControlBase) isMixerControlFrame() {}
+
+// MixerUpdateSettingsFrame updates the mixer's settings — for example to change
+// the background track or adjust its volume. The Settings are interpreted by the
+// mixer implementation.
+type MixerUpdateSettingsFrame struct {
+	MixerControlBase
+	// Settings are the mixer settings to apply (e.g. "volume", "track").
 	Settings map[string]any
 }
 
-// NewMixerControlFrame builds a MixerControlFrame carrying settings.
-func NewMixerControlFrame(settings map[string]any) *MixerControlFrame {
-	return &MixerControlFrame{
-		BaseControlFrame: NewBaseControlFrame("MixerControlFrame"),
+// NewMixerUpdateSettingsFrame builds a MixerUpdateSettingsFrame carrying settings.
+func NewMixerUpdateSettingsFrame(settings map[string]any) *MixerUpdateSettingsFrame {
+	return &MixerUpdateSettingsFrame{
+		MixerControlBase: MixerControlBase{NewBaseControlFrame("MixerUpdateSettingsFrame")},
 		Settings:         settings,
 	}
 }
 
-// Compile-time interface check.
-var _ ControlFrame = (*MixerControlFrame)(nil)
+// String implements fmt.Stringer.
+func (f *MixerUpdateSettingsFrame) String() string {
+	return fmt.Sprintf("%s(settings: %d)", f.Name(), len(f.Settings))
+}
+
+// MixerEnableFrame turns the mixer on or off at runtime, muting or restoring the
+// auxiliary audio without changing its settings.
+type MixerEnableFrame struct {
+	MixerControlBase
+	// Enable reports whether the mixer should be enabled.
+	Enable bool
+}
+
+// NewMixerEnableFrame builds a MixerEnableFrame.
+func NewMixerEnableFrame(enable bool) *MixerEnableFrame {
+	return &MixerEnableFrame{
+		MixerControlBase: MixerControlBase{NewBaseControlFrame("MixerEnableFrame")},
+		Enable:           enable,
+	}
+}
+
+// String implements fmt.Stringer.
+func (f *MixerEnableFrame) String() string {
+	return fmt.Sprintf("%s(enable: %t)", f.Name(), f.Enable)
+}
+
+// Compile-time interface checks.
+var (
+	_ MixerControlFrame = (*MixerUpdateSettingsFrame)(nil)
+	_ MixerControlFrame = (*MixerEnableFrame)(nil)
+)

--- a/frames/system.go
+++ b/frames/system.go
@@ -2,6 +2,15 @@ package frames
 
 import "fmt"
 
+// The sample rates NewStartFrame applies when the application does not override
+// them: input is sized for speech recognition, output for synthesis quality.
+const (
+	// DefaultAudioInSampleRate is the default input audio sample rate in Hz.
+	DefaultAudioInSampleRate = 16000
+	// DefaultAudioOutSampleRate is the default output audio sample rate in Hz.
+	DefaultAudioOutSampleRate = 24000
+)
+
 // StartFrame is the first frame pushed down a pipeline. It initializes every
 // processor with the pipeline-wide configuration. It is a system frame.
 type StartFrame struct {
@@ -23,8 +32,8 @@ type StartFrame struct {
 func NewStartFrame() *StartFrame {
 	return &StartFrame{
 		BaseSystemFrame:    NewBaseSystemFrame("StartFrame"),
-		AudioInSampleRate:  16000,
-		AudioOutSampleRate: 24000,
+		AudioInSampleRate:  DefaultAudioInSampleRate,
+		AudioOutSampleRate: DefaultAudioOutSampleRate,
 	}
 }
 
@@ -32,8 +41,8 @@ func NewStartFrame() *StartFrame {
 // any remaining queued frames. It is a system frame.
 type CancelFrame struct {
 	BaseSystemFrame
-	// Reason is an optional reason for the cancellation.
-	Reason any
+	// Reason describes why the pipeline was canceled; "" when unset.
+	Reason string
 }
 
 // NewCancelFrame builds a CancelFrame.
@@ -43,29 +52,7 @@ func NewCancelFrame() *CancelFrame {
 
 // String implements fmt.Stringer.
 func (f *CancelFrame) String() string {
-	return fmt.Sprintf("%s(reason: %v)", f.Name(), f.Reason)
-}
-
-// EndWorkerFrame requests a graceful shutdown of the pipeline worker (the Task).
-// A processor pushes it upstream; on reaching the Task it queues an EndFrame
-// downstream (see Task.StopWhenDone), so frames already queued are flushed and
-// the bot finishes speaking before the pipeline ends. It is a system frame, so
-// a processor with no Task handle can end the run and the signal reaches the
-// Task even while the pipeline is busy.
-type EndWorkerFrame struct {
-	BaseSystemFrame
-	// Reason is an optional reason for ending.
-	Reason any
-}
-
-// NewEndWorkerFrame builds an EndWorkerFrame.
-func NewEndWorkerFrame() *EndWorkerFrame {
-	return &EndWorkerFrame{BaseSystemFrame: NewBaseSystemFrame("EndWorkerFrame")}
-}
-
-// String implements fmt.Stringer.
-func (f *EndWorkerFrame) String() string {
-	return fmt.Sprintf("%s(reason: %v)", f.Name(), f.Reason)
+	return fmt.Sprintf("%s(reason: %s)", f.Name(), f.Reason)
 }
 
 // ErrorSource identifies the component that raised an error — in practice the
@@ -98,6 +85,25 @@ func NewErrorFrame(message string) *ErrorFrame {
 // String implements fmt.Stringer.
 func (f *ErrorFrame) String() string {
 	return fmt.Sprintf("%s(error: %s, fatal: %t)", f.Name(), f.Error, f.Fatal)
+}
+
+// FatalErrorFrame notifies upstream that an unrecoverable error occurred and the
+// bot should exit immediately. It is an ErrorFrame whose Fatal is always set, so
+// a processor can report an unrecoverable failure by type rather than by
+// remembering to set the flag.
+type FatalErrorFrame struct {
+	ErrorFrame
+}
+
+// NewFatalErrorFrame builds a FatalErrorFrame describing message.
+func NewFatalErrorFrame(message string) *FatalErrorFrame {
+	return &FatalErrorFrame{
+		ErrorFrame: ErrorFrame{
+			BaseSystemFrame: NewBaseSystemFrame("FatalErrorFrame"),
+			Error:           message,
+			Fatal:           true,
+		},
+	}
 }
 
 // InterruptionFrame interrupts the pipeline — for example when the user starts
@@ -161,6 +167,7 @@ var (
 	_ SystemFrame = (*StartFrame)(nil)
 	_ SystemFrame = (*CancelFrame)(nil)
 	_ SystemFrame = (*ErrorFrame)(nil)
+	_ SystemFrame = (*FatalErrorFrame)(nil)
 	_ SystemFrame = (*InterruptionFrame)(nil)
 	_ SystemFrame = (*UserStartedSpeakingFrame)(nil)
 	_ SystemFrame = (*UserStoppedSpeakingFrame)(nil)

--- a/frames/transport.go
+++ b/frames/transport.go
@@ -26,9 +26,12 @@ func (f *InputTransportMessageFrame) String() string {
 
 // OutputTransportMessageFrame carries an application message to send to the
 // client over the transport — for example an RTVI message onto a WebRTC data
-// channel. Message is serialized by the output transport. It is a system frame.
+// channel. Message is serialized by the output transport. It is a data frame, so
+// it is delivered in order with the surrounding audio: use it for a message that
+// must land in step with what the bot is saying. For a message that must go out
+// immediately, ahead of any queued audio, use OutputTransportMessageUrgentFrame.
 type OutputTransportMessageFrame struct {
-	BaseSystemFrame
+	BaseDataFrame
 	// Message is the message payload to send; the transport serializes it.
 	Message any
 }
@@ -36,13 +39,42 @@ type OutputTransportMessageFrame struct {
 // NewOutputTransportMessageFrame builds an OutputTransportMessageFrame.
 func NewOutputTransportMessageFrame(message any) *OutputTransportMessageFrame {
 	return &OutputTransportMessageFrame{
-		BaseSystemFrame: NewBaseSystemFrame("OutputTransportMessageFrame"),
+		BaseDataFrame: NewBaseDataFrame("OutputTransportMessageFrame"),
+		Message:       message,
+	}
+}
+
+// String implements fmt.Stringer.
+func (f *OutputTransportMessageFrame) String() string {
+	return fmt.Sprintf("%s(message: %v)", f.Name(), f.Message)
+}
+
+// OutputTransportMessageUrgentFrame carries an application message that must be
+// sent to the client immediately, ahead of any queued audio. It is a system
+// frame; prefer OutputTransportMessageFrame when the message should stay ordered
+// with the bot's speech.
+type OutputTransportMessageUrgentFrame struct {
+	BaseSystemFrame
+	// Message is the message payload to send; the transport serializes it.
+	Message any
+}
+
+// NewOutputTransportMessageUrgentFrame builds an OutputTransportMessageUrgentFrame.
+func NewOutputTransportMessageUrgentFrame(message any) *OutputTransportMessageUrgentFrame {
+	return &OutputTransportMessageUrgentFrame{
+		BaseSystemFrame: NewBaseSystemFrame("OutputTransportMessageUrgentFrame"),
 		Message:         message,
 	}
+}
+
+// String implements fmt.Stringer.
+func (f *OutputTransportMessageUrgentFrame) String() string {
+	return fmt.Sprintf("%s(message: %v)", f.Name(), f.Message)
 }
 
 // Compile-time interface checks.
 var (
 	_ SystemFrame = (*InputTransportMessageFrame)(nil)
-	_ SystemFrame = (*OutputTransportMessageFrame)(nil)
+	_ DataFrame   = (*OutputTransportMessageFrame)(nil)
+	_ SystemFrame = (*OutputTransportMessageUrgentFrame)(nil)
 )

--- a/frames/turns.go
+++ b/frames/turns.go
@@ -24,6 +24,11 @@ func NewVADUserStartedSpeakingFrame(startSecs float64) *VADUserStartedSpeakingFr
 	}
 }
 
+// String implements fmt.Stringer.
+func (f *VADUserStartedSpeakingFrame) String() string {
+	return fmt.Sprintf("%s(start_secs: %.3f)", f.Name(), f.StartSecs)
+}
+
 // VADUserStoppedSpeakingFrame reports that the VAD heard the user stop speaking.
 // It is a system frame.
 type VADUserStoppedSpeakingFrame struct {
@@ -43,6 +48,11 @@ func NewVADUserStoppedSpeakingFrame(stopSecs float64, timestamp string) *VADUser
 		StopSecs:        stopSecs,
 		Timestamp:       timestamp,
 	}
+}
+
+// String implements fmt.Stringer.
+func (f *VADUserStoppedSpeakingFrame) String() string {
+	return fmt.Sprintf("%s(stop_secs: %.3f)", f.Name(), f.StopSecs)
 }
 
 // UserSpeakingFrame is emitted periodically while the user is speaking, a
@@ -90,39 +100,6 @@ func NewUserMuteStoppedFrame() *UserMuteStoppedFrame {
 	return &UserMuteStoppedFrame{BaseSystemFrame: NewBaseSystemFrame("UserMuteStoppedFrame")}
 }
 
-// STTMetadataFrame carries metadata an STT service broadcasts at pipeline start.
-// Turn-stop strategies use the p99 time-to-final-speech latency to size their
-// safety-net timeouts, and a service that does its own server-side endpointing
-// recommends external turn strategies through UserTurns. It is a system frame
-// and satisfies ServiceMetadata.
-type STTMetadataFrame struct {
-	BaseSystemFrame
-	// ServiceName names the STT service that broadcast the metadata.
-	ServiceName string
-	// UserTurns is the turn strategy the service recommends; the user aggregator
-	// adopts it unless the application configured its own.
-	UserTurns UserTurnRecommendation
-	// TTFSP99Latency is the p99 latency from end of speech to a finalized
-	// transcript. Zero means unknown; strategies fall back to a default.
-	TTFSP99Latency time.Duration
-}
-
-// NewSTTMetadataFrame builds an STTMetadataFrame reporting the p99
-// time-to-final-speech latency. Set ServiceName and UserTurns on the returned
-// frame to describe the service further.
-func NewSTTMetadataFrame(ttfsP99 time.Duration) *STTMetadataFrame {
-	return &STTMetadataFrame{
-		BaseSystemFrame: NewBaseSystemFrame("STTMetadataFrame"),
-		TTFSP99Latency:  ttfsP99,
-	}
-}
-
-// Service implements ServiceMetadata.
-func (f *STTMetadataFrame) Service() string { return f.ServiceName }
-
-// RecommendedUserTurns implements ServiceMetadata.
-func (f *STTMetadataFrame) RecommendedUserTurns() UserTurnRecommendation { return f.UserTurns }
-
 // UserIdleTimeoutUpdateFrame updates the user-idle timeout at runtime. A value
 // <= 0 disables idle detection. It is a system frame.
 type UserIdleTimeoutUpdateFrame struct {
@@ -139,24 +116,9 @@ func NewUserIdleTimeoutUpdateFrame(timeout time.Duration) *UserIdleTimeoutUpdate
 	}
 }
 
-// FunctionCallCancelFrame reports that a tool call was canceled (for example by
-// a barge-in) so trackers can decrement their in-flight count. It is a control
-// frame.
-type FunctionCallCancelFrame struct {
-	BaseControlFrame
-	// ToolCallID identifies the canceled call.
-	ToolCallID string
-	// ToolName is the tool's name.
-	ToolName string
-}
-
-// NewFunctionCallCancelFrame builds a FunctionCallCancelFrame.
-func NewFunctionCallCancelFrame(toolCallID, name string) *FunctionCallCancelFrame {
-	return &FunctionCallCancelFrame{
-		BaseControlFrame: NewBaseControlFrame("FunctionCallCancelFrame"),
-		ToolCallID:       toolCallID,
-		ToolName:         name,
-	}
+// String implements fmt.Stringer.
+func (f *UserIdleTimeoutUpdateFrame) String() string {
+	return fmt.Sprintf("%s(timeout: %s)", f.Name(), f.Timeout)
 }
 
 // UserTurnInferenceCompletedFrame signals that an external judge (an LLM
@@ -225,31 +187,6 @@ func NewLLMMessagesAppendFrame(messages []Message) *LLMMessagesAppendFrame {
 	}
 }
 
-// String implements fmt.Stringer.
-func (f *VADUserStartedSpeakingFrame) String() string {
-	return fmt.Sprintf("%s(start_secs: %.3f)", f.Name(), f.StartSecs)
-}
-
-// String implements fmt.Stringer.
-func (f *VADUserStoppedSpeakingFrame) String() string {
-	return fmt.Sprintf("%s(stop_secs: %.3f)", f.Name(), f.StopSecs)
-}
-
-// String implements fmt.Stringer.
-func (f *STTMetadataFrame) String() string {
-	return fmt.Sprintf("%s(ttfs_p99: %s)", f.Name(), f.TTFSP99Latency)
-}
-
-// String implements fmt.Stringer.
-func (f *UserIdleTimeoutUpdateFrame) String() string {
-	return fmt.Sprintf("%s(timeout: %s)", f.Name(), f.Timeout)
-}
-
-// String implements fmt.Stringer.
-func (f *FunctionCallCancelFrame) String() string {
-	return fmt.Sprintf("%s(%s)", f.Name(), f.ToolName)
-}
-
 // Compile-time interface checks.
 var (
 	_ SystemFrame  = (*VADUserStartedSpeakingFrame)(nil)
@@ -258,10 +195,8 @@ var (
 	_ SystemFrame  = (*BotSpeakingFrame)(nil)
 	_ SystemFrame  = (*UserMuteStartedFrame)(nil)
 	_ SystemFrame  = (*UserMuteStoppedFrame)(nil)
-	_ SystemFrame  = (*STTMetadataFrame)(nil)
 	_ SystemFrame  = (*UserIdleTimeoutUpdateFrame)(nil)
 	_ SystemFrame  = (*SpeechControlParamsFrame)(nil)
-	_ ControlFrame = (*FunctionCallCancelFrame)(nil)
 	_ ControlFrame = (*UserTurnInferenceCompletedFrame)(nil)
 	_ DataFrame    = (*LLMMarkerFrame)(nil)
 	_ ControlFrame = (*LLMMessagesAppendFrame)(nil)

--- a/frames/worker.go
+++ b/frames/worker.go
@@ -1,0 +1,94 @@
+package frames
+
+import "fmt"
+
+// The worker frames ask the pipeline worker — the Task — to change the run's
+// lifecycle. A processor deep in the pipeline has no handle on the Task, so it
+// pushes one of these instead and the Task converts it into the corresponding
+// pipeline-wide frame: EndWorkerFrame becomes an EndFrame, CancelWorkerFrame a
+// CancelFrame, and so on. Push them downstream (the usual direction) so frames
+// queued ahead of them are processed first; the Task's sink returns them
+// upstream. Pushing upstream directly is also supported.
+//
+// The two graceful requests are control frames, so they are ordered behind the
+// work already queued, and uninterruptible, so a barge-in cannot drop the
+// request. The two immediate requests are system frames, so they reach the Task
+// even while the pipeline is busy.
+
+// EndWorkerFrame requests a graceful shutdown of the pipeline worker (the Task).
+// On reaching the Task it queues an EndFrame downstream, so frames already
+// queued are flushed and the bot finishes speaking before the pipeline ends.
+type EndWorkerFrame struct {
+	BaseControlFrame
+	UninterruptibleMixin
+	// Reason describes why the run is ending; "" when unset.
+	Reason string
+}
+
+// NewEndWorkerFrame builds an EndWorkerFrame.
+func NewEndWorkerFrame() *EndWorkerFrame {
+	return &EndWorkerFrame{BaseControlFrame: NewBaseControlFrame("EndWorkerFrame")}
+}
+
+// String implements fmt.Stringer.
+func (f *EndWorkerFrame) String() string {
+	return fmt.Sprintf("%s(reason: %s)", f.Name(), f.Reason)
+}
+
+// StopWorkerFrame requests that the Task stop once queued frames are flushed,
+// while leaving the processors running and ready for another run. On reaching the
+// Task it queues a StopFrame. It is the counterpart of EndWorkerFrame for a run
+// that should stop without shutting processors down.
+type StopWorkerFrame struct {
+	BaseControlFrame
+	UninterruptibleMixin
+}
+
+// NewStopWorkerFrame builds a StopWorkerFrame.
+func NewStopWorkerFrame() *StopWorkerFrame {
+	return &StopWorkerFrame{BaseControlFrame: NewBaseControlFrame("StopWorkerFrame")}
+}
+
+// CancelWorkerFrame requests immediate cancellation of the Task. On reaching it
+// the Task queues a CancelFrame downstream, so the pipeline stops at once without
+// flushing queued frames. It is the deliberate counterpart to a fatal ErrorFrame:
+// use it to stop a run that is not failing (the caller hung up, a supervisor
+// asked to stop).
+type CancelWorkerFrame struct {
+	BaseSystemFrame
+	// Reason describes why the run is being canceled; "" when unset.
+	Reason string
+}
+
+// NewCancelWorkerFrame builds a CancelWorkerFrame.
+func NewCancelWorkerFrame() *CancelWorkerFrame {
+	return &CancelWorkerFrame{BaseSystemFrame: NewBaseSystemFrame("CancelWorkerFrame")}
+}
+
+// String implements fmt.Stringer.
+func (f *CancelWorkerFrame) String() string {
+	return fmt.Sprintf("%s(reason: %s)", f.Name(), f.Reason)
+}
+
+// InterruptionWorkerFrame asks the Task to interrupt the pipeline. On reaching
+// the Task it queues an InterruptionFrame downstream. A processor that can
+// broadcast an InterruptionFrame itself should do so; this frame is for one that
+// only has a path to the Task.
+type InterruptionWorkerFrame struct {
+	BaseSystemFrame
+}
+
+// NewInterruptionWorkerFrame builds an InterruptionWorkerFrame.
+func NewInterruptionWorkerFrame() *InterruptionWorkerFrame {
+	return &InterruptionWorkerFrame{BaseSystemFrame: NewBaseSystemFrame("InterruptionWorkerFrame")}
+}
+
+// Compile-time interface checks.
+var (
+	_ ControlFrame    = (*EndWorkerFrame)(nil)
+	_ Uninterruptible = (*EndWorkerFrame)(nil)
+	_ ControlFrame    = (*StopWorkerFrame)(nil)
+	_ Uninterruptible = (*StopWorkerFrame)(nil)
+	_ SystemFrame     = (*CancelWorkerFrame)(nil)
+	_ SystemFrame     = (*InterruptionWorkerFrame)(nil)
+)

--- a/observers/observers.go
+++ b/observers/observers.go
@@ -19,8 +19,20 @@ import (
 	"github.com/gojargo/jargo/processor"
 )
 
-// deduper drops frames already seen at the other pipeline end (broadcast frames
-// reach both), keeping a bounded window of recent ids.
+// skipBroadcastSibling reports whether a frame is the upstream half of a
+// broadcast pair and should be ignored. A broadcast builds a distinct frame for
+// each direction, paired by BroadcastSiblingID, so an observer that watched both
+// would report one event twice. Counting only the downstream half reports it
+// once, and the pairing is what makes the two halves recognizable — their ids
+// deliberately differ, so the id deduper below cannot catch them.
+func skipBroadcastSibling(f frames.Frame, dir processor.Direction) bool {
+	_, paired := f.Base().BroadcastSiblingID()
+	return paired && dir != processor.Downstream
+}
+
+// deduper drops a frame already seen, keeping a bounded window of recent ids. It
+// catches the same instance arriving twice — a frame pushed on and later echoed
+// back — which is distinct from the broadcast pairing above.
 type deduper struct {
 	seen  map[uint64]struct{}
 	order []uint64
@@ -86,7 +98,10 @@ func NewTurnTracking(cfg TurnTrackingConfig) *TurnTracking {
 }
 
 // OnFrame implements pipeline.Observer.
-func (o *TurnTracking) OnFrame(f frames.Frame, _ processor.Direction) {
+func (o *TurnTracking) OnFrame(f frames.Frame, dir processor.Direction) {
+	if skipBroadcastSibling(f, dir) {
+		return
+	}
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	if o.dd.seenBefore(f.ID()) {
@@ -201,7 +216,10 @@ func NewUserBotLatency(cfg LatencyConfig) *UserBotLatency {
 }
 
 // OnFrame implements pipeline.Observer.
-func (o *UserBotLatency) OnFrame(f frames.Frame, _ processor.Direction) {
+func (o *UserBotLatency) OnFrame(f frames.Frame, dir processor.Direction) {
+	if skipBroadcastSibling(f, dir) {
+		return
+	}
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	if o.dd.seenBefore(f.ID()) {
@@ -246,7 +264,10 @@ func NewStartupTiming(cfg StartupConfig) *StartupTiming {
 }
 
 // OnFrame implements pipeline.Observer.
-func (o *StartupTiming) OnFrame(f frames.Frame, _ processor.Direction) {
+func (o *StartupTiming) OnFrame(f frames.Frame, dir processor.Direction) {
+	if skipBroadcastSibling(f, dir) {
+		return
+	}
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	if o.dd.seenBefore(f.ID()) {

--- a/observers/observers_test.go
+++ b/observers/observers_test.go
@@ -80,3 +80,38 @@ func TestStartupTimingFiresOnce(t *testing.T) {
 		t.Fatalf("OnStartup called %d times, want 1", n)
 	}
 }
+
+// TestBroadcastSiblingCountedOnce pins the invariant that a broadcast pair — two
+// distinct frames, one per direction — drives a single turn transition.
+//
+// The halves carry different ids by design, so the id deduper cannot pair them;
+// only BroadcastSiblingID can. TurnTracking's state machine happens to absorb a
+// duplicate barge-in on its own, so this test passes with or without the sibling
+// guard: it documents the contract every observer relies on rather than catching
+// a regression in this one.
+func TestBroadcastSiblingCountedOnce(t *testing.T) {
+	var started, ended int
+	o := observers.NewTurnTracking(observers.TurnTrackingConfig{
+		OnTurnStarted: func(int) { started++ },
+		OnTurnEnded:   func(int, time.Duration, bool) { ended++ },
+	})
+
+	// Turn one begins with the pipeline and the bot starts speaking.
+	o.OnFrame(frames.NewStartFrame(), processor.Downstream)
+	o.OnFrame(frames.NewBotStartedSpeakingFrame(), processor.Downstream)
+	started, ended = 0, 0
+
+	// The user barges in. UserTurnProcessor.Broadcast builds one frame per
+	// direction and pairs them, so both halves reach the observer.
+	down := frames.NewUserStartedSpeakingFrame()
+	up := frames.NewUserStartedSpeakingFrame()
+	down.SetBroadcastSiblingID(up.ID())
+	up.SetBroadcastSiblingID(down.ID())
+
+	o.OnFrame(down, processor.Downstream)
+	o.OnFrame(up, processor.Upstream)
+
+	if ended != 1 || started != 1 {
+		t.Errorf("turn transitions = %d ended / %d started, want exactly 1 each", ended, started)
+	}
+}

--- a/pipeline/lifecycle_test.go
+++ b/pipeline/lifecycle_test.go
@@ -1,0 +1,222 @@
+package pipeline_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gojargo/jargo/frames"
+	"github.com/gojargo/jargo/pipeline"
+	"github.com/gojargo/jargo/processor"
+)
+
+// Tests for the worker frames a processor pushes upstream to ask the Task to end,
+// cancel, stop or interrupt the run, and for the flush probe that reports when
+// the pipeline has drained.
+
+// upstreamOnce forwards every frame downstream and, the first time it sees a
+// TextFrame, pushes a preloaded frame upstream toward the Task. It stands in for
+// a processor deep in the pipeline that has no Task handle.
+type upstreamOnce struct {
+	*processor.Base
+	send frames.Frame
+	once sync.Once
+}
+
+func newUpstreamOnce(send frames.Frame) *upstreamOnce {
+	u := &upstreamOnce{send: send}
+	u.Base = processor.New("UpstreamOnce", u)
+	return u
+}
+
+func (u *upstreamOnce) ProcessFrame(ctx context.Context, f frames.Frame, dir processor.Direction) error {
+	if err := u.Base.ProcessFrame(ctx, f, dir); err != nil {
+		return err
+	}
+	if _, ok := f.(*frames.TextFrame); ok {
+		u.once.Do(func() { _ = u.PushFrame(ctx, u.send, processor.Upstream) })
+	}
+	return u.PushFrame(ctx, f, dir)
+}
+
+// runTask starts a task and returns a channel carrying its run error.
+func runTask(t *testing.T, task *pipeline.Task) chan error {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() { done <- task.Run(context.Background()) }()
+	return done
+}
+
+// waitDone fails the test if the task does not finish promptly.
+func waitDone(t *testing.T, done chan error) {
+	t.Helper()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("task run error: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("task did not finish")
+	}
+}
+
+// TestWorkerFramesEndTheRun checks each worker frame a processor pushes upstream
+// drives the Task to the matching pipeline-wide frame, so a processor with no
+// Task handle can still end, cancel or stop the run.
+func TestWorkerFramesEndTheRun(t *testing.T) {
+	tests := []struct {
+		name    string
+		send    func() frames.Frame
+		wantEnd func(frames.Frame) bool
+	}{
+		{
+			name: "EndWorkerFrame yields an EndFrame",
+			send: func() frames.Frame { return frames.NewEndWorkerFrame() },
+			wantEnd: func(f frames.Frame) bool {
+				_, ok := f.(*frames.EndFrame)
+				return ok
+			},
+		},
+		{
+			name: "CancelWorkerFrame yields a CancelFrame",
+			send: func() frames.Frame { return frames.NewCancelWorkerFrame() },
+			wantEnd: func(f frames.Frame) bool {
+				_, ok := f.(*frames.CancelFrame)
+				return ok
+			},
+		},
+		{
+			name: "StopWorkerFrame yields a StopFrame",
+			send: func() frames.Frame { return frames.NewStopWorkerFrame() },
+			wantEnd: func(f frames.Frame) bool {
+				_, ok := f.(*frames.StopFrame)
+				return ok
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var mu sync.Mutex
+			var saw bool
+
+			pipe := pipeline.New(newUpstreamOnce(tt.send()))
+			task := pipeline.NewTask(pipe, pipeline.TaskParams{
+				OnReachedDownstream: func(f frames.Frame) {
+					if tt.wantEnd(f) {
+						mu.Lock()
+						saw = true
+						mu.Unlock()
+					}
+				},
+			})
+
+			done := runTask(t, task)
+			task.QueueFrame(frames.NewTextFrame("go"))
+			waitDone(t, done)
+
+			mu.Lock()
+			defer mu.Unlock()
+			if !saw {
+				t.Error("the worker frame did not produce its pipeline-wide counterpart")
+			}
+		})
+	}
+}
+
+// TestCancelWorkerFrameCarriesReason checks a deliberate cancellation keeps its
+// reason, so stopping a healthy run is not reported as an error.
+func TestCancelWorkerFrameCarriesReason(t *testing.T) {
+	var mu sync.Mutex
+	var reason string
+	var sawError bool
+
+	cancel := frames.NewCancelWorkerFrame()
+	cancel.Reason = "caller hung up"
+
+	pipe := pipeline.New(newUpstreamOnce(cancel))
+	task := pipeline.NewTask(pipe, pipeline.TaskParams{
+		OnReachedDownstream: func(f frames.Frame) {
+			mu.Lock()
+			defer mu.Unlock()
+			if cf, ok := f.(*frames.CancelFrame); ok {
+				reason = cf.Reason
+			}
+			if _, ok := f.(*frames.ErrorFrame); ok {
+				sawError = true
+			}
+		},
+	})
+
+	done := runTask(t, task)
+	task.QueueFrame(frames.NewTextFrame("go"))
+	waitDone(t, done)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if reason != "caller hung up" {
+		t.Errorf("CancelFrame.Reason = %q, want the reason carried from the worker frame", reason)
+	}
+	if sawError {
+		t.Error("a deliberate cancellation should not surface as an ErrorFrame")
+	}
+}
+
+// TestFlushProbeRoundTrip checks Flush returns only after the frames queued ahead
+// of the probe have been processed — the guarantee a caller relies on to let the
+// pipeline settle before injecting new work.
+func TestFlushProbeRoundTrip(t *testing.T) {
+	var mu sync.Mutex
+	var seen []string
+
+	pipe := pipeline.New(newEcho())
+	task := pipeline.NewTask(pipe, pipeline.TaskParams{
+		OnReachedDownstream: func(f frames.Frame) {
+			if tf, ok := f.(*frames.TextFrame); ok {
+				mu.Lock()
+				seen = append(seen, tf.Text)
+				mu.Unlock()
+			}
+		},
+	})
+
+	done := runTask(t, task)
+
+	task.QueueFrame(frames.NewTextFrame("first"))
+	task.QueueFrame(frames.NewTextFrame("second"))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := task.Flush(ctx); err != nil {
+		t.Fatalf("Flush() = %v, want the probe to complete its round trip", err)
+	}
+
+	mu.Lock()
+	got := append([]string(nil), seen...)
+	mu.Unlock()
+	if len(got) != 2 || got[0] != "first" || got[1] != "second" {
+		t.Errorf("frames processed at flush = %v, want both queued frames done", got)
+	}
+
+	task.StopWhenDone()
+	waitDone(t, done)
+}
+
+// TestFlushHonorsContext checks Flush gives up when its context is canceled
+// rather than blocking forever on a pipeline that never drains.
+func TestFlushHonorsContext(t *testing.T) {
+	pipe := pipeline.New(newEcho())
+	task := pipeline.NewTask(pipe, pipeline.TaskParams{})
+
+	done := runTask(t, task)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := task.Flush(ctx); err == nil {
+		t.Error("Flush() = nil, want the canceled context's error")
+	}
+
+	task.StopWhenDone()
+	waitDone(t, done)
+}

--- a/pipeline/task.go
+++ b/pipeline/task.go
@@ -103,8 +103,27 @@ func (t *Task) QueueFrames(fs []frames.Frame) {
 // processed, by queueing an EndFrame.
 func (t *Task) StopWhenDone() { t.QueueFrame(frames.NewEndFrame()) }
 
+// Flush waits for the pipeline to drain: it queues a PipelineFlushFrame probe
+// and blocks until the probe has traveled down to the sink and back up to the
+// source, meaning every frame queued ahead of it has been processed. Use it to
+// let the pipeline settle — after an interruption, say — before injecting new
+// work. It returns ctx.Err() if ctx is done first.
+func (t *Task) Flush(ctx context.Context) error {
+	probe := frames.NewPipelineFlushFrame()
+	t.QueueFrame(probe)
+	select {
+	case <-probe.Done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 // Cancel stops the pipeline immediately by queueing a CancelFrame.
-func (t *Task) Cancel() {
+func (t *Task) Cancel() { t.cancelWithReason("") }
+
+// cancelWithReason queues a CancelFrame carrying reason, at most once.
+func (t *Task) cancelWithReason(reason string) {
 	t.mu.Lock()
 	if t.canceling {
 		t.mu.Unlock()
@@ -112,7 +131,9 @@ func (t *Task) Cancel() {
 	}
 	t.canceling = true
 	t.mu.Unlock()
-	t.QueueFrame(frames.NewCancelFrame())
+	cancel := frames.NewCancelFrame()
+	cancel.Reason = reason
+	t.QueueFrame(cancel)
 }
 
 // HasFinished reports whether the task has finished running.
@@ -193,11 +214,25 @@ func (t *Task) runLoop(ctx context.Context) error {
 
 // sinkPush observes frames reaching the end of the pipeline and signals the
 // lifecycle events the run loop waits on.
-func (t *Task) sinkPush(_ context.Context, f frames.Frame, _ processor.Direction) error {
+func (t *Task) sinkPush(ctx context.Context, f frames.Frame, _ processor.Direction) error {
+	// The flush probe reached the sink. Bounce the same instance back upstream so
+	// it returns to the source and the round trip covers both directions.
+	if probe, ok := f.(*frames.PipelineFlushFrame); ok {
+		return t.sink.PushFrame(ctx, probe, processor.Upstream)
+	}
+
+	// A worker frame pushed downstream — the documented default, so frames queued
+	// ahead of it are processed first — has now reached the end. Send a fresh
+	// instance back upstream so it arrives at the source, which converts it into
+	// the pipeline-wide frame.
+	if back := workerFrameEcho(f); back != nil {
+		return t.sink.PushFrame(ctx, back, processor.Upstream)
+	}
+
 	switch f.(type) {
 	case *frames.StartFrame:
 		t.startOnce.Do(func() { close(t.startSig) })
-	case *frames.EndFrame, *frames.CancelFrame:
+	case *frames.EndFrame, *frames.CancelFrame, *frames.StopFrame:
 		t.endOnce.Do(func() { close(t.endSig) })
 	}
 	if t.params.OnReachedDownstream != nil {
@@ -209,16 +244,40 @@ func (t *Task) sinkPush(_ context.Context, f frames.Frame, _ processor.Direction
 	return nil
 }
 
-// sourcePush observes frames reaching the start of the pipeline. A fatal error
-// cancels the pipeline.
-func (t *Task) sourcePush(_ context.Context, f frames.Frame, _ processor.Direction) error {
+// sourcePush observes frames reaching the start of the pipeline and converts the
+// worker frames a processor pushed upstream into the corresponding pipeline-wide
+// frame. A fatal error cancels the pipeline.
+func (t *Task) sourcePush(ctx context.Context, f frames.Frame, _ processor.Direction) error {
+	// The flush probe completed its round trip: everything queued ahead of it has
+	// been processed, so release whoever is waiting on it.
+	if probe, ok := f.(*frames.PipelineFlushFrame); ok {
+		probe.CloseDone()
+		return nil
+	}
+
 	if ef, ok := f.(*frames.ErrorFrame); ok && ef.Fatal {
 		t.Cancel()
 	}
-	// A processor asked to end gracefully: queue an EndFrame so frames already
-	// queued flush before the pipeline stops.
-	if _, ok := f.(*frames.EndWorkerFrame); ok {
-		t.StopWhenDone()
+
+	switch fr := f.(type) {
+	case *frames.EndWorkerFrame:
+		// End gracefully: queue an EndFrame so frames already queued flush before
+		// the pipeline stops.
+		end := frames.NewEndFrame()
+		end.Reason = fr.Reason
+		t.QueueFrame(end)
+	case *frames.CancelWorkerFrame:
+		// Stop right away, without flushing.
+		t.cancelWithReason(fr.Reason)
+	case *frames.StopWorkerFrame:
+		// Stop once queued frames are flushed, leaving processors running.
+		t.QueueFrame(frames.NewStopFrame())
+	case *frames.InterruptionWorkerFrame:
+		// Queue straight into the pipeline rather than the push queue, which may
+		// be blocked waiting for a pipeline-ending frame to finish traversing.
+		if err := t.pipeline.QueueFrame(ctx, frames.NewInterruptionFrame(), processor.Downstream); err != nil {
+			return err
+		}
 	}
 	if t.params.OnReachedUpstream != nil {
 		t.params.OnReachedUpstream(f)
@@ -229,9 +288,31 @@ func (t *Task) sourcePush(_ context.Context, f frames.Frame, _ processor.Directi
 	return nil
 }
 
+// workerFrameEcho returns a fresh worker frame to send back upstream when one
+// reaches the sink, or nil if f is not a worker frame. A new instance is built
+// rather than the original being reused so the two directions never share a
+// frame; the reason, where there is one, is carried across.
+func workerFrameEcho(f frames.Frame) frames.Frame {
+	switch fr := f.(type) {
+	case *frames.EndWorkerFrame:
+		back := frames.NewEndWorkerFrame()
+		back.Reason = fr.Reason
+		return back
+	case *frames.StopWorkerFrame:
+		return frames.NewStopWorkerFrame()
+	case *frames.CancelWorkerFrame:
+		back := frames.NewCancelWorkerFrame()
+		back.Reason = fr.Reason
+		return back
+	case *frames.InterruptionWorkerFrame:
+		return frames.NewInterruptionWorkerFrame()
+	}
+	return nil
+}
+
 func isPipelineEnd(f frames.Frame) bool {
 	switch f.(type) {
-	case *frames.EndFrame, *frames.CancelFrame:
+	case *frames.EndFrame, *frames.CancelFrame, *frames.StopFrame:
 		return true
 	}
 	return false

--- a/processor/aggregators/aggregators.go
+++ b/processor/aggregators/aggregators.go
@@ -133,15 +133,50 @@ func (u *UserAggregator) ProcessFrame(ctx context.Context, f frames.Frame, dir p
 		// is consumed and turned into the LLMContextFrame the LLM service runs.
 		return u.PushFrame(ctx, frames.NewLLMContextFrame(u.context), processor.Downstream)
 
-	case *frames.LLMMessagesAppendFrame:
-		// The turn-completion re-prompt appends a message to the context before a
-		// follow-up LLMRunFrame.
-		u.appendMessages(fr.Messages)
-		return u.PushFrame(ctx, f, dir)
+	case *frames.LLMMessagesAppendFrame, *frames.LLMMessagesUpdateFrame,
+		*frames.LLMSetToolsFrame, *frames.LLMSetToolChoiceFrame:
+		return u.handleContextUpdate(ctx, f, dir)
 
 	default:
 		return u.PushFrame(ctx, f, dir)
 	}
+}
+
+// handleContextUpdate applies a frame that mutates the shared LLM context and
+// then forwards it. Forwarding matters: a text LLM reads the context on its next
+// run, but a realtime (speech-to-speech) service generates continuously and
+// learns of a tool or message change only from the frame itself.
+func (u *UserAggregator) handleContextUpdate(
+	ctx context.Context, f frames.Frame, dir processor.Direction,
+) error {
+	runLLM := false
+
+	switch fr := f.(type) {
+	case *frames.LLMMessagesAppendFrame:
+		// The turn-completion re-prompt appends a message to the context before a
+		// follow-up LLMRunFrame.
+		u.appendMessages(fr.Messages)
+
+	case *frames.LLMMessagesUpdateFrame:
+		// Wholesale replacement of the conversation (restoring a saved session,
+		// resetting the conversation).
+		u.context.SetMessages(fr.Messages)
+		runLLM = fr.RunLLM
+
+	case *frames.LLMSetToolsFrame:
+		u.context.SetTools(fr.Tools)
+
+	case *frames.LLMSetToolChoiceFrame:
+		u.context.SetToolChoice(fr.ToolChoice)
+	}
+
+	if err := u.PushFrame(ctx, f, dir); err != nil {
+		return err
+	}
+	if runLLM {
+		return u.PushFrame(ctx, frames.NewLLMContextFrame(u.context), processor.Downstream)
+	}
+	return nil
 }
 
 // appendMessages adds messages to the context (used by the turn-completion

--- a/processor/aggregators/context_update_test.go
+++ b/processor/aggregators/context_update_test.go
@@ -1,0 +1,155 @@
+package aggregators_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/gojargo/jargo/frames"
+	"github.com/gojargo/jargo/pipeline"
+	"github.com/gojargo/jargo/processor/aggregators"
+)
+
+// Tests for the frames that mutate the shared LLM context. Each must do two
+// things: apply the change to the context, and reach downstream. The second half
+// is what a realtime (speech-to-speech) service depends on — it generates
+// continuously and never re-reads the context, so a change made only on the
+// context object would never reach the model.
+
+// runAggregator starts a task around the user aggregator and collects the frames
+// that reach the end of the pipeline.
+func runAggregator(t *testing.T, convo *frames.LLMContext) (*pipeline.Task, chan frames.Frame, chan error) {
+	t.Helper()
+	pair := aggregators.New(convo)
+	seen := make(chan frames.Frame, 32)
+	task := pipeline.NewTask(pipeline.New(pair.User()), pipeline.TaskParams{
+		OnReachedDownstream: func(f frames.Frame) {
+			select {
+			case seen <- f:
+			default:
+			}
+		},
+	})
+	runDone := make(chan error, 1)
+	go func() { runDone <- task.Run(context.Background()) }()
+	return task, seen, runDone
+}
+
+// awaitFrame waits for a frame the predicate accepts.
+func awaitFrame(t *testing.T, seen chan frames.Frame, match func(frames.Frame) bool, what string) frames.Frame {
+	t.Helper()
+	deadline := time.After(3 * time.Second)
+	for {
+		select {
+		case f := <-seen:
+			if match(f) {
+				return f
+			}
+		case <-deadline:
+			t.Fatalf("%s never reached the end of the pipeline", what)
+			return nil
+		}
+	}
+}
+
+// TestSetToolsFrameAppliesAndForwards is the regression test for the defect that
+// motivated the frame: changing tools must both update the context and travel
+// downstream, or a continuously running realtime service keeps the old toolset.
+func TestSetToolsFrameAppliesAndForwards(t *testing.T) {
+	convo := frames.NewLLMContext("system")
+	task, seen, runDone := runAggregator(t, convo)
+
+	tools := []frames.Tool{{
+		Name:        "get_weather",
+		Description: "look up the weather",
+		Parameters:  json.RawMessage(`{"type":"object"}`),
+	}}
+	task.QueueFrame(frames.NewLLMSetToolsFrame(tools))
+
+	got := awaitFrame(t, seen, func(f frames.Frame) bool {
+		_, ok := f.(*frames.LLMSetToolsFrame)
+		return ok
+	}, "LLMSetToolsFrame")
+
+	if fr, ok := got.(*frames.LLMSetToolsFrame); !ok || len(fr.Tools) != 1 {
+		t.Errorf("forwarded frame = %v, want it to carry the new toolset", got)
+	}
+	if ctxTools := convo.Tools(); len(ctxTools) != 1 || ctxTools[0].Name != "get_weather" {
+		t.Errorf("context tools = %+v, want the frame applied to the shared context", ctxTools)
+	}
+
+	task.StopWhenDone()
+	<-runDone
+}
+
+// TestSetToolChoiceFrameAppliesAndForwards covers the tool-choice counterpart.
+func TestSetToolChoiceFrameAppliesAndForwards(t *testing.T) {
+	convo := frames.NewLLMContext("system")
+	if got := convo.ToolChoice(); got != frames.ToolChoiceAuto {
+		t.Errorf("ToolChoice() = %q, want auto by default", got)
+	}
+
+	task, seen, runDone := runAggregator(t, convo)
+	task.QueueFrame(frames.NewLLMSetToolChoiceFrame(frames.ToolChoiceRequired))
+
+	awaitFrame(t, seen, func(f frames.Frame) bool {
+		_, ok := f.(*frames.LLMSetToolChoiceFrame)
+		return ok
+	}, "LLMSetToolChoiceFrame")
+
+	if got := convo.ToolChoice(); got != frames.ToolChoiceRequired {
+		t.Errorf("ToolChoice() = %q, want required", got)
+	}
+
+	task.StopWhenDone()
+	<-runDone
+}
+
+// TestMessagesUpdateFrameReplacesConversation checks the update frame replaces
+// the messages rather than appending, and leaves the system prompt alone.
+func TestMessagesUpdateFrameReplacesConversation(t *testing.T) {
+	convo := frames.NewLLMContext("system")
+	convo.AddUserMessage("old one")
+	convo.AddAssistantMessage("old two")
+
+	task, seen, runDone := runAggregator(t, convo)
+	task.QueueFrame(frames.NewLLMMessagesUpdateFrame([]frames.Message{
+		{Role: frames.RoleUser, Text: "restored"},
+	}))
+
+	awaitFrame(t, seen, func(f frames.Frame) bool {
+		_, ok := f.(*frames.LLMMessagesUpdateFrame)
+		return ok
+	}, "LLMMessagesUpdateFrame")
+
+	msgs := convo.Messages()
+	if len(msgs) != 1 || msgs[0].Text != "restored" {
+		t.Errorf("messages = %+v, want the conversation replaced, not appended", msgs)
+	}
+	if convo.System() != "system" {
+		t.Errorf("System() = %q, want the system prompt untouched", convo.System())
+	}
+
+	task.StopWhenDone()
+	<-runDone
+}
+
+// TestMessagesUpdateFrameRunLLM checks the update can trigger a generation on the
+// replaced conversation.
+func TestMessagesUpdateFrameRunLLM(t *testing.T) {
+	convo := frames.NewLLMContext("system")
+	task, seen, runDone := runAggregator(t, convo)
+
+	update := frames.NewLLMMessagesUpdateFrame([]frames.Message{{Role: frames.RoleUser, Text: "go"}})
+	update.RunLLM = true
+	task.QueueFrame(update)
+
+	awaitFrame(t, seen, func(f frames.Frame) bool {
+		_, ok := f.(*frames.LLMContextFrame)
+		return ok
+	}, "LLMContextFrame")
+
+	task.StopWhenDone()
+	<-runDone
+}

--- a/processor/rtvi/metrics_test.go
+++ b/processor/rtvi/metrics_test.go
@@ -14,7 +14,7 @@ func TestMetricsFrameBecomesMetricsMessage(t *testing.T) {
 	out := make(chan rtvi.Message, 8)
 	task := pipeline.NewTask(pipeline.New(rtvi.NewProcessor()), pipeline.TaskParams{
 		OnReachedDownstream: func(f frames.Frame) {
-			if m, ok := f.(*frames.OutputTransportMessageFrame); ok {
+			if m, ok := f.(*frames.OutputTransportMessageUrgentFrame); ok {
 				if msg, ok := m.Message.(rtvi.Message); ok {
 					select {
 					case out <- msg:

--- a/processor/rtvi/processor.go
+++ b/processor/rtvi/processor.go
@@ -15,7 +15,7 @@ import (
 // carries the messages to the client.
 //
 // Incoming client messages arrive as InputTransportMessageFrames; outgoing
-// messages are pushed downstream as OutputTransportMessageFrames.
+// messages are pushed downstream as OutputTransportMessageUrgentFrames.
 type Processor struct {
 	*processor.Base
 }
@@ -184,5 +184,5 @@ func (p *Processor) emitAndForward(ctx context.Context, f frames.Frame, dir proc
 
 // send pushes an RTVI message toward the output transport.
 func (p *Processor) send(ctx context.Context, msg Message) error {
-	return p.PushFrame(ctx, frames.NewOutputTransportMessageFrame(msg), processor.Downstream)
+	return p.PushFrame(ctx, frames.NewOutputTransportMessageUrgentFrame(msg), processor.Downstream)
 }

--- a/processor/rtvi/rtvi_test.go
+++ b/processor/rtvi/rtvi_test.go
@@ -50,12 +50,12 @@ func TestUserTranscriptionJSON(t *testing.T) {
 
 // TestProcessorHandshakeAndTranscript drives the RTVI processor in a pipeline:
 // a client-ready message must produce a bot-ready, and a TranscriptionFrame must
-// produce a user-transcription — both as OutputTransportMessageFrames.
+// produce a user-transcription — both as OutputTransportMessageUrgentFrames.
 func TestProcessorHandshakeAndTranscript(t *testing.T) {
 	out := make(chan rtvi.Message, 8)
 	task := pipeline.NewTask(pipeline.New(rtvi.NewProcessor()), pipeline.TaskParams{
 		OnReachedDownstream: func(f frames.Frame) {
-			if m, ok := f.(*frames.OutputTransportMessageFrame); ok {
+			if m, ok := f.(*frames.OutputTransportMessageUrgentFrame); ok {
 				if msg, ok := m.Message.(rtvi.Message); ok {
 					out <- msg
 				}
@@ -99,7 +99,7 @@ func TestProcessorLifecycleAndFunctionCalls(t *testing.T) {
 	out := make(chan rtvi.Message, 16)
 	task := pipeline.NewTask(pipeline.New(rtvi.NewProcessor()), pipeline.TaskParams{
 		OnReachedDownstream: func(f frames.Frame) {
-			if m, ok := f.(*frames.OutputTransportMessageFrame); ok {
+			if m, ok := f.(*frames.OutputTransportMessageUrgentFrame); ok {
 				if msg, ok := m.Message.(rtvi.Message); ok {
 					out <- msg
 				}

--- a/processor/turns/controller.go
+++ b/processor/turns/controller.go
@@ -22,7 +22,7 @@ type ControllerHooks struct {
 	StopTimeout        func(ctx context.Context)
 	ResetAggregation   func(ctx context.Context)
 	Push               func(ctx context.Context, f frames.Frame, dir processor.Direction)
-	Broadcast          func(ctx context.Context, f frames.Frame)
+	Broadcast          func(ctx context.Context, build func() frames.Frame)
 }
 
 // UserTurnController runs the start and stop strategy chains and owns the
@@ -145,10 +145,10 @@ func (c *UserTurnController) pushHook() func(frames.Frame, processor.Direction) 
 	}
 }
 
-func (c *UserTurnController) broadcastHook() func(frames.Frame) {
-	return func(f frames.Frame) {
+func (c *UserTurnController) broadcastHook() func(func() frames.Frame) {
+	return func(build func() frames.Frame) {
 		if c.hooks.Broadcast != nil {
-			c.hooks.Broadcast(c.ctx, f)
+			c.hooks.Broadcast(c.ctx, build)
 		}
 	}
 }

--- a/processor/turns/idle.go
+++ b/processor/turns/idle.go
@@ -74,15 +74,16 @@ func (c *UserIdleController) Push(ctx context.Context, f frames.Frame, dir proce
 	return emit.Push(ctx, f, dir)
 }
 
-// Broadcast sends a frame both downstream and upstream (for use from the callback).
-func (c *UserIdleController) Broadcast(ctx context.Context, f frames.Frame) error {
+// Broadcast sends a frame both downstream and upstream (for use from the
+// callback), building a separate instance for each direction.
+func (c *UserIdleController) Broadcast(ctx context.Context, build func() frames.Frame) error {
 	c.mu.Lock()
 	emit := c.emit
 	c.mu.Unlock()
 	if emit == nil {
 		return nil
 	}
-	return emit.Broadcast(ctx, f)
+	return emit.Broadcast(ctx, build)
 }
 
 // Process updates idle state from one frame and arms/cancels the timer.

--- a/processor/turns/processor.go
+++ b/processor/turns/processor.go
@@ -52,7 +52,7 @@ func NewUserTurnProcessor(cfg Config) *UserTurnProcessor {
 		Started:   p.onTurnStarted,
 		Stopped:   p.onTurnStopped,
 		Push:      func(ctx context.Context, f frames.Frame, dir processor.Direction) { _ = p.PushFrame(ctx, f, dir) },
-		Broadcast: func(ctx context.Context, f frames.Frame) { _ = p.Broadcast(ctx, f) },
+		Broadcast: func(ctx context.Context, build func() frames.Frame) { _ = p.Broadcast(ctx, build) },
 	})
 	return p
 }
@@ -113,9 +113,9 @@ func (p *UserTurnProcessor) suppressed(ctx context.Context, f frames.Frame) bool
 	if should != p.muted {
 		p.muted = should
 		if should {
-			_ = p.Broadcast(ctx, frames.NewUserMuteStartedFrame())
+			_ = p.Broadcast(ctx, func() frames.Frame { return frames.NewUserMuteStartedFrame() })
 		} else {
-			_ = p.Broadcast(ctx, frames.NewUserMuteStoppedFrame())
+			_ = p.Broadcast(ctx, func() frames.Frame { return frames.NewUserMuteStoppedFrame() })
 		}
 	}
 	if !p.muted {
@@ -137,22 +137,33 @@ func (p *UserTurnProcessor) Push(ctx context.Context, f frames.Frame, dir proces
 
 // Broadcast implements Emitter, sending a frame both downstream and upstream so
 // turn decisions reach the whole pipeline.
-func (p *UserTurnProcessor) Broadcast(ctx context.Context, f frames.Frame) error {
-	if err := p.PushFrame(ctx, f, processor.Downstream); err != nil {
+//
+// build is called once per direction: the two halves are distinct frames, paired
+// by BroadcastSiblingID. That matters for two reasons. The directions are
+// processed on separate goroutines, so a shared frame would be mutated
+// concurrently; and a consumer that sees both halves — an observer, say — can
+// recognize the pair and act on one of them rather than reporting the event
+// twice.
+func (p *UserTurnProcessor) Broadcast(ctx context.Context, build func() frames.Frame) error {
+	down, up := build(), build()
+	down.Base().SetBroadcastSiblingID(up.ID())
+	up.Base().SetBroadcastSiblingID(down.ID())
+
+	if err := p.PushFrame(ctx, down, processor.Downstream); err != nil {
 		return err
 	}
-	return p.PushFrame(ctx, f, processor.Upstream)
+	return p.PushFrame(ctx, up, processor.Upstream)
 }
 
 // onTurnStarted broadcasts the turn-start decision and barges in, and feeds the
 // idle controller a synthetic user-started frame so it tracks the turn.
 func (p *UserTurnProcessor) onTurnStarted(ctx context.Context, params UserTurnStartedParams) {
 	if params.EnableUserSpeakingFrames {
-		_ = p.Broadcast(ctx, frames.NewUserStartedSpeakingFrame())
+		_ = p.Broadcast(ctx, func() frames.Frame { return frames.NewUserStartedSpeakingFrame() })
 	}
 	p.idle.Process(frames.NewUserStartedSpeakingFrame())
 	if params.EnableInterruptions {
-		_ = p.Broadcast(ctx, frames.NewInterruptionFrame())
+		_ = p.Broadcast(ctx, func() frames.Frame { return frames.NewInterruptionFrame() })
 	}
 }
 
@@ -160,7 +171,7 @@ func (p *UserTurnProcessor) onTurnStarted(ctx context.Context, params UserTurnSt
 // a synthetic user-stopped frame.
 func (p *UserTurnProcessor) onTurnStopped(ctx context.Context, params UserTurnStoppedParams) {
 	if params.EnableUserSpeakingFrames {
-		_ = p.Broadcast(ctx, frames.NewUserStoppedSpeakingFrame())
+		_ = p.Broadcast(ctx, func() frames.Frame { return frames.NewUserStoppedSpeakingFrame() })
 	}
 	p.idle.Process(frames.NewUserStoppedSpeakingFrame())
 }

--- a/processor/turns/strategies_internal_test.go
+++ b/processor/turns/strategies_internal_test.go
@@ -40,7 +40,7 @@ func (s *spy) env() strategyEnv {
 		resetAggregation:   func() { s.resets++ },
 		inferenceTriggered: func() { s.inferences++ },
 		push:               func(_ frames.Frame, d processor.Direction) { s.pushed = append(s.pushed, d) },
-		broadcast:          func(f frames.Frame) { s.broadcast = append(s.broadcast, f) },
+		broadcast:          func(build func() frames.Frame) { s.broadcast = append(s.broadcast, build()) },
 	}
 }
 
@@ -868,7 +868,7 @@ func TestStrategyBaseNoOps(t *testing.T) {
 		b.Cleanup()
 		b.TriggerStopped()
 		b.Push(frames.NewUserSpeakingFrame(), processor.Downstream)
-		b.Broadcast(frames.NewUserSpeakingFrame())
+		b.Broadcast(func() frames.Frame { return frames.NewUserSpeakingFrame() })
 	})
 }
 
@@ -881,7 +881,7 @@ func TestStopStrategyBaseEmits(t *testing.T) {
 	b.attach(spy.env())
 
 	b.Push(frames.NewUserSpeakingFrame(), processor.Upstream)
-	b.Broadcast(frames.NewBotSpeakingFrame())
+	b.Broadcast(func() frames.Frame { return frames.NewBotSpeakingFrame() })
 	b.TriggerStopped()
 
 	if len(spy.pushed) != 1 || spy.pushed[0] != processor.Upstream {
@@ -958,7 +958,7 @@ func (e *fakeEmitter) Push(_ context.Context, _ frames.Frame, dir processor.Dire
 	return e.err
 }
 
-func (e *fakeEmitter) Broadcast(_ context.Context, _ frames.Frame) error {
+func (e *fakeEmitter) Broadcast(_ context.Context, _ func() frames.Frame) error {
 	e.broadcast++
 	return e.err
 }
@@ -971,7 +971,7 @@ func TestUserIdleControllerEmit(t *testing.T) {
 		if err := c.Push(t.Context(), frames.NewUserSpeakingFrame(), processor.Downstream); err != nil {
 			t.Errorf("Push before Setup: %v", err)
 		}
-		if err := c.Broadcast(t.Context(), frames.NewUserSpeakingFrame()); err != nil {
+		if err := c.Broadcast(t.Context(), func() frames.Frame { return frames.NewUserSpeakingFrame() }); err != nil {
 			t.Errorf("Broadcast before Setup: %v", err)
 		}
 	})
@@ -984,7 +984,7 @@ func TestUserIdleControllerEmit(t *testing.T) {
 		if err := c.Push(t.Context(), frames.NewUserSpeakingFrame(), processor.Upstream); err != nil {
 			t.Errorf("Push: %v", err)
 		}
-		if err := c.Broadcast(t.Context(), frames.NewUserSpeakingFrame()); err != nil {
+		if err := c.Broadcast(t.Context(), func() frames.Frame { return frames.NewUserSpeakingFrame() }); err != nil {
 			t.Errorf("Broadcast: %v", err)
 		}
 		if len(emit.pushed) != 1 || emit.pushed[0] != processor.Upstream {
@@ -1004,7 +1004,8 @@ func TestUserIdleControllerEmit(t *testing.T) {
 		if err := c.Push(t.Context(), frames.NewUserSpeakingFrame(), processor.Downstream); !errors.Is(err, errEmit) {
 			t.Errorf("Push error = %v, want errEmit", err)
 		}
-		if err := c.Broadcast(t.Context(), frames.NewUserSpeakingFrame()); !errors.Is(err, errEmit) {
+		build := func() frames.Frame { return frames.NewUserSpeakingFrame() }
+		if err := c.Broadcast(t.Context(), build); !errors.Is(err, errEmit) {
 			t.Errorf("Broadcast error = %v, want errEmit", err)
 		}
 	})

--- a/processor/turns/strategy.go
+++ b/processor/turns/strategy.go
@@ -22,7 +22,7 @@ type strategyEnv struct {
 	inferenceTriggered func()
 	stopped            func(params UserTurnStoppedParams)
 	push               func(f frames.Frame, dir processor.Direction)
-	broadcast          func(f frames.Frame)
+	broadcast          func(build func() frames.Frame)
 }
 
 // after schedules fn to run after d with the shared mutex held, returning a
@@ -166,10 +166,11 @@ func (b *StopStrategyBase) Push(f frames.Frame, dir processor.Direction) {
 	}
 }
 
-// Broadcast sends a frame both downstream and upstream.
-func (b *StopStrategyBase) Broadcast(f frames.Frame) {
+// Broadcast builds one frame per direction and sends them both ways. It takes a
+// constructor so the two directions never share an instance.
+func (b *StopStrategyBase) Broadcast(build func() frames.Frame) {
 	if b.env.broadcast != nil {
-		b.env.broadcast(f)
+		b.env.broadcast(build)
 	}
 }
 

--- a/processor/turns/types.go
+++ b/processor/turns/types.go
@@ -54,11 +54,14 @@ func DefaultStoppedParams() UserTurnStoppedParams {
 
 // Emitter lets a controller or strategy push frames into the pipeline. The
 // UserTurnProcessor implements it. Broadcast sends a frame both downstream and
-// upstream (the analog of Pipecat's broadcast_frame), which is how turn
-// decisions and interruptions reach the whole pipeline.
+// upstream, which is how turn decisions and interruptions reach the whole
+// pipeline.
 type Emitter interface {
 	// Push sends a frame to the neighbor in dir.
 	Push(ctx context.Context, f frames.Frame, dir processor.Direction) error
-	// Broadcast sends a frame both downstream and upstream.
-	Broadcast(ctx context.Context, f frames.Frame) error
+	// Broadcast builds one frame per direction and sends them both ways. It takes
+	// a constructor rather than a frame because the two directions must not share
+	// one instance: each is processed on its own goroutine, and a frame is owned
+	// by a single goroutine at a time.
+	Broadcast(ctx context.Context, build func() frames.Frame) error
 }

--- a/provider/openairealtime/s2s.go
+++ b/provider/openairealtime/s2s.go
@@ -1,11 +1,13 @@
 package openairealtime
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net/http"
 	"sync"
 
@@ -25,6 +27,13 @@ type Service struct {
 	cancel  context.CancelFunc
 	writeMu sync.Mutex
 	wg      sync.WaitGroup
+
+	// tools and toolChoice are the function-calling configuration currently
+	// advertised to the session. The model generates continuously, so it does not
+	// re-read the context between turns: every change must be pushed to it with a
+	// session.update. They are guarded by mu.
+	tools      []frames.Tool
+	toolChoice frames.ToolChoice
 }
 
 // New builds a Realtime service.
@@ -63,6 +72,20 @@ func (s *Service) ProcessFrame(ctx context.Context, f frames.Frame, dir processo
 			s.sendAudio(fr.Audio)
 			return nil // The model consumes the audio; it does not flow on.
 		}
+		return s.PushFrame(ctx, f, dir)
+	case *frames.LLMContextFrame:
+		// Seed the function-calling configuration from the shared context.
+		if fr.Context != nil {
+			s.syncTools(fr.Context.Tools(), fr.Context.ToolChoice())
+		}
+		return s.PushFrame(ctx, f, dir)
+	case *frames.LLMSetToolsFrame:
+		// The toolset changed mid-conversation. A text LLM would pick this up on
+		// its next run; this model is generating continuously, so tell it now.
+		s.syncTools(fr.Tools, s.currentToolChoice())
+		return s.PushFrame(ctx, f, dir)
+	case *frames.LLMSetToolChoiceFrame:
+		s.syncTools(s.currentTools(), fr.ToolChoice)
 		return s.PushFrame(ctx, f, dir)
 	case *frames.EndFrame, *frames.CancelFrame:
 		s.disconnect()
@@ -141,7 +164,89 @@ func (s *Service) sessionUpdate() sessionUpdateMsg {
 	if s.cfg.TranscriptionModel != "-" {
 		session["input_audio_transcription"] = map[string]any{"model": s.cfg.TranscriptionModel}
 	}
+	maps.Copy(session, s.toolSession(s.currentTools(), s.currentToolChoice()))
 	return sessionUpdateMsg{Type: "session.update", Session: session}
+}
+
+// toolSession renders the function-calling part of a session payload. It is
+// empty when no tools are advertised, so a session without function calling is
+// configured exactly as before.
+func (s *Service) toolSession(tools []frames.Tool, choice frames.ToolChoice) map[string]any {
+	if len(tools) == 0 {
+		return nil
+	}
+	specs := make([]map[string]any, 0, len(tools))
+	for _, t := range tools {
+		spec := map[string]any{"type": "function", "name": t.Name}
+		if t.Description != "" {
+			spec["description"] = t.Description
+		}
+		if len(t.Parameters) > 0 {
+			spec["parameters"] = t.Parameters
+		}
+		specs = append(specs, spec)
+	}
+	if choice == "" {
+		choice = frames.ToolChoiceAuto
+	}
+	return map[string]any{"tools": specs, "tool_choice": string(choice)}
+}
+
+// currentTools returns the tools currently advertised to the session.
+func (s *Service) currentTools() []frames.Tool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.tools
+}
+
+// currentToolChoice returns the tool choice currently advertised to the session.
+func (s *Service) currentToolChoice() frames.ToolChoice {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.toolChoice
+}
+
+// syncTools records the function-calling configuration and, when it differs from
+// what the live session was told, pushes a session.update so the continuously
+// running model picks the change up. It is a no-op before the session connects;
+// the initial sessionUpdate carries whatever has been recorded by then.
+func (s *Service) syncTools(tools []frames.Tool, choice frames.ToolChoice) {
+	s.mu.Lock()
+	if sameTools(s.tools, tools) && s.toolChoice == choice {
+		s.mu.Unlock()
+		return
+	}
+	s.tools = tools
+	s.toolChoice = choice
+	live := s.conn != nil
+	s.mu.Unlock()
+
+	if !live {
+		return
+	}
+	session := s.toolSession(tools, choice)
+	if session == nil {
+		// Clearing the toolset still has to reach the model.
+		session = map[string]any{"tools": []map[string]any{}}
+	}
+	if err := s.send(sessionUpdateMsg{Type: "session.update", Session: session}); err != nil {
+		slog.Warn("openai realtime tool update failed", "err", err)
+	}
+}
+
+// sameTools reports whether two toolsets are equivalent for session purposes.
+func sameTools(a, b []frames.Tool) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Name != b[i].Name ||
+			a[i].Description != b[i].Description ||
+			!bytes.Equal(a[i].Parameters, b[i].Parameters) {
+			return false
+		}
+	}
+	return true
 }
 
 // sendAudio appends a chunk of input PCM to the model's input buffer.

--- a/provider/openairealtime/tools_test.go
+++ b/provider/openairealtime/tools_test.go
@@ -1,0 +1,151 @@
+package openairealtime_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/gojargo/jargo/frames"
+	"github.com/gojargo/jargo/pipeline"
+	"github.com/gojargo/jargo/provider/openairealtime"
+)
+
+// A realtime model generates continuously, so it never re-reads the shared LLM
+// context between turns: a tool change reaches it only if the service pushes a
+// session.update. These tests drive the service against a fake server and assert
+// on what it actually sent.
+
+// recordingRealtime is a WebSocket server that records every message the client
+// sends and never speaks first.
+type recordingRealtime struct {
+	*httptest.Server
+	mu   sync.Mutex
+	sent []map[string]any
+}
+
+func newRecordingRealtime(t *testing.T) *recordingRealtime {
+	t.Helper()
+	r := &recordingRealtime{}
+	r.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		c, err := websocket.Accept(w, req, &websocket.AcceptOptions{InsecureSkipVerify: true})
+		if err != nil {
+			return
+		}
+		defer func() { _ = c.Close(websocket.StatusNormalClosure, "") }()
+		ctx := req.Context()
+		for {
+			_, data, err := c.Read(ctx)
+			if err != nil {
+				return
+			}
+			var msg map[string]any
+			if json.Unmarshal(data, &msg) != nil {
+				continue
+			}
+			r.mu.Lock()
+			r.sent = append(r.sent, msg)
+			r.mu.Unlock()
+		}
+	}))
+	return r
+}
+
+// awaitSessionWithTools waits for a session.update whose session carries a tool
+// named want, returning the tool_choice it was sent with.
+func (r *recordingRealtime) awaitSessionWithTools(t *testing.T, want string) string {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		r.mu.Lock()
+		msgs := append([]map[string]any(nil), r.sent...)
+		r.mu.Unlock()
+
+		for _, m := range msgs {
+			if m["type"] != "session.update" {
+				continue
+			}
+			session, ok := m["session"].(map[string]any)
+			if !ok {
+				continue
+			}
+			tools, ok := session["tools"].([]any)
+			if !ok {
+				continue
+			}
+			for _, tool := range tools {
+				spec, ok := tool.(map[string]any)
+				if ok && spec["name"] == want {
+					choice, _ := session["tool_choice"].(string)
+					return choice
+				}
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("no session.update advertising tool %q was sent", want)
+	return ""
+}
+
+// runService starts the realtime service in a pipeline against srv.
+func runService(t *testing.T, url string) (*pipeline.Task, chan error) {
+	t.Helper()
+	svc := openairealtime.New(openairealtime.Config{
+		APIKey:  "k",
+		BaseURL: "ws" + strings.TrimPrefix(url, "http"),
+	})
+	task := pipeline.NewTask(pipeline.New(svc), pipeline.TaskParams{})
+	done := make(chan error, 1)
+	go func() { done <- task.Run(context.Background()) }()
+	return task, done
+}
+
+// TestSetToolsFrameReachesTheSession is the regression test for the defect:
+// changing tools mid-conversation must produce a session.update, or the running
+// model keeps offering the old toolset.
+func TestSetToolsFrameReachesTheSession(t *testing.T) {
+	srv := newRecordingRealtime(t)
+	defer srv.Close()
+
+	task, done := runService(t, srv.URL)
+
+	task.QueueFrame(frames.NewLLMSetToolsFrame([]frames.Tool{{
+		Name:        "get_weather",
+		Description: "look up the weather",
+		Parameters:  json.RawMessage(`{"type":"object"}`),
+	}}))
+
+	if choice := srv.awaitSessionWithTools(t, "get_weather"); choice != string(frames.ToolChoiceAuto) {
+		t.Errorf("tool_choice = %q, want auto by default", choice)
+	}
+
+	task.StopWhenDone()
+	<-done
+}
+
+// TestContextFrameSeedsSessionTools checks the toolset configured on the shared
+// context reaches the session too, so function calling works without the caller
+// having to push a tools frame by hand.
+func TestContextFrameSeedsSessionTools(t *testing.T) {
+	srv := newRecordingRealtime(t)
+	defer srv.Close()
+
+	convo := frames.NewLLMContext("system")
+	convo.SetTools([]frames.Tool{{Name: "book_table"}})
+	convo.SetToolChoice(frames.ToolChoiceRequired)
+
+	task, done := runService(t, srv.URL)
+	task.QueueFrame(frames.NewLLMContextFrame(convo))
+
+	if choice := srv.awaitSessionWithTools(t, "book_table"); choice != string(frames.ToolChoiceRequired) {
+		t.Errorf("tool_choice = %q, want required", choice)
+	}
+
+	task.StopWhenDone()
+	<-done
+}

--- a/transport/output.go
+++ b/transport/output.go
@@ -103,16 +103,10 @@ func (bo *BaseOutput) ProcessFrame(ctx context.Context, f frames.Frame, dir proc
 		bo.handleInterruption()
 		bo.stopBotSpeaking(ctx)
 		return nil
-	case *frames.OutputTransportMessageFrame:
-		if err := bo.sendMessage(ctx, fr); err != nil {
-			return err
-		}
-		return bo.PushFrame(ctx, f, dir)
-	case *frames.MixerControlFrame:
-		if bo.params.AudioOutMixer != nil {
-			_ = bo.params.AudioOutMixer.Control(ctx, fr.Settings)
-		}
-		return bo.PushFrame(ctx, f, dir)
+	case *frames.OutputTransportMessageFrame, *frames.OutputTransportMessageUrgentFrame:
+		return bo.handleTransportMessage(ctx, f, dir)
+	case frames.MixerControlFrame:
+		return bo.handleMixerControl(ctx, fr, dir)
 	case *frames.TTSAudioRawFrame, *frames.OutputAudioRawFrame:
 		if dir == processor.Downstream {
 			audio, rate, channels := outputAudio(f)
@@ -218,10 +212,51 @@ func (bo *BaseOutput) drainAudio(ctx context.Context) {
 	}
 }
 
-// sendMessage serializes a transport message to JSON and hands it to the
-// concrete transport.
-func (bo *BaseOutput) sendMessage(ctx context.Context, f *frames.OutputTransportMessageFrame) error {
-	data, err := json.Marshal(f.Message)
+// handleMixerControl applies a mixer control frame to the output mixer and
+// forwards it. The mixer's settings map is its whole control surface, so
+// enabling is expressed as the "enabled" setting.
+func (bo *BaseOutput) handleMixerControl(
+	ctx context.Context, f frames.MixerControlFrame, dir processor.Direction,
+) error {
+	if bo.params.AudioOutMixer != nil {
+		var settings map[string]any
+		switch fr := f.(type) {
+		case *frames.MixerUpdateSettingsFrame:
+			settings = fr.Settings
+		case *frames.MixerEnableFrame:
+			settings = map[string]any{"enabled": fr.Enable}
+		}
+		if settings != nil {
+			_ = bo.params.AudioOutMixer.Control(ctx, settings)
+		}
+	}
+	return bo.PushFrame(ctx, f, dir)
+}
+
+// handleTransportMessage sends an application message to the client and forwards
+// the frame on. It serves both message frames: the ordered one, which reaches
+// here in step with the surrounding audio, and the urgent one, which is a system
+// frame and so arrives ahead of anything queued.
+func (bo *BaseOutput) handleTransportMessage(
+	ctx context.Context, f frames.Frame, dir processor.Direction,
+) error {
+	var message any
+	switch fr := f.(type) {
+	case *frames.OutputTransportMessageFrame:
+		message = fr.Message
+	case *frames.OutputTransportMessageUrgentFrame:
+		message = fr.Message
+	}
+	if err := bo.sendMessage(ctx, message); err != nil {
+		return err
+	}
+	return bo.PushFrame(ctx, f, dir)
+}
+
+// sendMessage serializes a transport message payload to JSON and hands it to the
+// concrete transport. It serves both the ordered and the urgent message frames.
+func (bo *BaseOutput) sendMessage(ctx context.Context, message any) error {
+	data, err := json.Marshal(message)
 	if err != nil {
 		return err
 	}

--- a/transport/wsserver/rtviws/rtviws.go
+++ b/transport/wsserver/rtviws/rtviws.go
@@ -4,7 +4,7 @@
 // microphone audio arrives as raw-audio messages and enters the pipeline as
 // InputAudioRawFrames (VAD, turn detection and STT then see it as a live mic).
 // Outbound RTVI server messages reach the socket through the transport's own
-// message path (an OutputTransportMessageFrame).
+// message path (an OutputTransportMessageUrgentFrame).
 //
 // Bot audio is not yet streamed back over the socket, so a client on this
 // transport hears events and text, not synthesized speech. Pair it with a
@@ -60,7 +60,7 @@ func New() *Serializer { return &Serializer{} }
 func (*Serializer) Setup(*frames.StartFrame) error { return nil }
 
 // Serialize drops outbound frames. RTVI server messages reach the socket through
-// the transport's own OutputTransportMessageFrame path rather than the
+// the transport's own OutputTransportMessageUrgentFrame path rather than the
 // serializer, and bot audio is not streamed over this channel.
 func (*Serializer) Serialize(frames.Frame) ([]byte, error) { return nil, nil }
 


### PR DESCRIPTION
## Summary

Three defects and a package cleanup, found while reviewing `jargo/frames` against the design it is ported from.

### Fixes

**Speech-to-speech services never learned about tool changes.** A realtime model generates continuously and never re-reads the shared context between turns, so a toolset changed through `LLMContext.SetTools` reached a text LLM on its next run but never reached a realtime one. The OpenAI Realtime service made it worse by never sending tools at all — its session configuration carried voice, formats and turn detection but no function-calling configuration, so context-driven tool calls could not work there. Runtime changes now travel as frames (`LLMSetToolsFrame`, `LLMSetToolChoiceFrame`, `LLMMessagesUpdateFrame`): the aggregator applies each to the shared context *and forwards it*, which is what lets a continuously running service hear about it.

**Application messages jumped ahead of queued audio.** `OutputTransportMessageFrame` was a system frame, so a message meant to land in step with the bot's speech went out early, and no ordered variant existed. It is a data frame again, with `OutputTransportMessageUrgentFrame` as the immediate variant. RTVI uses the urgent one, so its behaviour is unchanged.

**A broadcast shared one frame between two goroutines.** `Broadcast` pushed the same pointer downstream and upstream, and the two directions are drained by separate goroutines — a latent data race on the path carrying every turn decision and interruption. It now builds one frame per direction, cross-linked by `BroadcastSiblingID`, and observers skip the upstream half so an event is still reported once.

### Added

- **Worker lifecycle frames.** `CancelWorkerFrame`, `StopWorkerFrame` and `InterruptionWorkerFrame` join `EndWorkerFrame`, so a processor with no `Task` handle can cancel, stop or interrupt a run. Cancelling a healthy run no longer has to be dressed as a fatal error.
- **`Task.Flush`**, a drain barrier: a `PipelineFlushFrame` probe travels to the sink and back, so a caller can wait for the pipeline to settle before injecting new work.
- **`MixerUpdateSettingsFrame` / `MixerEnableFrame`**, replacing the single settings-carrying frame.

### Changed

`frames.Frame` is now four methods (`String`, `ID`, `Name`, `Base`); the optional per-frame state lives on `BaseFrame` and is reached through `Base()`. The accessors stay promoted onto every concrete frame, so the whole tree compiled with no changes outside `frames/`. Also: `Reason` fields are `string` rather than `any`, `STTMetadataFrame` embeds `ServiceMetadataFrame`, `AudioRawData.NumFrames` is derived rather than cached, and the package now documents its category taxonomy and ownership rule.

The README intro is one sentence, and the project's maturity is now visible: a status badge, a warning callout, and a `Project status` section.

## Testing

`go build ./...`, `go test ./...`, `go test -race` on every touched package, and `golangci-lint run` are all clean. `frames` coverage is 99.2%. New tests cover the worker frames and the flush round trip, the context-update frames, and the realtime tool sync end to end against a recording WebSocket server.

## Notes for review

- The API breaks in several places. The project is `0.0.x`, and `CHANGELOG.md` lists each change.
- The observers' broadcast-sibling test documents an invariant rather than catching a regression: `TurnTracking`'s state machine happens to absorb a duplicate on its own. The comment says so.
- Three realtime providers (`geminilive`, `novasonic`, `sambanova`) still need the same tool-sync wiring as `openairealtime`; the frames flow past them today doing nothing. Left for a follow-up.