### PR TITLE
feat(elevenlabs): synthesize over a held-open WebSocket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- **ElevenLabs WebSocket text-to-speech** (`provider/elevenlabs.NewRealtimeTTS`),
+  the multi-stream-input protocol over a single connection held open for the
+  session. `NewTTS` issues an HTTP request per sentence, and since the TTS base
+  synthesizes a sentence at a time, every sentence boundary in a reply paid for
+  connection setup before its first audio came back — a pause the listener hears.
+  Each synthesis opens a context, sends its text, and closes it, which is what
+  makes the final marker arrive immediately after the last audio byte rather than
+  after the server waits to see whether more text is coming. Audio is attributed
+  by context id, so what the server had already generated for a synthesis
+  abandoned by an interruption cannot leak into the next sentence. Optionally
+  reports word timing (`WordTimestamps`): ElevenLabs times every character, and
+  those are assembled into words with `utils/context.CharAccumulator`, which lets
+  the assistant context record what was actually spoken when a turn is cut short.
 - **Four streaming speech-to-text variants**, each sitting alongside a service
   the provider already had:
 

--- a/provider/elevenlabs/elevenlabs.go
+++ b/provider/elevenlabs/elevenlabs.go
@@ -1,11 +1,17 @@
-// Package elevenlabs is a streaming text-to-speech service backed by the
-// ElevenLabs HTTP streaming API. The shared TTS base aggregates incoming text
-// into sentences; this service synthesizes each and streams raw PCM downstream
-// at the configured rate (48 kHz by default, matching the WebRTC Opus rate so no
-// resampling is needed).
+// Package elevenlabs is a streaming text-to-speech service backed by ElevenLabs.
+// The shared TTS base aggregates incoming text into sentences; the service
+// synthesizes each and streams raw PCM downstream at the configured rate (48 kHz
+// by default, matching the WebRTC Opus rate so no resampling is needed).
 //
