### PR TITLE
fix(anthropic): put the cache breakpoint before the recalled context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,6 +289,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- **The Anthropic prompt cache is now read, not only written.** The cache
+  breakpoint sat at the end of the system prompt, which folds in the transient
+  context a memory service recalls each turn. A cached prefix is only reused
+  while it stays byte-identical, so the breakpoint moved on every request: each
+  turn wrote a fresh cache entry and read none back, paying the write premium for
+  no benefit. It now sits on the part of the system prompt that survives between
+  turns, with the recalled context after it where it is free to vary.
+  `LLMContext.SystemParts` exposes that split.
 - **The Pion transport sends on every frame boundary for the life of the
   session**, falling back to silence when nothing is queued, instead of writing
   only when the pipeline handed it audio. RTP timestamps advance one frame per

--- a/frames/llm_context.go
+++ b/frames/llm_context.go
@@ -105,6 +105,29 @@ func (c *LLMContext) systemLocked() string {
 	return strings.Join(parts, "\n\n")
 }
 
+// SystemParts returns the system prompt split at its first volatile point:
+// stable is the part that survives from one turn to the next, volatile the
+// transient recalled context that a memory service replaces every turn.
+// Concatenated with a blank line between them they are exactly System().
+//
+// The split exists for prompt caching. A provider that caches a prefix of the
+// prompt can only reuse it while that prefix is byte-identical, so a breakpoint
+// placed after the recalled context would be rewritten every turn and never
+// read back. Caching stable and leaving volatile outside the breakpoint keeps
+// the bulk of the prompt reusable.
+func (c *LLMContext) SystemParts() (stable, volatile string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	parts := make([]string, 0, 2)
+	if c.system != "" {
+		parts = append(parts, c.system)
+	}
+	if c.summary != "" {
+		parts = append(parts, summaryHeader+"\n"+c.summary)
+	}
+	return strings.Join(parts, "\n\n"), c.recall
+}
+
 // Summary returns the rolling summary of compacted older turns, or "" if the
 // conversation has not been compacted yet.
 func (c *LLMContext) Summary() string {

--- a/provider/anthropic/anthropic_test.go
+++ b/provider/anthropic/anthropic_test.go
@@ -211,3 +211,75 @@ func TestToMessagesBuildsToolTurns(t *testing.T) {
 		}
 	}
 }
+
+// A cached prefix is only reused while it stays byte-identical. Recalled context
+// is replaced every turn, so the breakpoint has to sit before it: inside it, the
+// cache would be written on every request and never read back, which costs more
+// than not caching at all.
+func TestNewParamsKeepsTheCachedPrefixStableAcrossRecall(t *testing.T) {
+	s := NewLLM(Config{})
+	convo := frames.NewLLMContext("you are a companion")
+	convo.AddUserMessage("hi")
+
+	cachedPrefix := func() string {
+		params := s.newParams(convo)
+		var prefix []string
+		for _, block := range params.System {
+			if block.CacheControl.Type != "" {
+				prefix = append(prefix, block.Text)
+			}
+		}
+		return strings.Join(prefix, "\n\n")
+	}
+
+	convo.SetRecall("I recall: the user has a cat")
+	first := cachedPrefix()
+	convo.SetRecall("I recall: the user has a dog")
+	second := cachedPrefix()
+
+	if first == "" {
+		t.Fatal("nothing was marked for caching")
+	}
+	if first != second {
+		t.Fatalf("the cached prefix changed when recall did:\n first: %q\nsecond: %q", first, second)
+	}
+	if strings.Contains(first, "cat") || strings.Contains(first, "dog") {
+		t.Fatalf("recalled context is inside the cached prefix: %q", first)
+	}
+}
+
+// Recall still has to reach the model — it just travels outside the breakpoint.
+func TestNewParamsStillSendsRecall(t *testing.T) {
+	s := NewLLM(Config{})
+	convo := frames.NewLLMContext("you are a companion")
+	convo.AddUserMessage("hi")
+	convo.SetRecall("I recall: the user has a cat")
+
+	b, err := json.Marshal(s.newParams(convo))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), "the user has a cat") {
+		t.Fatalf("recall missing from the request: %s", b)
+	}
+}
+
+// With caching off the system prompt travels as one uncached block.
+func TestNewParamsWithoutCaching(t *testing.T) {
+	off := false
+	s := NewLLM(Config{EnablePromptCaching: &off})
+	convo := frames.NewLLMContext("you are a companion")
+	convo.AddUserMessage("hi")
+	convo.SetRecall("I recall: the user has a cat")
+
+	params := s.newParams(convo)
+	if len(params.System) != 1 {
+		t.Fatalf("got %d system blocks, want 1", len(params.System))
+	}
+	if params.System[0].CacheControl.Type != "" {
+		t.Fatal("cache control set although caching is off")
+	}
+	if !strings.Contains(params.System[0].Text, "the user has a cat") {
+		t.Fatal("recall missing from the system prompt")
+	}
+}

