### PR TITLE
fix(tts): warm the synthesizer on start, and stop rejecting large audio messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -287,8 +287,27 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - The `frames` package documents its ownership rule: a frame has a single owner
   at a time and must not be mutated after it is pushed.
 
+### Added
+
+- **`tts.Starter`**, the counterpart to `tts.Closer` at the other end of the
+  pipeline's life: an optional interface a Synthesizer implements when it has
+  setup to do before the first sentence, such as dialing the connection it will
+  reuse. Upstream every WebSocket TTS service connects in its `start(StartFrame)`
+  and none dials lazily, so this closes a gap rather than adding an optimization —
+  the Synthesizer contract had no way to take part in the pipeline starting.
+  `provider/elevenlabs.NewRealtimeTTS` implements it, having dialed on first use:
+  its handshake measured 2.3 s on a session's first synthesis against roughly
+  120 ms for every one after, all of it in the silence before the bot's opening
+  words.
+
 ### Fixed
 
+- **A single WebSocket message larger than a megabyte failed the read.** The
+  shared read limit was set on the premise that a provider's base64 audio chunks
+  fit comfortably below it; a TTS provider generating a long sentence in one go
+  sends well past that, and the synthesis died part-way through a reply with
+  `message too big`. The limit exists to stop a server streaming without end, not
+  to bound a legitimate message, so it is now 16 MiB.
 - **The ElevenLabs WebSocket TTS produced no audio at all.** `auto_mode` was only
   sent when the caller set it, and with it absent the server buffers text until an
   explicit flush — then discards whatever was never flushed when the context

--- a/provider/elevenlabs/realtime_tts.go
+++ b/provider/elevenlabs/realtime_tts.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -188,6 +189,19 @@ func (s *realtimeSynthesizer) drop() {
 	}
 	_ = s.conn.Close(websocket.StatusInternalError, "")
 	s.conn = nil
+}
+
+// Start dials the shared connection when the pipeline starts, implementing
+// tts.Starter. The handshake to the vendor is the slowest part of a session's
+// first sentence, so leaving it to be dialed lazily puts it in front of the
+// bot's opening words.
+func (s *realtimeSynthesizer) Start(ctx context.Context) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, err := s.stream(ctx); err != nil {
+		// Best-effort: the first synthesis dials again and reports the failure.
+		slog.Debug("elevenlabs realtime tts connect on start failed", "error", err)
+	}
 }
 
 // Close releases the shared connection, implementing tts.Closer.

--- a/provider/elevenlabs/realtime_tts_test.go
+++ b/provider/elevenlabs/realtime_tts_test.go
@@ -74,6 +74,39 @@ func TestRealtimeTTSEndpoint(t *testing.T) {
 	}
 }
 
