### PR TITLE
feat(opus): inband FEC for lossy links, and a libopus frame-size fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   until the server acknowledges the session, and closing signals end of audio so
   the last transcript is flushed. `provider/xai/grok` previously offered only the LLM.
 
+- **Opus inband FEC.** `transport.Params` gained `AudioOutFEC` and
+  `AudioOutExpectedPacketLoss`, which enable forward error correction on the
+  outgoing stream so receivers can rebuild dropped packets instead of concealing
+  them. Worth enabling whenever clients may be on lossy links (mobile radio,
+  relayed media); on a clean link the redundancy is never decoded. Honored by
+  the `libopus` build; the pure-Go SILK encoder ignores it.
+
 - **Pipeline lifecycle frames.** A processor with no handle on the `Task` can now
   ask it to change the run's lifecycle, and the `Task` converts the request into
   the matching pipeline-wide frame: `frames.CancelWorkerFrame` becomes a
@@ -224,6 +231,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   behavior is untouched. A provider offering a single service (`deepgram`,
   `cartesia`, `nvidia`, …) keeps its top-level folder.
 
+- **`opus.NewEncoder` takes an `opus.EncoderConfig`** instead of positional
+  `channels, bitrate` arguments, matching the config-struct convention used
+  elsewhere and leaving room for the new FEC settings.
 - **Speech-to-speech services are told when tools change.** A realtime model
   generates continuously and never re-reads the shared context between turns, so
   a toolset changed with `LLMContext.SetTools` never reached it. Tool changes now
@@ -263,6 +273,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   construction, so it stays correct when `Audio` is replaced.
 - The `frames` package documents its ownership rule: a frame has a single owner
   at a time and must not be mutated after it is pushed.
+
+### Fixed
+
+- **The `libopus` encoder rejects wrong-sized frames** instead of reading past
+  the end of the caller's buffer: `opus_encode` consumes a fixed frame regardless
+  of the slice length, so a short frame read out of bounds. It now returns the
+  same error the pure-Go encoder does, as the shared API promises.
 
 ### Added
 

--- a/audio/opus/encoder_libopus.go
+++ b/audio/opus/encoder_libopus.go
@@ -8,12 +8,18 @@ package opus
 #include <stdlib.h>
 
 // opus_encoder_ctl is variadic, which cgo cannot call directly, so wrap the
-// two control requests we use in plain functions.
+// control requests we use in plain functions.
 static int jargo_opus_set_bitrate(OpusEncoder *enc, opus_int32 bitrate) {
 	return opus_encoder_ctl(enc, OPUS_SET_BITRATE(bitrate));
 }
 static int jargo_opus_set_signal_voice(OpusEncoder *enc) {
 	return opus_encoder_ctl(enc, OPUS_SET_SIGNAL(OPUS_SIGNAL_VOICE));
+}
+static int jargo_opus_set_inband_fec(OpusEncoder *enc, int on) {
+	return opus_encoder_ctl(enc, OPUS_SET_INBAND_FEC(on));
+}
+static int jargo_opus_set_packet_loss_perc(OpusEncoder *enc, int perc) {
+	return opus_encoder_ctl(enc, OPUS_SET_PACKET_LOSS_PERC(perc));
 }
 */
 import "C"
@@ -35,18 +41,17 @@ type Encoder struct {
 	out      []byte
 }
 
-var errEmptyPCM = errors.New("opus: empty pcm frame")
+var errFrameSize = errors.New("opus: wrong frame size")
 
