### PR TITLE
fix(turns,mem0,pionrtc): stop repeating memory searches and miscounting starvation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,6 +289,27 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- **`MinWordsStart` drops back to the single-word threshold as soon as a turn
+  opens.** It tracked the bot's speaking state only from the bot-speaking frames,
+  so after a barge-in it kept requiring `MinWords` until the interrupted bot's
+  stopped frame arrived, and the rest of that turn was held to the interruption
+  bar rather than the ordinary one. It now clears the flag on turn start, matching
+  the upstream strategy's `handle_user_turn_started`.
+- **`mem0` searches once per user message rather than once per context frame.** A
+  tool-calling turn replays the context after every round trip, and each replay
+  repeated the same retrieval — latency and load on the critical path before the
+  reply, for a result already in hand. Retrieval is now keyed on the user message
+  it was performed for. `Config.SearchTimeout` bounds that blocking retrieval
+  separately from `Timeout`, since a late memory is worse than a missing one when
+  a reply is waiting on it, and `Config.Prewarm` issues one throwaway search when
+  the session starts so the first real one does not pay to warm the path.
+- **The Pion sender's starvation counter no longer charges every utterance for
+  its own ending.** It counted any silence sent within a fixed window after real
+  audio, but the window is also exactly what a normal end of speech looks like, so
+  the figure tracked how many times the bot spoke rather than how often the writer
+  fell behind — it read as a fault on every healthy session. A run of silence is
+  now only charged once real audio resumes after it, and the log reports the
+  number of gaps alongside the frame count.
 - **The Anthropic prompt cache is now read, not only written.** The cache
   breakpoint sat at the end of the system prompt, which folds in the transient
   context a memory service recalls each turn. A cached prefix is only reused

--- a/processor/turns/start.go
+++ b/processor/turns/start.go
@@ -99,6 +99,11 @@ func NewMinWordsStart(cfg MinWordsStartConfig) *MinWordsStart {
 	return s
 }
 
