### PR TITLE
fix(elevenlabs): default auto_mode on, or the realtime TTS emits no audio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,6 +289,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- **The ElevenLabs WebSocket TTS produced no audio at all.** `auto_mode` was only
+  sent when the caller set it, and with it absent the server buffers text until an
+  explicit flush — then discards whatever was never flushed when the context
+  closes, answering with a final marker and an empty audio field. Every synthesis
+  therefore completed, quickly and without error, having emitted nothing.
+  `auto_mode` now defaults on, as upstream does; a caller driving generation with
+  its own flushes can still turn it off. The fake server in the tests accepted the
+  broken sequence, which is why this passed CI: it now generates only when auto
+  mode is on or a flush was sent, as the real one does.
 - **`MinWordsStart` drops back to the single-word threshold as soon as a turn
   opens.** It tracked the bot's speaking state only from the bot-speaking frames,
   so after a barge-in it kept requiring `MinWords` until the interrupted bot's

--- a/provider/elevenlabs/realtime_tts.go
+++ b/provider/elevenlabs/realtime_tts.go
@@ -89,6 +89,14 @@ func (c RealtimeTTSConfig) withDefaults() RealtimeTTSConfig {
 	if c.SampleRate == 0 {
 		c.SampleRate = defaultSampleRate
 	}
+	if c.AutoMode == nil {
+		// Without auto mode the server holds text until it is explicitly flushed,
+		// and closing a context discards whatever was never flushed — the synthesis
+		// then ends with a final marker and no audio at all. Sentence-at-a-time
+		// synthesis has nothing to gain from that buffering, so it is on unless the
+		// caller turns it off.
+		c.AutoMode = new(true)
+	}
 	return c
 }
 

--- a/provider/elevenlabs/realtime_tts_test.go
+++ b/provider/elevenlabs/realtime_tts_test.go
@@ -64,10 +64,31 @@ func TestRealtimeTTSEndpoint(t *testing.T) {
 		"model_id":      defaultModel,
 		"output_format": "pcm_24000",
 		"language_code": "fr",
+		// Omitting auto_mode leaves the server buffering text that closing the
+		// context then discards, so a synthesis returns no audio whatsoever.
+		"auto_mode": "true",
 	} {
 		if got := u.Query().Get(key); got != want {
 			t.Errorf("%s = %q, want %q", key, got, want)
 		}
+	}
+}
+
+// TestRealtimeTTSAutoModeCanBeDisabled checks the default is a default and not a
+// constant: a caller driving generation itself with explicit flushes can turn it
+// off.
+func TestRealtimeTTSAutoModeCanBeDisabled(t *testing.T) {
+	s := &realtimeSynthesizer{cfg: RealtimeTTSConfig{
+		APIKey:   "k",
+		AutoMode: new(false),
+	}.withDefaults()}
+
+	u, err := url.Parse(s.endpoint())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := u.Query().Get("auto_mode"); got != "false" {
+		t.Errorf("auto_mode = %q, want %q", got, "false")
 	}
 }
 
@@ -85,10 +106,16 @@ func realtimeTTSServer(t *testing.T, script [][]map[string]any) (host string, se
 		defer func() { _ = c.Close(websocket.StatusNormalClosure, "") }()
 		ctx := r.Context()
 
+		// Auto mode makes the server generate as text arrives. Without it, text is
+		// held until a flush, and closing the context discards what was never
+		// flushed — the real server then answers with a final marker and no audio.
+		autoMode := r.URL.Query().Get("auto_mode") == "true"
+
 		for _, events := range script {
 			// Each synthesis opens a context, sends its text, and closes it.
 			var contextID string
-			for range 3 {
+			generate := autoMode
+			for {
 				_, data, err := c.Read(ctx)
 				if err != nil {
 					return
@@ -101,6 +128,19 @@ func realtimeTTSServer(t *testing.T, script [][]map[string]any) (host string, se
 				if id, ok := msg["context_id"].(string); ok {
 					contextID = id
 				}
+				if flush, ok := msg["flush"].(bool); ok && flush {
+					generate = true
+				}
+				if closed, ok := msg["close_context"].(bool); ok && closed {
+					break
+				}
+			}
+			if !generate {
+				b, _ := json.Marshal(map[string]any{"contextId": contextID, "isFinal": true})
+				if c.Write(ctx, websocket.MessageText, b) != nil {
+					return
+				}
+				continue
 			}
 			for _, ev := range events {
 				// The server stamps every message with the context it belongs to.


### PR DESCRIPTION
### The bug

`NewRealtimeTTS` sent `auto_mode` only when the caller set it. With the parameter absent, the server buffers text until an explicit flush — and closing the context **discards whatever was never flushed**, answering with a final marker and an empty audio field.

So every synthesis completed quickly, with no error and **no audio**. The bot never spoke a word. Spans recorded a successful synthesis of the right character count, which is what made this hard to see: what listeners heard were the start/end chimes, queued as raw audio frames and never routed through TTS.

### Confirmed against the live endpoint

Sending the exact sequence this code sends:

| sequence | result |
|---|---|
| `{text:" "}`, `{text:…}`, `{close_context:true}` | **1 message, isFinal, 0 audio** |
| same, with a trailing space on the text | 0 audio |
| same, plus `{flush:true}` before close | 137,636 b64 chars |
| `auto_mode=true` in the URL, original sequence | 135,640 b64 chars |

With `auto_mode=true` every sequence returns audio. An explicit flush also works, but auto mode is what [upstream defaults to](https://github.com/pipecat-ai/pipecat/blob/main/src/pipecat/services/elevenlabs/tts.py) (`auto_mode: bool | None = True`, always placed in the URL), and sentence-at-a-time synthesis has nothing to gain from the buffering. It stays a `*bool`, so a caller driving generation with its own flushes can turn it off.

Verified end to end through the provider's own code path against the live API: two syntheses on one connection produced 0.63s and 2.49s of audio.

### Why CI never caught it

The fake server in the tests replied with its scripted audio regardless of what the client sent — more permissive than the real one. It now models the real contract: generate only under auto mode or after a flush. Without the fix, three existing tests fail with `emitted []`, exactly the production symptom.