--- a/provider/anthropic/llm.go
+++ b/provider/anthropic/llm.go
@@ -125,15 +125,42 @@ func (s *Service) newParams(convo *frames.LLMContext) sdk.MessageNewParams {
 	if s.thinkingSet {
 		params.Thinking = s.thinking
 	}
-	if system := convo.System(); system != "" {
-		block := sdk.TextBlockParam{Text: system}
-		if s.cachePrompt {
-			// Cache the system prompt so repeated turns reuse it.
-			block.CacheControl = sdk.NewCacheControlEphemeralParam()
-		}
-		params.System = []sdk.TextBlockParam{block}
-	}
+	params.System = s.systemBlocks(convo)
 	return params
+}
+
+// systemBlocks renders the system prompt, with the cache breakpoint on the part
+// of it that survives between turns.
+//
+// A cached prefix is only reused while it stays byte-identical, and everything
+// after the breakpoint is free to vary without disturbing it. The recalled
+// context a memory service refreshes every turn is exactly that: putting it
+// inside the breakpoint rewrites the cache on every request and never reads one
+// back, which costs more than not caching at all.
+func (s *Service) systemBlocks(convo *frames.LLMContext) []sdk.TextBlockParam {
+	if !s.cachePrompt {
+		system := convo.System()
+		if system == "" {
+			return nil
+		}
+		return []sdk.TextBlockParam{{Text: system}}
+	}
+
+	stable, volatile := convo.SystemParts()
+	blocks := make([]sdk.TextBlockParam, 0, 2)
+	if stable != "" {
+		blocks = append(blocks, sdk.TextBlockParam{
+			Text:         stable,
+			CacheControl: sdk.NewCacheControlEphemeralParam(),
+		})
+	}
+	if volatile != "" {
+		blocks = append(blocks, sdk.TextBlockParam{Text: volatile})
+	}
+	if len(blocks) == 0 {
+		return nil
+	}
+	return blocks
 }
 
 // toUsage converts the SDK's per-request usage into the pipeline's token usage.


### PR DESCRIPTION
## Why

Observed on a live voice session: **every** turn reported
`cache_creation_input_tokens` for the whole prompt and **zero** cache reads.

```json
{"input": 0, "output": 77, "input_cache_creation": 1906}
```

So the prompt cache paid its write premium on every request and never once read
an entry back — worse than not caching, and the full time-to-first-token every
turn. Measured at ~2.4s fixed TTFT on a ~1900-token prompt.

The cause: the breakpoint sat at the end of the system prompt, and
`LLMContext.systemLocked` composes that as `base + summary + recall`. A memory
service replaces `recall` every turn via `SetRecall`, so the cached prefix was
different on every request.

## What

The breakpoint now sits on the part of the system prompt that survives between
turns — the base prompt and any rolling summary — with the recalled context sent
as a second block after it, where content may vary freely without disturbing what
is cached. `LLMContext.SystemParts` exposes the split.

With caching disabled the system prompt still travels as a single uncached block,
unchanged.

## On the upstream design

Upstream marks the **two most recent user messages** rather than the system
prompt, and its comment names this exact trap:

> If we only added the marker to the last user message, we'd only ever be adding
> to the cache, never looking up from it.

It needs two markers because the content it caches is new each turn — the newest
marker writes, the second-newest reads the prefix that existed last turn. A
breakpoint on a prefix that is *already* stable both writes and reads on its own,
so one is enough here.

Porting the message-level markers on their own would not have fixed this:
Anthropic caches a prefix of `tools → system → messages`, so while the system
block moves every turn, no marker further down can hit. Making the system prefix
stable is the prerequisite. Caching the conversation as well is a worthwhile
follow-up now that the prefix ahead of it holds still.

## Testing

`TestNewParamsKeepsTheCachedPrefixStableAcrossRecall` asserts the cached prefix
is unchanged when recall changes, and that recalled text is not inside it. Run
against the previous behaviour it fails, showing the recall text in the prefix
(`...has a cat` vs `...has a dog`). Plus: recall still reaches the model, and the
caching-off path is unchanged.

`go test -race`, `golangci-lint run` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)