-// This wraps the HTTP /stream endpoint. It does not implement ElevenLabs'
-// WebSocket multi-stream-input transport or word-level timestamp alignment.
+// There are two transports. NewTTS wraps the HTTP /stream endpoint, one request
+// per sentence. NewRealtimeTTS speaks the WebSocket multi-stream-input protocol
+// over a single connection held open for the session, so a sentence pays no
+// connection setup before its first audio; it also reports word-level timing,
+// which lets the assistant context record what was actually spoken when a turn
+// is cut short. Prefer it for conversation, where the pause between one
+// synthesized sentence and the next is heard.
+//
+// The package also provides streaming speech-to-text (NewSTT, NewRealtimeSTT).
 package elevenlabs
 
 import (

--- a/provider/elevenlabs/realtime_tts.go
+++ b/provider/elevenlabs/realtime_tts.go
@@ -1,0 +1,405 @@
+package elevenlabs
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"sync"
+	"sync/atomic"
+
+	"github.com/coder/websocket"
+	"github.com/gojargo/jargo/internal/validate"
+	"github.com/gojargo/jargo/language"
+	"github.com/gojargo/jargo/service/tts"
+	"github.com/gojargo/jargo/service/wsutil"
+	uctx "github.com/gojargo/jargo/utils/context"
+)
+
+// realtimeTTSPath is the multi-stream-input endpoint. Multi-stream is what
+// carries a context id on every message, which is how audio is attributed to the
+// synthesis that asked for it.
+const realtimeTTSPath = "/v1/text-to-speech/%s/multi-stream-input"
+
+// defaultRealtimeTTSHost is the ElevenLabs WebSocket host.
+const defaultRealtimeTTSHost = "wss://api.elevenlabs.io"
+
+// Message keys on the multi-stream-input protocol.
+const (
+	keyText      = "text"
+	keyContextID = "context_id"
+)
+
+// errRealtimeTTS wraps an error the server reported on the stream.
+//
+//nolint:gochecknoglobals // sentinel error
+var errRealtimeTTS = errors.New("elevenlabs realtime tts")
+
+// RealtimeTTSConfig configures the streaming WebSocket TTS service.
+type RealtimeTTSConfig struct {
+	// APIKey is the ElevenLabs API key, sent as the xi-api-key header. Required.
+	APIKey string `validate:"required"`
+	// Host overrides the WebSocket host; empty uses the hosted API.
+	Host string
+	// VoiceID is the ElevenLabs voice; empty uses a default public voice.
+	VoiceID string
+	// Model is the ElevenLabs model; empty uses the low-latency flash model.
+	Model string
+	// SampleRate is the PCM rate requested and emitted downstream. Empty uses
+	// 48 kHz. Must be a rate ElevenLabs supports.
+	SampleRate int
+	// Language for multilingual models; the zero value leaves it unset.
+	Language language.Language
+	// VoiceSettings overrides the voice's default settings when non-nil.
+	VoiceSettings *VoiceSettings
+	// AutoMode lets ElevenLabs decide when it has enough text to start
+	// generating, rather than waiting to be told. nil leaves it on, which is
+	// what suits a sentence at a time.
+	AutoMode *bool
+	// ApplyTextNormalization controls spoken-form normalization ("auto", "on",
+	// "off"); empty leaves it unset.
+	ApplyTextNormalization string
+	// EnableLogging toggles server-side logging; nil leaves it unset.
+	EnableLogging *bool
+	// PronunciationDictionaryLocators applies the given dictionaries.
+	PronunciationDictionaryLocators []PronunciationDictionaryLocator
+	// WordTimestamps reports per-word timing alongside the audio, which lets the
+	// assistant context record what was actually spoken before an interruption.
+	// ElevenLabs times every character, so the words are assembled from those.
+	WordTimestamps bool
+}
+
+// Validate reports whether the configuration is usable.
+func (c RealtimeTTSConfig) Validate() error { return validate.Struct(c) }
+
+func (c RealtimeTTSConfig) withDefaults() RealtimeTTSConfig {
+	if c.Host == "" {
+		c.Host = defaultRealtimeTTSHost
+	}
+	if c.VoiceID == "" {
+		c.VoiceID = defaultVoiceID
+	}
+	if c.Model == "" {
+		c.Model = defaultModel
+	}
+	if c.SampleRate == 0 {
+		c.SampleRate = defaultSampleRate
+	}
+	return c
+}
+
+// NewRealtimeTTS builds an ElevenLabs TTS service over the streaming WebSocket
+// API. Unlike NewTTS, which issues one HTTP request per sentence, this holds a
+// single connection open for the session, so a sentence pays no connection setup
+// before the first audio comes back.
+func NewRealtimeTTS(cfg RealtimeTTSConfig) *tts.Base {
+	s := &realtimeSynthesizer{cfg: cfg.withDefaults()}
+	if cfg.WordTimestamps {
+		// Only the timestamp-aware type implements tts.WordTimestamps, so the
+		// base takes the word-aligned path solely when timings were requested.
+		return tts.New("ElevenLabsRealtimeTTS", &timedRealtimeSynthesizer{realtimeSynthesizer: s})
+	}
+	return tts.New("ElevenLabsRealtimeTTS", s)
+}
+
+type realtimeSynthesizer struct {
+	cfg RealtimeTTSConfig
+
+	// mu guards the lazily dialed connection, which is reused across syntheses
+	// so a sentence does not pay for a fresh handshake. It is held for the whole
+	// of a synthesis: the base synthesizes one sentence at a time, and the
+	// stream is read inline rather than by a background reader.
+	mu   sync.Mutex
+	conn *websocket.Conn
+
+	// context ids only have to be unique within the connection.
+	nextContext atomic.Uint64
+}
+
+// timedRealtimeSynthesizer adds word-timestamp streaming on top of
+// realtimeSynthesizer. It implements tts.WordTimestamps.
+type timedRealtimeSynthesizer struct {
+	*realtimeSynthesizer
+}
+
+// SampleRate reports the requested PCM output rate.
+func (s *realtimeSynthesizer) SampleRate() int { return s.cfg.SampleRate }
+
+// Metadata reports the ElevenLabs model and voice synthesis is billed against.
+func (s *realtimeSynthesizer) Metadata() tts.Metadata {
+	return tts.Metadata{Model: s.cfg.Model, VoiceID: s.cfg.VoiceID}
+}
+
+// endpoint builds the multi-stream-input URL. The voice, model and output format
+// are fixed for the connection; only the text varies per message.
+func (s *realtimeSynthesizer) endpoint() string {
+	q := url.Values{}
+	q.Set("model_id", s.cfg.Model)
+	q.Set("output_format", outputFormat(s.cfg.SampleRate))
+	if s.cfg.AutoMode != nil {
+		q.Set("auto_mode", strconv.FormatBool(*s.cfg.AutoMode))
+	}
+	if s.cfg.ApplyTextNormalization != "" {
+		q.Set("apply_text_normalization", s.cfg.ApplyTextNormalization)
+	}
+	if s.cfg.EnableLogging != nil {
+		q.Set("enable_logging", strconv.FormatBool(*s.cfg.EnableLogging))
+	}
+	if code := elevenlabsLanguage(s.cfg.Language); code != "" {
+		q.Set("language_code", code)
+	}
+	path := fmt.Sprintf(realtimeTTSPath, s.cfg.VoiceID)
+	return s.cfg.Host + path + "?" + q.Encode()
+}
+
+// stream returns the shared connection, dialing it on first use and redialing
+// when a previous synthesis left it broken. Callers hold mu.
+func (s *realtimeSynthesizer) stream(ctx context.Context) (*websocket.Conn, error) {
+	if s.conn != nil {
+		return s.conn, nil
+	}
+	header := http.Header{}
+	header.Set("xi-api-key", s.cfg.APIKey)
+	conn, err := wsutil.Dial(ctx, s.endpoint(), header, wsutil.DefaultReadLimit)
+	if err != nil {
+		return nil, err
+	}
+	s.conn = conn
+	return conn, nil
+}
+
+// drop closes the connection so the next synthesis dials a fresh one. Used when
+// a stream has failed and its state can no longer be trusted.
+func (s *realtimeSynthesizer) drop() {
+	if s.conn == nil {
+		return
+	}
+	_ = s.conn.Close(websocket.StatusInternalError, "")
+	s.conn = nil
+}
+
+// Close releases the shared connection, implementing tts.Closer.
+func (s *realtimeSynthesizer) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.conn == nil {
+		return nil
+	}
+	conn := s.conn
+	s.conn = nil
+	// Ask the server to close so it does not sit on a half-open stream.
+	_ = writeJSON(context.Background(), conn, map[string]any{"close_socket": true})
+	return conn.Close(websocket.StatusNormalClosure, "")
+}
+
+// Synthesize sends the sentence on the shared stream and emits the audio.
+func (s *realtimeSynthesizer) Synthesize(ctx context.Context, text string, emit func(pcm []byte) error) error {
+	return s.run(ctx, text, emit, nil)
+}
+
+// SynthesizeTimed streams audio and reports per-word timing, implementing
+// tts.WordTimestamps.
+func (s *timedRealtimeSynthesizer) SynthesizeTimed(
+	ctx context.Context,
+	text string,
+	emit func(pcm []byte) error,
+	word func(text string, offset float64) error,
+) error {
+	return s.run(ctx, text, emit, word)
+}
+
+// run drives one synthesis over the shared stream.
+func (s *realtimeSynthesizer) run(
+	ctx context.Context,
+	text string,
+	emit func(pcm []byte) error,
+	word func(text string, offset float64) error,
+) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	conn, err := s.stream(ctx)
+	if err != nil {
+		return err
+	}
+	contextID := strconv.FormatUint(s.nextContext.Add(1), 10)
+
+	if err := s.send(ctx, conn, contextID, text); err != nil {
+		// A failed write leaves the server's view of the stream unknown.
+		s.drop()
+		return err
+	}
+	if err := s.receive(ctx, conn, contextID, emit, word); err != nil {
+		s.drop()
+		return err
+	}
+	return nil
+}
+
+// send opens a context, hands it the sentence, and closes it. Closing is what
+// makes the final marker arrive immediately after the last audio byte rather
+// than after the server waits to see whether more text is coming.
+func (s *realtimeSynthesizer) send(
+	ctx context.Context,
+	conn *websocket.Conn,
+	contextID, text string,
+) error {
+	// The opening message carries the voice parameters for the context. A single
+	// space rather than the sentence: it initializes without committing text.
+	open := map[string]any{keyText: " ", keyContextID: contextID}
+	if s.cfg.VoiceSettings != nil {
+		open["voice_settings"] = s.cfg.VoiceSettings
+	}
+	if len(s.cfg.PronunciationDictionaryLocators) > 0 {
+		open["pronunciation_dictionary_locators"] = s.cfg.PronunciationDictionaryLocators
+	}
+	messages := []map[string]any{
+		open,
+		{keyText: text, keyContextID: contextID},
+		{keyContextID: contextID, "close_context": true},
+	}
+	for _, msg := range messages {
+		if err := writeJSON(ctx, conn, msg); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// writeJSON sends one JSON message as a text frame.
+func writeJSON(ctx context.Context, conn *websocket.Conn, msg map[string]any) error {
+	payload, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+	return conn.Write(ctx, websocket.MessageText, payload)
+}
+
+// realtimeTTSMessage is one server message. Audio arrives base64-encoded, and
+// alignment times every character rather than every word.
+type realtimeTTSMessage struct {
+	ContextID string `json:"contextId"` //nolint:tagliatelle // ElevenLabs wire keys are camelCase
+	Audio     string `json:"audio"`
+	IsFinal   bool   `json:"isFinal"` //nolint:tagliatelle // ElevenLabs wire keys are camelCase
+	Alignment *struct {
+		Chars            []string  `json:"chars"`
+		CharStartTimesMs []float64 `json:"charStartTimesMs"` //nolint:tagliatelle // ElevenLabs wire keys are camelCase
+	} `json:"alignment"`
+	NormalizedAlignment *struct {
+		Chars            []string  `json:"chars"`
+		CharStartTimesMs []float64 `json:"charStartTimesMs"` //nolint:tagliatelle // ElevenLabs wire keys are camelCase
+	} `json:"normalizedAlignment"` //nolint:tagliatelle // ElevenLabs wire keys are camelCase
+	Error string `json:"error"`
+}
+
+// receive reads until the context is final, emitting its audio and words.
+//
+// Messages for any other context are skipped: an interruption abandons a
+// synthesis mid-flight, and audio the server had already generated for it
+// arrives afterwards. Attributing by context id keeps that audio out of the next
+// sentence, which is what the ids are for.
+func (s *realtimeSynthesizer) receive(
+	ctx context.Context,
+	conn *websocket.Conn,
+	contextID string,
+	emit func(pcm []byte) error,
+	word func(text string, offset float64) error,
+) error {
+	var acc uctx.CharAccumulator
+	for {
+		msg, err := readRealtimeTTSMessage(ctx, conn)
+		if err != nil {
+			return err
+		}
+		if msg.ContextID != contextID {
+			continue
+		}
+		if err := s.handleMessage(msg, &acc, emit, word); err != nil {
+			return err
+		}
+		if msg.IsFinal {
+			if word == nil {
+				return nil
+			}
+			// The closing word ends on the utterance, not on a space.
+			if wt, ok := acc.Flush(); ok {
+				return word(wt.Word, wt.Offset)
+			}
+			return nil
+		}
+	}
+}
+
+// readRealtimeTTSMessage reads and decodes one server message.
+func readRealtimeTTSMessage(ctx context.Context, conn *websocket.Conn) (*realtimeTTSMessage, error) {
+	_, data, err := conn.Read(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var msg realtimeTTSMessage
+	if err := json.Unmarshal(data, &msg); err != nil {
+		return nil, fmt.Errorf("%w: decode message: %w", errRealtimeTTS, err)
+	}
+	if msg.Error != "" {
+		return nil, fmt.Errorf("%w: %s", errRealtimeTTS, msg.Error)
+	}
+	return &msg, nil
+}
+
+// handleMessage emits a message's audio and reports the words it completes.
+func (s *realtimeSynthesizer) handleMessage(
+	msg *realtimeTTSMessage,
+	acc *uctx.CharAccumulator,
+	emit func(pcm []byte) error,
+	word func(text string, offset float64) error,
+) error {
+	if msg.Audio != "" {
+		pcm, err := base64.StdEncoding.DecodeString(msg.Audio)
+		if err != nil {
+			return fmt.Errorf("%w: decode audio: %w", errRealtimeTTS, err)
+		}
+		if err := emit(pcm); err != nil {
+			return err
+		}
+	}
+	if word == nil {
+		return nil
+	}
+	return s.reportWords(acc, msg, word)
+}
+
+// reportWords folds a message's character timings into whole words and reports
+// each one that completed.
+func (s *realtimeSynthesizer) reportWords(
+	acc *uctx.CharAccumulator,
+	msg *realtimeTTSMessage,
+	word func(text string, offset float64) error,
+) error {
+	alignment := msg.Alignment
+	if s.cfg.PronunciationDictionaryLocators != nil && msg.NormalizedAlignment != nil {
+		// A pronunciation dictionary rewrites what is spoken, so the normalized
+		// form is the one the timings belong to.
+		alignment = msg.NormalizedAlignment
+	}
+	if alignment == nil {
+		return nil
+	}
+	starts := make([]float64, len(alignment.CharStartTimesMs))
+	for i, ms := range alignment.CharStartTimesMs {
+		starts[i] = ms / 1000
+	}
+	words, err := acc.Add(alignment.Chars, starts)
+	if err != nil {
+		return err
+	}
+	for _, wt := range uctx.MergePunctTokens(words) {
+		if err := word(wt.Word, wt.Offset); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/provider/elevenlabs/realtime_tts_test.go
+++ b/provider/elevenlabs/realtime_tts_test.go
@@ -1,0 +1,265 @@
+package elevenlabs
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/coder/websocket"
+	"github.com/gojargo/jargo/internal/providertest"
+	"github.com/gojargo/jargo/language"
+	"github.com/gojargo/jargo/service/tts"
+)
+
+// TestRealtimeTTSConfigValidate pins which fields the service requires.
+func TestRealtimeTTSConfigValidate(t *testing.T) {
+	providertest.Configs(t, []providertest.ConfigCase{
+		{Name: "missing API key", Cfg: RealtimeTTSConfig{}, Valid: false},
+		{Name: "API key only", Cfg: RealtimeTTSConfig{APIKey: "k"}, Valid: true},
+	})
+}
+
+// TestNewRealtimeTTS checks the constructor returns a service under the label
+// that identifies it in logs, metrics and traces.
+func TestNewRealtimeTTS(t *testing.T) {
+	providertest.Service(t, "ElevenLabsRealtimeTTS", NewRealtimeTTS(RealtimeTTSConfig{APIKey: "k"}))
+}
+
+// Word timings are only reported when they were asked for, so the base takes the
+// word-aligned path solely then.
+func TestRealtimeTTSWordTimestampsAreOptional(t *testing.T) {
+	plain := &realtimeSynthesizer{cfg: RealtimeTTSConfig{APIKey: "k"}.withDefaults()}
+	if _, ok := any(plain).(tts.WordTimestamps); ok {
+		t.Fatal("the plain synthesizer must not implement tts.WordTimestamps")
+	}
+	timed := &timedRealtimeSynthesizer{realtimeSynthesizer: plain}
+	if _, ok := any(timed).(tts.WordTimestamps); !ok {
+		t.Fatal("the timed synthesizer must implement tts.WordTimestamps")
+	}
+}
+
+// The connection is opened once and its fixed parameters live in the URL, since
+// only the text varies from one sentence to the next.
+func TestRealtimeTTSEndpoint(t *testing.T) {
+	s := &realtimeSynthesizer{cfg: RealtimeTTSConfig{
+		APIKey:     "k",
+		SampleRate: 24000,
+		Language:   language.French,
+	}.withDefaults()}
+
+	raw := s.endpoint()
+	if !strings.HasPrefix(raw, defaultRealtimeTTSHost+"/v1/text-to-speech/"+defaultVoiceID+"/multi-stream-input?") {
+		t.Fatalf("unexpected endpoint: %s", raw)
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for key, want := range map[string]string{
+		"model_id":      defaultModel,
+		"output_format": "pcm_24000",
+		"language_code": "fr",
+	} {
+		if got := u.Query().Get(key); got != want {
+			t.Errorf("%s = %q, want %q", key, got, want)
+		}
+	}
+}
+
+// realtimeTTSServer starts a fake multi-stream-input endpoint that records the
+// client's messages and replies with a scripted sequence per synthesis.
+func realtimeTTSServer(t *testing.T, script [][]map[string]any) (host string, sent <-chan map[string]any) {
+	t.Helper()
+	messages := make(chan map[string]any, 32)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = c.Close(websocket.StatusNormalClosure, "") }()
+		ctx := r.Context()
+
+		for _, events := range script {
+			// Each synthesis opens a context, sends its text, and closes it.
+			var contextID string
+			for range 3 {
+				_, data, err := c.Read(ctx)
+				if err != nil {
+					return
+				}
+				var msg map[string]any
+				if json.Unmarshal(data, &msg) != nil {
+					return
+				}
+				messages <- msg
+				if id, ok := msg["context_id"].(string); ok {
+					contextID = id
+				}
+			}
+			for _, ev := range events {
+				// The server stamps every message with the context it belongs to.
+				if _, ok := ev["contextId"]; !ok {
+					ev["contextId"] = contextID
+				}
+				b, _ := json.Marshal(ev)
+				if c.Write(ctx, websocket.MessageText, b) != nil {
+					return
+				}
+			}
+		}
+		for {
+			if _, _, err := c.Read(ctx); err != nil {
+				return
+			}
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	return "ws" + strings.TrimPrefix(srv.URL, "http"), messages
+}
+
+func audioMessage(pcm []byte) map[string]any {
+	return map[string]any{"audio": base64.StdEncoding.EncodeToString(pcm)}
+}
+
+// TestRealtimeTTSSynthesize checks the messages the service sends and the audio
+// it emits.
+func TestRealtimeTTSSynthesize(t *testing.T) {
+	host, sent := realtimeTTSServer(t, [][]map[string]any{{
+		audioMessage([]byte{1, 2, 3, 4}),
+		audioMessage([]byte{5, 6}),
+		{"isFinal": true},
+	}})
+
+	s := &realtimeSynthesizer{cfg: RealtimeTTSConfig{APIKey: "k", Host: host}.withDefaults()}
+	t.Cleanup(func() { _ = s.Close() })
+
+	var got []byte
+	err := s.Synthesize(context.Background(), "Bonjour.", func(pcm []byte) error {
+		got = append(got, pcm...)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []byte{1, 2, 3, 4, 5, 6}; string(got) != string(want) {
+		t.Fatalf("emitted %v, want %v", got, want)
+	}
+
+	open := <-sent
+	if open["text"] != " " {
+		t.Errorf("the opening message should initialize without committing text, got %q", open["text"])
+	}
+	body := <-sent
+	if body["text"] != "Bonjour." {
+		t.Errorf("sent text = %q, want %q", body["text"], "Bonjour.")
+	}
+	// Closing the context is what makes the final marker arrive right after the
+	// last audio byte instead of the server waiting for more text.
+	closing := <-sent
+	if closing["close_context"] != true {
+		t.Errorf("the context should be closed after the text, got %v", closing)
+	}
+	if open["context_id"] != body["context_id"] || body["context_id"] != closing["context_id"] {
+		t.Error("every message of a synthesis must carry the same context id")
+	}
+}
+
+// A second sentence must reuse the open connection: not paying for a handshake
+// per sentence is the whole point of this service over the HTTP one.
+func TestRealtimeTTSReusesTheConnection(t *testing.T) {
+	host, _ := realtimeTTSServer(t, [][]map[string]any{
+		{audioMessage([]byte{1}), {"isFinal": true}},
+		{audioMessage([]byte{2}), {"isFinal": true}},
+	})
+
+	s := &realtimeSynthesizer{cfg: RealtimeTTSConfig{APIKey: "k", Host: host}.withDefaults()}
+	t.Cleanup(func() { _ = s.Close() })
+
+	discard := func([]byte) error { return nil }
+	if err := s.Synthesize(context.Background(), "Un.", discard); err != nil {
+		t.Fatal(err)
+	}
+	first := s.conn
+	if err := s.Synthesize(context.Background(), "Deux.", discard); err != nil {
+		t.Fatal(err)
+	}
+	if s.conn != first {
+		t.Fatal("the second synthesis redialed instead of reusing the open connection")
+	}
+}
+
+// Audio the server had already generated for an abandoned synthesis arrives
+// after it. Attributing by context id is what keeps it out of the next sentence.
+func TestRealtimeTTSIgnoresOtherContexts(t *testing.T) {
+	host, _ := realtimeTTSServer(t, [][]map[string]any{{
+		{"contextId": "stale", "audio": base64.StdEncoding.EncodeToString([]byte{9, 9, 9})},
+		audioMessage([]byte{7}),
+		{"isFinal": true},
+	}})
+
+	s := &realtimeSynthesizer{cfg: RealtimeTTSConfig{APIKey: "k", Host: host}.withDefaults()}
+	t.Cleanup(func() { _ = s.Close() })
+
+	var got []byte
+	err := s.Synthesize(context.Background(), "Bonjour.", func(pcm []byte) error {
+		got = append(got, pcm...)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []byte{7}; string(got) != string(want) {
+		t.Fatalf("emitted %v, want %v: audio from another context leaked into this synthesis", got, want)
+	}
+}
+
+// ElevenLabs times every character; the words spoken are assembled from those.
+func TestRealtimeTTSReportsWords(t *testing.T) {
+	host, _ := realtimeTTSServer(t, [][]map[string]any{{
+		{
+			"audio": base64.StdEncoding.EncodeToString([]byte{1, 2}),
+			"alignment": map[string]any{
+				"chars":            []string{"S", "a", "l", "u", "t", " ", "t", "o", "i"},
+				"charStartTimesMs": []float64{0, 50, 100, 150, 200, 250, 300, 350, 400},
+			},
+		},
+		{"isFinal": true},
+	}})
+
+	s := &timedRealtimeSynthesizer{realtimeSynthesizer: &realtimeSynthesizer{
+		cfg: RealtimeTTSConfig{APIKey: "k", Host: host, WordTimestamps: true}.withDefaults(),
+	}}
+	t.Cleanup(func() { _ = s.Close() })
+
+	type spoken struct {
+		word   string
+		offset float64
+	}
+	var words []spoken
+	err := s.SynthesizeTimed(context.Background(), "Salut toi",
+		func([]byte) error { return nil },
+		func(text string, offset float64) error {
+			words = append(words, spoken{text, offset})
+			return nil
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []spoken{{"Salut", 0}, {"toi", 0.3}}
+	if len(words) != len(want) {
+		t.Fatalf("reported %v, want %v", words, want)
+	}
+	for i, w := range want {
+		if words[i].word != w.word || words[i].offset != w.offset {
+			t.Errorf("word %d = %v, want %v", i, words[i], w)
+		}
+	}
+}

--- a/provider/elevenlabs/tts.go
+++ b/provider/elevenlabs/tts.go
@@ -64,7 +64,7 @@ func (s *synthesizer) SampleRate() int { return s.cfg.SampleRate }
 // Synthesize requests speech for text and streams the raw PCM downstream.
 func (s *synthesizer) Synthesize(ctx context.Context, text string, emit func(pcm []byte) error) error {
 	payload := map[string]any{
-		"text":     text,
+		keyText:    text,
 		"model_id": s.cfg.Model,
 	}
 	if code := elevenlabsLanguage(s.cfg.Language); code != "" {


### PR DESCRIPTION
## Why

The TTS base synthesizes a sentence at a time, and `NewTTS` issues an HTTP
request per sentence. Every sentence boundary in a reply therefore paid for
connection setup before its first audio came back, and a listener hears that as
a pause mid-reply.

This surfaced while chasing choppy audio in the Pion transport: that work made
the transport carry these gaps correctly, but the gaps themselves come from
here.

## What

`NewRealtimeTTS` speaks the multi-stream-input protocol over one connection held
open for the session.

- **Each synthesis opens a context, sends its text, then closes it.** Closing is
  what makes the final marker arrive immediately after the last audio byte,
  rather than after the server waits to see whether more text is coming.
- **Audio is attributed by context id.** An interruption abandons a synthesis
  mid-flight and audio the server had already generated arrives afterwards;
  filtering by id keeps it out of the next sentence, which is what the ids are
  for.
- **Optional word timing.** ElevenLabs times every character and
  `utils/context.CharAccumulator` already assembles those into words, so the
  assistant context can record what was actually spoken when a turn is cut
  short. Only the timestamp-aware type implements `tts.WordTimestamps`, so the
  base takes that path solely when timings were asked for.
- The connection is dialed lazily and released through `tts.Closer`, following
  the Riva TTS service. A failed read or write drops it, so the next synthesis
  dials afresh rather than trusting a stream whose server-side state is unknown.

`NewTTS` is untouched and remains the simpler choice for one-off synthesis.

## Testing

Against a fake endpoint: the message sequence and shared context id, connection
reuse across sentences, audio from a foreign context being ignored, and
character timings assembled into words.

The two substantive tests were checked against implementations lacking those
behaviors and fail there — dropping the context filter yields
`emitted [9 9 9 7], want [7]`, and redialing per synthesis fails the reuse test.

`go test -race`, `-tags libopus` build, and `golangci-lint run` all clean.

**Not exercised against the live API.** The protocol is implemented from the
message shapes; a real-traffic check is still owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)