-// NewEncoder builds an Encoder for channels-channel 48 kHz audio at the given
-// bitrate in bits per second; pass 0 for the codec default.
-func NewEncoder(channels, bitrate int) (*Encoder, error) {
+// NewEncoder builds an Encoder for 48 kHz audio from cfg.
+func NewEncoder(cfg EncoderConfig) (*Encoder, error) {
 	var cerr C.int
-	enc := C.opus_encoder_create(C.opus_int32(SampleRate), C.int(channels), C.OPUS_APPLICATION_VOIP, &cerr)
+	enc := C.opus_encoder_create(C.opus_int32(SampleRate), C.int(cfg.Channels), C.OPUS_APPLICATION_VOIP, &cerr)
 	if cerr != C.OPUS_OK || enc == nil {
 		return nil, fmt.Errorf("opus_encoder_create failed: %d", int(cerr))
 	}
-	if bitrate > 0 {
-		if rc := C.jargo_opus_set_bitrate(enc, C.opus_int32(bitrate)); rc != C.OPUS_OK {
+	if cfg.Bitrate > 0 {
+		if rc := C.jargo_opus_set_bitrate(enc, C.opus_int32(cfg.Bitrate)); rc != C.OPUS_OK {
 			C.opus_encoder_destroy(enc)
 			return nil, fmt.Errorf("opus set bitrate failed: %d", int(rc))
 		}
@@ -54,7 +59,21 @@ func NewEncoder(channels, bitrate int) (*Encoder, error) {
 	// Bias toward SILK for speech; harmless if the content is not voice.
 	C.jargo_opus_set_signal_voice(enc)
 
-	e := &Encoder{enc: enc, channels: channels, out: make([]byte, maxPacketBytes)}
+	if cfg.InbandFEC {
+		if rc := C.jargo_opus_set_inband_fec(enc, 1); rc != C.OPUS_OK {
+			C.opus_encoder_destroy(enc)
+			return nil, fmt.Errorf("opus set inband fec failed: %d", int(rc))
+		}
+		// Without a loss estimate libopus assumes 0% and emits no redundancy,
+		// so FEC would be on in name only.
+		perc := min(max(cfg.ExpectedPacketLoss, 0), 100)
+		if rc := C.jargo_opus_set_packet_loss_perc(enc, C.int(perc)); rc != C.OPUS_OK {
+			C.opus_encoder_destroy(enc)
+			return nil, fmt.Errorf("opus set packet loss perc failed: %d", int(rc))
+		}
+	}
+
+	e := &Encoder{enc: enc, channels: cfg.Channels, out: make([]byte, maxPacketBytes)}
 	// libopus encoders must be freed; tie the C lifetime to the Go object.
 	runtime.SetFinalizer(e, (*Encoder).free)
 	return e, nil
@@ -71,7 +90,7 @@ func (e *Encoder) free() {
 // FrameBytes(channels) bytes — into a single Opus packet.
 func (e *Encoder) Encode(pcm []byte) ([]byte, error) {
 	if len(pcm) == 0 {
-		return nil, errEmptyPCM
+		return nil, errFrameSize
 	}
 	// S16LE interleaved bytes are native int16 on little-endian targets
 	// (amd64/arm64), so the buffer can be read as opus_int16 without a copy.

--- a/audio/opus/encoder_libopus.go
+++ b/audio/opus/encoder_libopus.go
@@ -89,8 +89,10 @@ func (e *Encoder) free() {
 // Encode encodes exactly one 20 ms frame of interleaved S16LE PCM — that is
 // FrameBytes(channels) bytes — into a single Opus packet.
 func (e *Encoder) Encode(pcm []byte) ([]byte, error) {
-	if len(pcm) == 0 {
-		return nil, errFrameSize
+	// opus_encode reads a fixed FrameSamples*channels samples from the pointer
+	// regardless of the slice length, so a short frame would read out of bounds.
+	if len(pcm) != FrameBytes(e.channels) {
+		return nil, fmt.Errorf("%w: got %d bytes, want %d", errFrameSize, len(pcm), FrameBytes(e.channels))
 	}
 	// S16LE interleaved bytes are native int16 on little-endian targets
 	// (amd64/arm64), so the buffer can be read as opus_int16 without a copy.

--- a/audio/opus/encoder_silk.go
+++ b/audio/opus/encoder_silk.go
@@ -34,9 +34,10 @@ type Encoder struct {
 	out      []byte
 }
 
-// NewEncoder builds a SILK Encoder for channels-channel 48 kHz audio at the
-// given bitrate in bits per second; pass 0 for the codec default.
-func NewEncoder(channels, bitrate int) (*Encoder, error) {
+// NewEncoder builds a SILK Encoder for 48 kHz audio from cfg.
+// EncoderConfig.InbandFEC is ignored: this encoder emits no FEC redundancy.
+func NewEncoder(cfg EncoderConfig) (*Encoder, error) {
+	bitrate := cfg.Bitrate
 	if bitrate <= 0 {
 		bitrate = 24000
 	}
@@ -49,7 +50,7 @@ func NewEncoder(channels, bitrate int) (*Encoder, error) {
 		return nil, fmt.Errorf("new silk resampler: %w", err)
 	}
 
-	return &Encoder{enc: enc, down: down, channels: channels, out: make([]byte, maxPacketBytes)}, nil
+	return &Encoder{enc: enc, down: down, channels: cfg.Channels, out: make([]byte, maxPacketBytes)}, nil
 }
 
 // Encode encodes exactly one 20 ms frame of interleaved S16LE PCM — that is

--- a/audio/opus/opus.go
+++ b/audio/opus/opus.go
@@ -36,6 +36,26 @@ const (
 // FrameBytes is the size in bytes of one 20 ms S16LE frame for channels.
 func FrameBytes(channels int) int { return FrameSamples * channels * 2 }
 
+// EncoderConfig configures an Encoder.
+type EncoderConfig struct {
+	// Channels is the number of channels in the PCM handed to Encode.
+	Channels int
+	// Bitrate is the target bitrate in bits per second; 0 uses the codec
+	// default. Speech is transparent well below the codec's fullband range, so
+	// raising this past ~32 kbps for a single voice mostly costs bandwidth.
+	Bitrate int
+	// InbandFEC embeds a low-rate copy of the previous frame in each packet so
+	// the receiver can reconstruct a dropped one instead of concealing it. It
+	// trades a little of the bitrate budget for resilience, which is worth it
+	// on lossy links (mobile radio, relayed media) and inert on clean ones,
+	// where the redundancy is simply never decoded. Honored by the libopus
+	// build; the pure-Go SILK encoder ignores it.
+	InbandFEC bool
+	// ExpectedPacketLoss is the loss percentage (0-100) the encoder sizes its
+	// FEC redundancy for. Ignored unless InbandFEC is set.
+	ExpectedPacketLoss int
+}
+
 // Decoder decodes Opus packets into signed 16-bit little-endian PCM.
 type Decoder struct {
 	dec      pion.Decoder

--- a/audio/opus/opus_test.go
+++ b/audio/opus/opus_test.go
@@ -19,7 +19,7 @@ func sineFrame(freq float64) []byte {
 }
 
 func TestEncodeProducesPacket(t *testing.T) {
-	enc, err := opus.NewEncoder(1, 0)
+	enc, err := opus.NewEncoder(opus.EncoderConfig{Channels: 1})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -33,7 +33,7 @@ func TestEncodeProducesPacket(t *testing.T) {
 }
 
 func TestEncodeRejectsWrongFrameSize(t *testing.T) {
-	enc, err := opus.NewEncoder(1, 0)
+	enc, err := opus.NewEncoder(opus.EncoderConfig{Channels: 1})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -43,7 +43,7 @@ func TestEncodeRejectsWrongFrameSize(t *testing.T) {
 }
 
 func TestRoundTrip(t *testing.T) {
-	enc, err := opus.NewEncoder(1, 0)
+	enc, err := opus.NewEncoder(opus.EncoderConfig{Channels: 1})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/examples/silktest/main.go
+++ b/examples/silktest/main.go
@@ -31,7 +31,7 @@ func main() {
 	// Pure-Go resample to jargo's 48 kHz stream rate.
 	pcm48 := resampleI16(pcm, rate, opus.SampleRate)
 
-	enc, err := opus.NewEncoder(1, 24000)
+	enc, err := opus.NewEncoder(opus.EncoderConfig{Channels: 1, Bitrate: 24000})
 	must(err)
 	dec, err := opus.NewDecoder(1)
 	must(err)

--- a/transport/livekit/transport.go
+++ b/transport/livekit/transport.go
@@ -160,7 +160,13 @@ func (out *outputTransport) SendMessage(_ context.Context, data []byte) error {
 func (out *outputTransport) WriteAudio(ctx context.Context, pcm []byte) error {
 	ch := channels(out.Params().AudioOutChannels)
 	if out.enc == nil {
-		enc, err := opus.NewEncoder(ch, out.Params().AudioOutBitrate)
+		p := out.Params()
+		enc, err := opus.NewEncoder(opus.EncoderConfig{
+			Channels:           ch,
+			Bitrate:            p.AudioOutBitrate,
+			InbandFEC:          p.AudioOutFEC,
+			ExpectedPacketLoss: p.AudioOutExpectedPacketLoss,
+		})
 		if err != nil {
 			return err
 		}

--- a/transport/pionrtc/pionrtc_test.go
+++ b/transport/pionrtc/pionrtc_test.go
@@ -126,7 +126,7 @@ func TestWebRTCEchoLoopback(t *testing.T) {
 	go func() { _ = task.Run(ctx); close(taskDone) }()
 
 	// Client streams Opus audio until the test ends.
-	enc, err := opus.NewEncoder(1, 0)
+	enc, err := opus.NewEncoder(opus.EncoderConfig{Channels: 1})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/transport/pionrtc/transport.go
+++ b/transport/pionrtc/transport.go
@@ -165,7 +165,13 @@ func (out *outputTransport) SendMessage(_ context.Context, data []byte) error {
 func (out *outputTransport) WriteAudio(ctx context.Context, pcm []byte) error {
 	ch := channels(out.Params().AudioOutChannels)
 	if out.enc == nil {
-		enc, err := opus.NewEncoder(ch, out.Params().AudioOutBitrate)
+		p := out.Params()
+		enc, err := opus.NewEncoder(opus.EncoderConfig{
+			Channels:           ch,
+			Bitrate:            p.AudioOutBitrate,
+			InbandFEC:          p.AudioOutFEC,
+			ExpectedPacketLoss: p.AudioOutExpectedPacketLoss,
+		})
 		if err != nil {
 			return err
 		}

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -38,6 +38,14 @@ type Params struct {
 	// AudioOutBitrate is the output bitrate in bits per second; 0 uses the
 	// codec default.
 	AudioOutBitrate int
+	// AudioOutFEC enables Opus inband forward error correction on the outgoing
+	// stream, letting receivers rebuild dropped packets. Recommended whenever
+	// clients may be on lossy links.
+	AudioOutFEC bool
+	// AudioOutExpectedPacketLoss is the loss percentage (0-100) the encoder
+	// sizes its FEC redundancy for. Ignored unless AudioOutFEC is set; 0 leaves
+	// FEC enabled but carrying no redundancy, so set it alongside.
+	AudioOutExpectedPacketLoss int
 	// AudioOut10msChunks is how many 10 ms chunks of audio are written at a
 	// time. With WebRTC Opus this is 2, so audio is written in 20 ms frames.
 	AudioOut10msChunks int


### PR DESCRIPTION
## Why

A caller on mobile radio hears the bot's speech break up, while the same
build sounds fine on a desktop link. Nothing in the transport does
congestion control, NACK or retransmission, so every lost packet is a
concealed gap with no way to recover it — and the outgoing bitrate never
adapts to what the link can carry.

## What

**`feat(opus)`** — `transport.Params` gains `AudioOutFEC` and
`AudioOutExpectedPacketLoss`, wired through the Pion and LiveKit
transports. Opus inband FEC carries a low-rate copy of the previous frame
in each packet, so a receiver can rebuild a dropped one. It spends a
slice of the bitrate budget, and on a clean link the redundancy is simply
never decoded.

libopus needs both knobs: with FEC enabled but no loss estimate it
assumes 0% and emits no redundancy at all, so FEC would be on in name
only.

`opus.NewEncoder` now takes an `EncoderConfig` instead of positional
`channels, bitrate` arguments, following the repo's config-struct
convention and leaving room for the new settings. The pure-Go SILK
encoder accepts the config and ignores the FEC fields.

**`fix(opus)`** — `opus_encode` consumes a fixed `FrameSamples*channels`
samples from the pointer it is handed regardless of the Go slice length,
so a short frame read past the end of the caller's buffer. Only an empty
frame was rejected. It now returns the same error the pure-Go encoder
does, as the shared API promises.

`TestEncodeRejectsWrongFrameSize` was already failing on `main` under
`-tags libopus` — CI does not exercise that tag, so it went unseen.

## Testing

- `go build ./...` and `go test ./...` (cgo-free default)
- `go build -tags libopus ./...` and `go test -tags libopus ./audio/opus/...`
- `golangci-lint run ./...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)