+// TurnStarted clears the bot-speaking flag: the turn that just started will have
+// interrupted the bot, so the rest of it counts against the single-word threshold
+// without waiting for the bot-stopped frame to catch up.
+func (s *MinWordsStart) TurnStarted() { s.botSpeaking = false }
+
 // Process counts words and triggers once the threshold is met.
 func (s *MinWordsStart) Process(f frames.Frame) ProcessFrameResult {
 	switch fr := f.(type) {

--- a/processor/turns/strategies_internal_test.go
+++ b/processor/turns/strategies_internal_test.go
@@ -230,6 +230,27 @@ func TestMinWordsStartBotStopsSpeaking(t *testing.T) {
 	}
 }
 
+// TestMinWordsStartTurnStartedClearsBotSpeaking checks the threshold drops to one
+// word as soon as a turn opens, rather than waiting for the bot-stopped frame the
+// interruption will produce.
+func TestMinWordsStartTurnStartedClearsBotSpeaking(t *testing.T) {
+	s := NewMinWordsStart(MinWordsStartConfig{MinWords: 3})
+	spy := attachStart(s)
+
+	spy.send(s, frames.NewBotStartedSpeakingFrame())
+	spy.send(s, transcript("three words now"))
+	if spy.starts() != 1 {
+		t.Fatalf("starts = %d, want 1 once three words interrupt the bot", spy.starts())
+	}
+	s.TurnStarted()
+
+	// No BotStoppedSpeakingFrame yet — the flag must already be clear.
+	spy.send(s, transcript("yes"))
+	if spy.starts() != 2 {
+		t.Errorf("starts = %d, want 2: one word should suffice after a turn opened", spy.starts())
+	}
+}
+
 func TestMinWordsStartInterim(t *testing.T) {
 	t.Run("counted by default", func(t *testing.T) {
 		s := NewMinWordsStart(MinWordsStartConfig{MinWords: 2})

--- a/provider/mem0/mem0.go
+++ b/provider/mem0/mem0.go
@@ -31,6 +31,9 @@ const (
 	defaultTimeout     = 10 * time.Second
 	// recallHeader frames the retrieved memories injected into the system prompt.
 	recallHeader = "Based on previous conversations, you recall the following about the user:"
+	// prewarmQuery is the throwaway query used to warm the search path. Search is
+	// read-only, so it leaves nothing behind.
+	prewarmQuery = "hello"
 )
 
 // Config configures the memory service.
@@ -54,6 +57,13 @@ type Config struct {
 	SearchThreshold float64
 	// Timeout bounds a single mem0 request; 0 uses a default.
 	Timeout time.Duration
+	// SearchTimeout bounds the per-turn retrieval specifically, which runs before
+	// the LLM and so delays the reply; 0 falls back to Timeout. Set it well below
+	// Timeout for voice, where a late memory is worse than a missing one.
+	SearchTimeout time.Duration
+	// Prewarm issues one throwaway search when the session starts, so the first
+	// real retrieval does not pay the cost of warming the path.
+	Prewarm bool
 	// HTTPClient overrides the HTTP client; nil uses one with Timeout.
 	HTTPClient *http.Client
 }

--- a/provider/mem0/mem0_test.go
+++ b/provider/mem0/mem0_test.go
@@ -5,12 +5,15 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/gojargo/jargo/frames"
 	"github.com/gojargo/jargo/pipeline"
+	"github.com/gojargo/jargo/processor"
 	"github.com/gojargo/jargo/provider/mem0"
 )
 
@@ -139,6 +142,185 @@ func TestMemoryNoResultsClearsRecall(t *testing.T) {
 
 	task.StopWhenDone()
 	<-runDone
+}
+
+// countingServer answers every search and records the queries it was asked, so a
+// test can tell how many times retrieval actually ran.
+func countingServer(t *testing.T, delay time.Duration) (*httptest.Server, func() []string) {
+	t.Helper()
+	var mu sync.Mutex
+	var queries []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/search" {
+			var b searchBody
+			_ = json.NewDecoder(r.Body).Decode(&b)
+			mu.Lock()
+			queries = append(queries, b.Query)
+			mu.Unlock()
+			if delay > 0 {
+				select {
+				case <-time.After(delay):
+				case <-r.Context().Done():
+					return
+				}
+			}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"results": []any{}})
+	}))
+	return srv, func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		return slices.Clone(queries)
+	}
+}
+
+// searchQueries returns the non-prewarm queries seen so far.
+func searchQueries(all []string) []string {
+	var out []string
+	for _, q := range all {
+		if q != "hello" {
+			out = append(out, q)
+		}
+	}
+	return out
+}
+
+// A tool-calling turn replays the same context once per round trip. Retrieval is
+// keyed on the user message, so the replays must not each cost a search.
+func TestMemorySearchesOncePerUserMessage(t *testing.T) {
+	srv, queries := countingServer(t, 0)
+	defer srv.Close()
+
+	convo := frames.NewLLMContext("base")
+	convo.AddUserMessage("where did I put my keys?")
+	m := mem0.NewMemory(mem0.Config{Host: srv.URL, UserID: "u1"})
+
+	task := pipeline.NewTask(pipeline.New(m), pipeline.TaskParams{})
+	runDone := make(chan error, 1)
+	go func() { runDone <- task.Run(context.Background()) }()
+
+	for range 3 {
+		task.QueueFrame(frames.NewLLMContextFrame(convo))
+	}
+	if !waitFor(3*time.Second, func() bool { return len(searchQueries(queries())) >= 1 }) {
+		t.Fatal("mem0 search was never called")
+	}
+
+	// A second user message is a new query and must search again.
+	convo.AddUserMessage("and my glasses?")
+	task.QueueFrame(frames.NewLLMContextFrame(convo))
+	if !waitFor(3*time.Second, func() bool { return len(searchQueries(queries())) >= 2 }) {
+		t.Fatal("the second user message did not trigger a search")
+	}
+
+	task.StopWhenDone()
+	<-runDone
+
+	got := searchQueries(queries())
+	want := []string{"where did I put my keys?", "and my glasses?"}
+	if !slices.Equal(got, want) {
+		t.Errorf("searched for %q, want %q — one search per user message", got, want)
+	}
+}
+
+func TestMemoryPrewarmsTheSearchPath(t *testing.T) {
+	srv, queries := countingServer(t, 0)
+	defer srv.Close()
+
+	m := mem0.NewMemory(mem0.Config{Host: srv.URL, UserID: "u1", Prewarm: true})
+	task := pipeline.NewTask(pipeline.New(m), pipeline.TaskParams{})
+	runDone := make(chan error, 1)
+	go func() { runDone <- task.Run(context.Background()) }()
+
+	// StartFrame alone must warm the path, before any user message exists.
+	if !waitFor(3*time.Second, func() bool { return len(queries()) > 0 }) {
+		t.Fatal("no search was issued on start, so the path was not prewarmed")
+	}
+
+	task.StopWhenDone()
+	<-runDone
+}
+
+func TestMemoryPrewarmIsOptIn(t *testing.T) {
+	srv, queries := countingServer(t, 0)
+	defer srv.Close()
+
+	m := mem0.NewMemory(mem0.Config{Host: srv.URL, UserID: "u1"})
+	task := pipeline.NewTask(pipeline.New(m), pipeline.TaskParams{})
+	runDone := make(chan error, 1)
+	go func() { runDone <- task.Run(context.Background()) }()
+
+	time.Sleep(200 * time.Millisecond)
+	if got := queries(); len(got) != 0 {
+		t.Errorf("searched %q on start, want nothing without Prewarm", got)
+	}
+
+	task.StopWhenDone()
+	<-runDone
+}
+
+// A slow server must not hold the turn past SearchTimeout: the reply goes out
+// without memories rather than late with them.
+func TestMemorySearchTimeoutReleasesTheTurn(t *testing.T) {
+	srv, _ := countingServer(t, 2*time.Second)
+	defer srv.Close()
+
+	convo := frames.NewLLMContext("base")
+	convo.AddUserMessage("hello there")
+	m := mem0.NewMemory(mem0.Config{
+		Host: srv.URL, UserID: "u1",
+		Timeout:       10 * time.Second,
+		SearchTimeout: 100 * time.Millisecond,
+	})
+
+	downstream := newFrameSink()
+	task := pipeline.NewTask(pipeline.New(m, downstream), pipeline.TaskParams{})
+	runDone := make(chan error, 1)
+	go func() { runDone <- task.Run(context.Background()) }()
+
+	start := time.Now()
+	task.QueueFrame(frames.NewLLMContextFrame(convo))
+	if !waitFor(3*time.Second, func() bool { return downstream.sawContext() }) {
+		t.Fatal("the context frame never reached the LLM")
+	}
+	// Well under the server's 2s, so the deadline and not the server ended it.
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("context frame took %v to pass, want it released near the 100ms SearchTimeout", elapsed)
+	}
+
+	task.StopWhenDone()
+	<-runDone
+}
+
+// frameSink records whether a context frame made it downstream of memory.
+type frameSink struct {
+	*processor.Base
+	mu  sync.Mutex
+	got bool
+}
+
+func newFrameSink() *frameSink {
+	s := &frameSink{}
+	s.Base = processor.New("Sink", s)
+	return s
+}
+
+func (s *frameSink) ProcessFrame(ctx context.Context, f frames.Frame, dir processor.Direction) error {
+	if err := s.Base.ProcessFrame(ctx, f, dir); err != nil {
+		return err
+	}
+	if _, ok := f.(*frames.LLMContextFrame); ok {
+		s.mu.Lock()
+		s.got = true
+		s.mu.Unlock()
+	}
+	return s.PushFrame(ctx, f, dir)
+}
+
+func (s *frameSink) sawContext() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.got
 }
 
 func waitFor(timeout time.Duration, cond func() bool) bool {

--- a/provider/mem0/memory.go
+++ b/provider/mem0/memory.go
@@ -26,6 +26,10 @@ type Service struct {
 	// Store de-duplication state, touched only on the process goroutine.
 	lastUser      string
 	lastAssistant string
+	// lastQuery is the query the current recall was retrieved for, so a context
+	// replayed for the same user message does not search again. A tool-calling
+	// turn replays the context once per round trip.
+	lastQuery string
 }
 
 // NewMemory builds a memory service from cfg.
@@ -55,8 +59,16 @@ func (s *Service) ProcessFrame(ctx context.Context, f frames.Frame, dir processo
 	if err := s.Base.ProcessFrame(ctx, f, dir); err != nil {
 		return err
 	}
-	if cf, ok := f.(*frames.LLMContextFrame); ok && dir == processor.Downstream {
-		s.onContext(ctx, cf.Context)
+	switch fr := f.(type) {
+	case *frames.LLMContextFrame:
+		if dir == processor.Downstream {
+			s.onContext(ctx, fr.Context)
+		}
+	case *frames.StartFrame:
+		if s.cfg.Prewarm {
+			//nolint:gosec // detached like store: the warm-up must outlive a turn that gets interrupted
+			go s.prewarm()
+		}
 	}
 	return s.PushFrame(ctx, f, dir)
 }
@@ -67,14 +79,38 @@ func (s *Service) ProcessFrame(ctx context.Context, f frames.Frame, dir processo
 // the background under a detached context so memories outlive a barge-in.
 func (s *Service) onContext(ctx context.Context, convo *frames.LLMContext) {
 	msgs := convo.Messages()
-	if query := lastText(msgs, frames.RoleUser); query != "" {
-		mems, err := s.search(ctx, query)
+	if query := lastText(msgs, frames.RoleUser); query != "" && query != s.lastQuery {
+		s.lastQuery = query
+		sctx, cancel := s.searchContext(ctx)
+		mems, err := s.search(sctx, query)
+		cancel()
 		if err != nil && ctx.Err() == nil {
 			slog.Warn("mem0 search failed", "processor", s.Name(), "error", err)
 		}
 		convo.SetRecall(formatMemories(mems))
 	}
 	s.store(msgs)
+}
+
+// searchContext bounds retrieval when SearchTimeout is set, so a slow mem0
+// delays a reply by no more than that.
+func (s *Service) searchContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if s.cfg.SearchTimeout <= 0 {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, s.cfg.SearchTimeout)
+}
+
+// prewarm issues one throwaway search at session start so the first real one
+// does not pay for whatever the path warms up. Measured over a session on a
+// self-hosted server: 1.52s for the first search, 0.58s for the second, 0.19s
+// for the third.
+func (s *Service) prewarm() {
+	ctx, cancel := context.WithTimeout(context.Background(), s.cfg.Timeout)
+	defer cancel()
+	if _, err := s.search(ctx, prewarmQuery); err != nil {
+		slog.Debug("mem0 prewarm failed", "processor", s.Name(), "error", err)
+	}
 }
 
 // store sends the latest user and assistant turns to mem0 once each. The

--- a/transport/pionrtc/gap_test.go
+++ b/transport/pionrtc/gap_test.go
@@ -1,0 +1,69 @@
+package pionrtc
+
+import (
+	"strings"
+	"testing"
+)
+
+// speech is a run of frames of real audio, quiet a run of silence frames sent
+// because the queue was empty. Runs are built rather than written out so the
+// lengths stay legible next to starvationFrames.
+func speech(n int) string { return strings.Repeat("#", n) }
+func quiet(n int) string  { return strings.Repeat(".", n) }
+
+// play drives a tracker over a pattern of those runs.
+func play(pattern string) gapTracker {
+	var g gapTracker
+	for _, c := range pattern {
+		if c == '#' {
+			g.real()
+		} else {
+			g.quiet()
+		}
+	}
+	return g
+}
+
+// pause is longer than any gap can be, so it reads as the talker stopping.
+func pause() string { return quiet(starvationFrames + 5) }
+
+func TestGapTrackerChargesOnlySilenceInsideSpeech(t *testing.T) {
+	cases := []struct {
+		name    string
+		pattern string
+		starved int64
+		gaps    int64
+	}{
+		// The counter this replaces charged every one of these tails, which made
+		// starved track the number of utterances rather than any fault.
+		{"an utterance and its trailing silence", speech(5) + pause(), 0, 0},
+		{"two utterances, each with a tail", speech(3) + pause() + speech(3) + pause(), 0, 0},
+		{"silence before anything is spoken", pause() + speech(5), 0, 0},
+		{"a hiccup in the middle of a word", speech(5) + quiet(2) + speech(5), 2, 1},
+		{"two hiccups in one utterance", speech(3) + quiet(1) + speech(3) + quiet(2) + speech(3), 3, 2},
+		{"a hiccup at the edge of the window", speech(3) + quiet(starvationFrames) + speech(3), starvationFrames, 1},
+		{"one frame past the window", speech(3) + quiet(starvationFrames+1) + speech(3), 0, 0},
+		{"a hiccup, then the end of the utterance", speech(3) + quiet(2) + speech(3) + pause(), 2, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := play(tc.pattern)
+			if g.starved != tc.starved || g.gaps != tc.gaps {
+				t.Errorf("%q: starved=%d gaps=%d, want starved=%d gaps=%d",
+					tc.pattern, g.starved, g.gaps, tc.starved, tc.gaps)
+			}
+		})
+	}
+}
+
+func TestGapTrackerCountsEverySilentFrame(t *testing.T) {
+	// silence stays the raw total, independent of the fault accounting, so the
+	// two numbers together say how much of the silence was a fault.
+	g := play(speech(3) + pause() + speech(3) + quiet(2) + speech(3))
+	if want := int64(len(pause()) + 2); g.silence != want {
+		t.Errorf("silence=%d, want %d", g.silence, want)
+	}
+	if g.starved != 2 || g.gaps != 1 {
+		t.Errorf("starved=%d gaps=%d, want 2 and 1", g.starved, g.gaps)
+	}
+}

--- a/transport/pionrtc/transport.go
+++ b/transport/pionrtc/transport.go
@@ -145,9 +145,41 @@ func (in *inputTransport) readLoop(ctx context.Context) {
 // bot-speaking state stays close to what is actually playing.
 const queuedFrames = 8
 
-// starvationWindow is how soon after real audio a silence frame counts as the
-// sender having been starved rather than the talker having stopped.
-const starvationWindow = 200 * time.Millisecond
+// starvationFrames is the longest run of silence that still counts as a gap in
+// speech once real audio resumes after it. A longer run is taken as the end of
+// an utterance.
+const starvationFrames = 10
+
+// gapTracker accounts for the silence the sender emits. Only silence that real
+// audio resumes after is a fault: the writer fell behind and a word was chopped.
+// Silence that nothing resumes is the talker having stopped, which is why a run
+// stays pending until it is known which one it was — counting it on sight charges
+// every utterance for its own ending.
+type gapTracker struct {
+	silence int64
+	starved int64
+	gaps    int64
+	pending int64
+	spoken  bool
+}
+
+// real records a frame of real audio, settling any silence run before it.
+func (g *gapTracker) real() {
+	if g.pending > 0 && g.pending <= starvationFrames {
+		g.starved += g.pending
+		g.gaps++
+	}
+	g.pending = 0
+	g.spoken = true
+}
+
+// quiet records a frame of silence sent because the queue was empty.
+func (g *gapTracker) quiet() {
+	g.silence++
+	if g.spoken {
+		g.pending++
+	}
+}
 
 // outputTransport encodes outgoing PCM into Opus and writes it to the
 // connection's audio track at real time.
@@ -315,12 +347,12 @@ func (out *outputTransport) sendLoop(ctx context.Context, frameBytes int) {
 
 	quiet := make([]byte, frameBytes)
 	start := time.Now()
-	var sent, silence, starved int64
-	var lastReal time.Time
+	var sent int64
+	var gap gapTracker
 
 	defer func() {
-		slog.Info("pion sender stopped", "processor", out.Name(),
-			"frames", sent, "silence", silence, "starved", starved)
+		slog.Info("pion sender stopped", "processor", out.Name(), "frames", sent,
+			"silence", gap.silence, "starved", gap.starved, "gaps", gap.gaps)
 	}()
 
 	for {
@@ -349,14 +381,9 @@ func (out *outputTransport) sendLoop(ctx context.Context, frameBytes int) {
 		case frame := <-out.queue:
 			pcm = frame
 			out.queued.Add(-1)
-			lastReal = time.Now()
+			gap.real()
 		default:
-			silence++
-			// Silence arriving mid-speech means the writer did not keep up, which
-			// is heard as a chopped word rather than a pause.
-			if !lastReal.IsZero() && time.Since(lastReal) < starvationWindow {
-				starved++
-			}
+			gap.quiet()
 		}
 
 		packet, err := out.enc.Encode(pcm)


### PR DESCRIPTION
Three independent fixes found while chasing why a voice session produced three replies the caller never heard.

### `MinWordsStart` never cleared its bot-speaking flag on turn start

It tracked the bot's speaking state only from the bot-speaking frames, so after a barge-in it kept requiring `MinWords` until the interrupted bot's stopped frame arrived — holding the rest of that turn to the interruption bar rather than the ordinary one.

Upstream does this in [`MinWordsUserTurnStartStrategy.handle_user_turn_started`](https://github.com/pipecat-ai/pipecat/blob/main/src/pipecat/turns/user_start/min_words_user_turn_start_strategy.py); jargo has the `TurnStarted()` hook but the strategy did not override it. The rest of the port (`min_words if bot_speaking else 1`, interim handling, trigger/reset) already matched.

### mem0 searched once per context frame, not once per user message

A tool-calling turn replays the context after every round trip, and each replay repeated the same retrieval — latency and load on the critical path *before* the reply, for a result already in hand. Upstream guards this with `if self.last_query == query: return`.

Adds two config fields for the same critical path:

- `SearchTimeout` bounds the blocking retrieval separately from `Timeout`. A late memory is worse than a missing one when a reply is waiting on it.
- `Prewarm` issues one throwaway search at session start. Measured against a self-hosted server, the first search of a session took **1.52s**, the second 0.58s, the third 0.19s — so the first turn of every session paid the warm-up.

### The Pion starvation counter charged every utterance for its own ending

It counted any silence sent within a 200ms window after real audio. That window is also exactly what the end of an utterance looks like, so the figure tracked *how many times the bot spoke* rather than how often the writer fell behind — `starved ≈ 10 × utterances` on healthy sessions, reading as a fault every time.

A run of silence is now only charged once real audio resumes after it, and the log reports `gaps` alongside the frame count. **No change to what is sent** — the diff touches only the counters and the log line; the deadline computation, queue `select`, encode and write are untouched.

### Testing

`go test ./...` and `golangci-lint run` clean. Each behavioural test was mutation-checked — reverting the fix makes it fail:

- `TestMinWordsStartTurnStartedClearsBotSpeaking` → `starts = 1, want 2`
- `TestMemorySearchesOncePerUserMessage` → searched 4 times, want 2
- `TestMemorySearchTimeoutReleasesTheTurn` → `took 2.004s, want near the 100ms SearchTimeout`
- `TestGapTrackerChargesOnlySilenceInsideSpeech` covers tails, leading silence, mid-word hiccups, and the window edge