### PR TITLE
fix(mem0): nest search entity ids under filters for mem0 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,6 +203,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- **Memory recall failed against mem0 2.x** (`provider/mem0`): a search sent the
+  user, agent and run ids as top-level fields, which `search` rejects from 2.0.0
+  on — every retrieval failed with a 502 and the bot ran with no long-term
+  recall, while storage kept working. They now travel nested under `filters`,
+  the shape search expects. Storage still passes them top-level, which `add`
+  accepts.
+
 - **Trailing audio dropped at turn ends** (`transport`): the base output
   transport buffers audio into fixed-size chunks and used to leave the final
   sub-chunk of a turn sitting in the buffer, where a barge-in would clear it —

--- a/provider/mem0/mem0_test.go
+++ b/provider/mem0/mem0_test.go
@@ -16,9 +16,10 @@ import (
 
 // wire decodes the mem0 request bodies the test inspects.
 type searchBody struct {
-	Query  string `json:"query"`
-	UserID string `json:"user_id"`
-	TopK   int    `json:"top_k"`
+	Query   string            `json:"query"`
+	UserID  string            `json:"user_id"`
+	Filters map[string]string `json:"filters"`
+	TopK    int               `json:"top_k"`
 }
 
 type addBody struct {
@@ -64,8 +65,12 @@ func TestMemoryRetrievesAndStores(t *testing.T) {
 
 	select {
 	case b := <-searched:
-		if b.Query != "what do you remember about me?" || b.UserID != "u1" || b.TopK != 5 {
-			t.Fatalf("search request = %+v, want query/user/top_k populated", b)
+		if b.Query != "what do you remember about me?" || b.Filters["user_id"] != "u1" || b.TopK != 5 {
+			t.Fatalf("search request = %+v, want query/filters.user_id/top_k populated", b)
+		}
+		// The entity scope belongs under "filters"; search rejects it top-level.
+		if b.UserID != "" {
+			t.Fatalf("search request carried a top-level user_id = %q, want it only in filters", b.UserID)
 		}
 	case <-time.After(3 * time.Second):
 		t.Fatal("mem0 search was not called")

--- a/provider/mem0/memory.go
+++ b/provider/mem0/memory.go
@@ -98,13 +98,27 @@ func (s *Service) store(msgs []frames.Message) {
 	}
 }
 
+// searchFilters scopes a search to the configured entities. Search takes them
+// nested under "filters" and rejects the top-level fields that add accepts.
+func (s *Service) searchFilters() map[string]any {
+	filters := make(map[string]any, 3)
+	if s.cfg.UserID != "" {
+		filters["user_id"] = s.cfg.UserID
+	}
+	if s.cfg.AgentID != "" {
+		filters["agent_id"] = s.cfg.AgentID
+	}
+	if s.cfg.RunID != "" {
+		filters["run_id"] = s.cfg.RunID
+	}
+	return filters
+}
+
 // search returns the memories relevant to query.
 func (s *Service) search(ctx context.Context, query string) ([]memory, error) {
 	body := searchRequest{
 		Query:     query,
-		UserID:    s.cfg.UserID,
-		AgentID:   s.cfg.AgentID,
-		RunID:     s.cfg.RunID,
+		Filters:   s.searchFilters(),
 		TopK:      s.cfg.SearchLimit,
 		Threshold: s.cfg.SearchThreshold,
 	}
@@ -202,12 +216,10 @@ type addRequest struct {
 }
 
 type searchRequest struct {
-	Query     string  `json:"query"`
-	UserID    string  `json:"user_id,omitempty"`
-	AgentID   string  `json:"agent_id,omitempty"`
-	RunID     string  `json:"run_id,omitempty"`
-	TopK      int     `json:"top_k,omitempty"`
-	Threshold float64 `json:"threshold,omitempty"`
+	Query     string         `json:"query"`
+	Filters   map[string]any `json:"filters,omitempty"`
+	TopK      int            `json:"top_k,omitempty"`
+	Threshold float64        `json:"threshold,omitempty"`
 }
 
 // memory is one retrieved memory; the server returns more fields, but the text


### PR DESCRIPTION
## Summary

Memory recall has been failing against a mem0 2.x server. `Memory.search()` moved the entity scope (`user_id`, `agent_id`, `run_id`) into `filters` in 2.0.0 and now **rejects** the top-level fields:

```
ValueError: Top-level entity parameters frozenset({'user_id'}) are not supported in search().
Use filters={'user_id': '...'} instead.
```

The REST server forwards the request body straight into `search(**params)`, so it surfaced as a 502 on every `/search`. Storage was unaffected — `add` still takes them top-level — so a deployment accumulated memories it could never read back, degrading silently to no recall at all.

Search now sends them nested under `filters`; `add` is left as it is.

## Testing

`go build ./...`, `go test ./...` and `golangci-lint run` clean. The existing round-trip test now asserts the scope arrives in `filters` **and** that no top-level `user_id` is sent. Verified against a real self-hosted mem0 2.0.1: the previous body 502s, the new one returns 200 with the expected memories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)