+// TestRealtimeTTSAcceptsALargeAudioMessage checks a single message carrying a
+// long sentence's audio is read rather than rejected. Generating a whole sentence
+// at once puts well over a megabyte of base64 in one message, and a read limit
+// tight enough to cut that off fails the synthesis part-way through a reply.
+func TestRealtimeTTSAcceptsALargeAudioMessage(t *testing.T) {
+	// Comfortably past the megabyte that used to be the ceiling.
+	big := make([]byte, 2<<20)
+	for i := range big {
+		big[i] = byte(i)
+	}
+	host, _ := realtimeTTSServer(t, [][]map[string]any{{
+		audioMessage(big),
+		{"isFinal": true},
+	}})
+
+	s := &realtimeSynthesizer{cfg: RealtimeTTSConfig{
+		APIKey: "k", Host: host, SampleRate: 24000,
+	}.withDefaults()}
+	defer func() { _ = s.Close() }()
+
+	total := 0
+	err := s.Synthesize(context.Background(), "Une phrase longue.", func(pcm []byte) error {
+		total += len(pcm)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("synthesis of a large message failed: %v", err)
+	}
+	if total != len(big) {
+		t.Errorf("emitted %d bytes, want %d", total, len(big))
+	}
+}
+
 // TestRealtimeTTSAutoModeCanBeDisabled checks the default is a default and not a
 // constant: a caller driving generation itself with explicit flushes can turn it
 // off.

--- a/service/tts/tts.go
+++ b/service/tts/tts.go
@@ -96,6 +96,16 @@ type Closer interface {
 	Close() error
 }
 
+// Starter is an optional interface a Synthesizer implements when it has setup to
+// do before the first synthesis, such as dialing the connection it will reuse.
+// The Base calls it when the pipeline starts — the counterpart to Closer at
+// teardown — so the cost lands while the transport is still negotiating rather
+// than in front of the first thing the bot says. It runs off the frame goroutine.
+// A Synthesizer that does not implement it is unaffected.
+type Starter interface {
+	Start(ctx context.Context)
+}
+
 // pendingWord is a TTSTextFrame awaiting the point in the emitted audio where
 // its word begins, so it is pushed downstream in step with playback.
 type pendingWord struct {
@@ -173,6 +183,11 @@ func (b *Base) ProcessFrame(ctx context.Context, f frames.Frame, dir processor.D
 			return err
 		}
 		b.broadcastMetadata(ctx)
+		if st, ok := b.syn.(Starter); ok {
+			// Detached: the setup outlives this frame, and a turn canceled by an
+			// interruption must not abandon a connection half-dialed.
+			go st.Start(context.WithoutCancel(ctx))
+		}
 		return nil
 	default:
 		return b.PushFrame(ctx, f, dir)

--- a/service/tts/tts_test.go
+++ b/service/tts/tts_test.go
@@ -226,6 +226,44 @@ func TestCleanupClosesSynthesizer(t *testing.T) {
 	}
 }
 
+// startingSynth records that it was given the chance to set up before the first
+// synthesis.
+type startingSynth struct {
+	*fakeSynth
+	started chan struct{}
+}
+
+func (s *startingSynth) Start(context.Context) {
+	select {
+	case s.started <- struct{}{}:
+	default:
+	}
+}
+
+// TestStartStartsSynthesizer checks a Synthesizer with setup to do is asked to do
+// it on start. The vendor handshake is the slowest part of a session's first
+// synthesis, and it belongs in the window where the transport is still
+// negotiating rather than in front of the bot's first words.
+func TestStartStartsSynthesizer(t *testing.T) {
+	syn := &startingSynth{
+		fakeSynth: &fakeSynth{rate: 24000, chunk: []byte{1}, spoken: make(chan string, 1)},
+		started:   make(chan struct{}, 1),
+	}
+	task := pipeline.NewTask(pipeline.New(tts.New("StartingTTS", syn)), pipeline.TaskParams{})
+	runDone := make(chan error, 1)
+	go func() { runDone <- task.Run(context.Background()) }()
+
+	// StartFrame alone: no text has been queued and nothing has been synthesized.
+	select {
+	case <-syn.started:
+	case <-time.After(3 * time.Second):
+		t.Fatal("the synthesizer was not started on start")
+	}
+
+	task.StopWhenDone()
+	<-runDone
+}
+
 // TestCleanupWithoutCloserIsFine checks a Synthesizer that holds nothing open is
 // unaffected by the teardown hook.
 func TestCleanupWithoutCloserIsFine(t *testing.T) {

--- a/service/wsutil/wsutil.go
+++ b/service/wsutil/wsutil.go
@@ -11,9 +11,11 @@ import (
 	"github.com/coder/websocket"
 )
 
-// DefaultReadLimit bounds a single inbound WebSocket message. Providers stream
-// base64-encoded audio chunks, which fit comfortably in 1 MiB.
-const DefaultReadLimit = 1 << 20
+// DefaultReadLimit bounds a single inbound WebSocket message. It guards against
+// a server that streams without end, not against large messages: a TTS provider
+// generating a long sentence in one go sends base64 audio well past a megabyte,
+// and a limit tight enough to cut that off fails the synthesis mid-reply.
+const DefaultReadLimit = 16 << 20
 
 // Dial opens a WebSocket to url with the given headers, closes the handshake
 // response body, and applies readLimit when it is positive. The caller owns the


### PR DESCRIPTION
Two problems the now-working audio path exposed in a live session.

### The first synthesis of a session paid the vendor handshake

Measured over one session: `tts.ttfb_ms` was **2348** on the first synthesis and **100–202** on the twelve after it. That 2.2s sat in the silence before the bot's opening words.

`tts.Warmer` is a new optional interface — a Synthesizer that can prepare ahead of the first sentence (dialing a connection it will reuse) is asked to on start, off the frame goroutine. Optional and detached like the existing `Closer`, since a turn canceled by an interruption must not abandon a half-dialed connection. `NewRealtimeTTS` implements it.

### A single audio message over a megabyte failed the read

```
tts synthesis failed err="failed to read: websocket: message too big: read limited at 1048577 bytes"
```

That truncated a reply mid-sentence. `DefaultReadLimit` was 1 MiB, with a comment asserting that providers' base64 audio chunks "fit comfortably" in it — they do not, once a provider generates a whole sentence in one go. The limit guards against a server that streams without end, not against a large legitimate message, so it is now 16 MiB. It is shared by every WebSocket provider, so this fixes the audio-bearing ones together.

### Testing

`go test ./...` and `golangci-lint run` clean. Both fixes are mutation-checked:

- reverting the read limit: `synthesis of a large message failed: websocket: message too big: read limited at 1048577 bytes` — the production error, verbatim
- disabling the warm hook: `the synthesizer was not warmed on start`