### PR TITLE
fix(transport): drive bot speaking off the TTS stop, not a timer

### DIFF
--- a/audio/utils.go
+++ b/audio/utils.go
@@ -1,0 +1,30 @@
+package audio
+
+import "encoding/binary"
+
+// speakingThreshold is the largest absolute 16-bit sample amplitude a buffer can
+// contain and still count as silence. Speech normally reaches amplitudes of
+// roughly 500 to 5000 depending on loudness and microphone gain, so the
+// threshold sits well below speech and distinguishes it from a silent stream.
+const speakingThreshold = 20
+
+// IsSilence reports whether a chunk of 16-bit signed PCM is silence, by
+// comparing the largest absolute sample amplitude against speakingThreshold.
+//
+// It expects clean speech or true silence: a stream with audible background
+// noise keeps the amplitude above the threshold and never reads as silent. An
+// empty buffer carries no audible sample and so counts as silence.
+func IsSilence(pcm []byte) bool {
+	for i := 0; i+1 < len(pcm); i += 2 {
+		// Widen to int before negating: the most negative 16-bit sample has no
+		// positive counterpart, so negating it in place would wrap.
+		sample := int(int16(binary.LittleEndian.Uint16(pcm[i:])))
+		if sample < 0 {
+			sample = -sample
+		}
+		if sample > speakingThreshold {
+			return false
+		}
+	}
+	return true
+}

--- a/audio/utils_test.go
+++ b/audio/utils_test.go
@@ -1,0 +1,43 @@
+package audio_test
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/gojargo/jargo/audio"
+)
+
+// pcm builds a little-endian S16LE buffer from samples.
+func pcm(samples ...int16) []byte {
+	b := make([]byte, len(samples)*2)
+	for i, s := range samples {
+		binary.LittleEndian.PutUint16(b[i*2:], uint16(s))
+	}
+	return b
+}
+
+func TestIsSilence(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []byte
+		want bool
+	}{
+		{"empty buffer", nil, true},
+		{"all zero samples", pcm(0, 0, 0, 0), true},
+		{"at the threshold", pcm(20, -20), true},
+		{"just past the threshold", pcm(0, 21), false},
+		{"just past it going negative", pcm(0, -21), false},
+		{"speech level", pcm(0, 1200, -3000), false},
+		{"the most negative sample", pcm(-32768), false},
+		{"one loud sample among quiet ones", pcm(1, -2, 5000, 3), false},
+		{"odd trailing byte is ignored", append(pcm(0, 0), 0xFF), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := audio.IsSilence(tt.in); got != tt.want {
+				t.Errorf("IsSilence() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/frames/audio.go
+++ b/frames/audio.go
@@ -92,9 +92,27 @@ func NewTTSAudioRawFrame(audio []byte, sampleRate, numChannels int) *TTSAudioRaw
 	}
 }
 
+// SpeechOutputAudioRawFrame is one chunk of a continuous stream of speech audio.
+// The stream can also carry silence between utterances, so a consumer that needs
+// to tell the two apart has to test the samples themselves.
+type SpeechOutputAudioRawFrame struct {
+	OutputAudioRawFrame
+}
+
+// NewSpeechOutputAudioRawFrame builds a SpeechOutputAudioRawFrame from PCM audio.
+func NewSpeechOutputAudioRawFrame(audio []byte, sampleRate, numChannels int) *SpeechOutputAudioRawFrame {
+	return &SpeechOutputAudioRawFrame{
+		OutputAudioRawFrame: OutputAudioRawFrame{
+			BaseDataFrame: NewBaseDataFrame("SpeechOutputAudioRawFrame"),
+			AudioRawData:  newAudioRawData(audio, sampleRate, numChannels),
+		},
+	}
+}
+
 // Compile-time interface checks.
 var (
 	_ SystemFrame = (*InputAudioRawFrame)(nil)
 	_ DataFrame   = (*OutputAudioRawFrame)(nil)
 	_ DataFrame   = (*TTSAudioRawFrame)(nil)
+	_ DataFrame   = (*SpeechOutputAudioRawFrame)(nil)
 )

--- a/processor/aggregators/aggregators.go
+++ b/processor/aggregators/aggregators.go
@@ -575,23 +575,7 @@ func (u *UserAggregator) Push(ctx context.Context, f frames.Frame, dir processor
 	return u.PushFrame(ctx, f, dir)
 }
 
-// Broadcast implements turns.Emitter, sending a frame both downstream and
-// upstream so turn decisions reach the whole pipeline.
-//
-// build is called once per direction: the two halves are distinct frames, paired
-// by BroadcastSiblingID. The directions are processed on separate goroutines, so
-// a shared frame would be mutated concurrently, and a consumer that sees both
-// halves can recognize the pair rather than reporting the event twice.
-func (u *UserAggregator) Broadcast(ctx context.Context, build func() frames.Frame) error {
-	down, up := build(), build()
-	down.Base().SetBroadcastSiblingID(up.ID())
-	up.Base().SetBroadcastSiblingID(down.ID())
-
-	if err := u.PushFrame(ctx, down, processor.Downstream); err != nil {
-		return err
-	}
-	return u.PushFrame(ctx, up, processor.Upstream)
-}
+// Broadcast, which turns.Emitter also requires, is promoted from processor.Base.
 
 // onTurnStarted broadcasts the turn-start decision and barges in, and feeds the
 // idle controller a synthetic user-started frame so it tracks the turn.

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -333,6 +333,24 @@ func (b *Base) PushFrame(ctx context.Context, f frames.Frame, dir Direction) err
 	return nil
 }
 
+// Broadcast sends a frame both downstream and upstream, so an event that the
+// whole pipeline has to see reaches processors on either side of this one.
+//
+// build is called once per direction: the two halves are distinct frames paired
+// by BroadcastSiblingID. The directions are processed on separate goroutines, so
+// a single shared frame would be mutated concurrently, and a consumer that sees
+// both halves can recognize the pair rather than reporting the event twice.
+func (b *Base) Broadcast(ctx context.Context, build func() frames.Frame) error {
+	down, up := build(), build()
+	down.Base().SetBroadcastSiblingID(up.ID())
+	up.Base().SetBroadcastSiblingID(down.ID())
+
+	if err := b.PushFrame(ctx, down, Downstream); err != nil {
+		return err
+	}
+	return b.PushFrame(ctx, up, Upstream)
+}
+
 // PushTokenUsage reports LLM token usage measured by a service that does not run
 // through the LLM base — a realtime (speech-to-speech) service that receives a
 // usage event from its provider. It opens a short "llm" span carrying the

--- a/transport/output.go
+++ b/transport/output.go
@@ -5,17 +5,31 @@ import (
 	"encoding/json"
 	"log/slog"
 	"sync"
-	"sync/atomic"
 	"time"
 
+	"github.com/gojargo/jargo/audio"
 	"github.com/gojargo/jargo/audio/resample"
 	"github.com/gojargo/jargo/frames"
 	"github.com/gojargo/jargo/processor"
 )
 
-// botStopDebounce is how long after the last audio chunk the bot is considered
-// to have stopped speaking.
-const botStopDebounce = 250 * time.Millisecond
+const (
+	// botVADStop is how long a speech stream has to stay silent before the
+	// bot counts as having stopped speaking. It applies only to a speech stream,
+	// which carries silence between utterances; TTS output is ended by its
+	// TTSStoppedFrame instead.
+	botVADStop = 350 * time.Millisecond
+
+	// botVADStopFallback is the fallback, used when nothing reaches the
+	// output at all: with no audio and no stop frame for this long, the bot
+	// counts as having stopped speaking.
+	botVADStopFallback = 3 * time.Second
+
+	// botSpeakingFramePeriod is how often a BotSpeakingFrame is broadcast while
+	// the bot holds the floor. It only has an effect while it stays longer than
+	// one chunk's duration.
+	botSpeakingFramePeriod = 200 * time.Millisecond
+)
 
 // BaseOutput is the tail of a pipeline: it buffers OutputAudioRawFrames, slices
 // them into fixed-size chunks, and hands each chunk to the concrete transport
@@ -36,6 +50,11 @@ type BaseOutput struct {
 
 	bufMu  sync.Mutex
 	buffer []byte
+	// newChunk rebuilds a buffered chunk as the same frame type as the audio it
+	// was buffered from, so TTS audio stays a TTSAudioRawFrame and a speech
+	// stream stays a SpeechOutputAudioRawFrame. The bot-speaking bookkeeping
+	// reads that type to tell which of the two it is pacing out.
+	newChunk func(pcm []byte, sampleRate, numChannels int) frames.Frame
 
 	audioOut    chan frames.Frame
 	audioCtx    context.Context
@@ -47,17 +66,20 @@ type BaseOutput struct {
 	// drainWait, set under bufMu before a drain marker is queued, is closed by
 	// the audio loop once it has paced out everything ahead of the marker.
 	drainWait chan struct{}
-	// flushFrame holds the padded trailing chunk emitted when a turn ends. The
-	// audio loop plays it but skips the bot-speaking bookkeeping, so flushing a
-	// turn's tail does not re-arm speaking on a floor the bot has already given up.
-	flushFrame atomic.Pointer[frames.OutputAudioRawFrame]
 
-	// Bot-speaking detection: a BotStartedSpeakingFrame is emitted upstream when
-	// audio starts flowing and a BotStoppedSpeakingFrame after it drains, so the
-	// turn and idle controllers know when the bot holds the floor.
-	botMu         sync.Mutex
-	botSpeaking   bool
-	botStopCancel func()
+	// Bot-speaking detection: BotStartedSpeakingFrame is broadcast when the
+	// bot's audio starts flowing and BotStoppedSpeakingFrame once it ends, so
+	// the turn and idle controllers know when the bot holds the floor.
+	botMu sync.Mutex
+	// botSpeaking is whether the bot currently holds the floor.
+	botSpeaking bool
+	// ttsAudioReceived gates ending a turn on TTSStoppedFrame: a stop only
+	// counts once TTS audio has actually arrived for the turn.
+	ttsAudioReceived bool
+	// botSpeakingFrameAt is when the last periodic BotSpeakingFrame went out.
+	botSpeakingFrameAt time.Time
+	// botSpeechLastAt is when the bot was last audibly speaking.
+	botSpeechLastAt time.Time
 }
 
 // NewBaseOutput builds a BaseOutput. self is the embedding transport, used to
@@ -79,6 +101,9 @@ func (bo *BaseOutput) WriteAudio(context.Context, []byte) error { return nil }
 
 // SendMessage is the default no-op; a concrete transport overrides it.
 func (bo *BaseOutput) SendMessage(context.Context, []byte) error { return nil }
+
+// WriteTransportFrame is the default no-op; a concrete transport overrides it.
+func (bo *BaseOutput) WriteTransportFrame(context.Context, frames.Frame) error { return nil }
 
 // ProcessFrame handles the transport lifecycle and routes audio.
 func (bo *BaseOutput) ProcessFrame(ctx context.Context, f frames.Frame, dir processor.Direction) error {
@@ -104,17 +129,21 @@ func (bo *BaseOutput) ProcessFrame(ctx context.Context, f frames.Frame, dir proc
 			return err
 		}
 		bo.handleInterruption()
-		bo.stopBotSpeaking(ctx)
+		bo.botStoppedSpeaking(ctx)
 		return nil
 	case *frames.OutputTransportMessageFrame, *frames.OutputTransportMessageUrgentFrame:
 		return bo.handleTransportMessage(ctx, f, dir)
 	case frames.MixerControlFrame:
 		return bo.handleMixerControl(ctx, fr, dir)
-	case *frames.TTSAudioRawFrame, *frames.OutputAudioRawFrame:
+	case *frames.TTSAudioRawFrame, *frames.SpeechOutputAudioRawFrame, *frames.OutputAudioRawFrame:
 		if dir == processor.Downstream {
-			audio, rate, channels := outputAudio(f)
-			bo.handleAudioFrame(audio, rate, channels)
+			bo.handleAudioFrame(f)
 			return nil
+		}
+		return bo.PushFrame(ctx, f, dir)
+	case *frames.TTSStoppedFrame:
+		if dir == processor.Downstream {
+			return bo.handleTTSStopped(ctx, fr)
 		}
 		return bo.PushFrame(ctx, f, dir)
 	default:
@@ -168,7 +197,7 @@ func (bo *BaseOutput) startStreaming(ctx context.Context, f *frames.StartFrame) 
 }
 
 func (bo *BaseOutput) stopStreaming(ctx context.Context) {
-	bo.stopBotSpeaking(ctx)
+	bo.botStoppedSpeaking(ctx)
 	if bo.params.AudioOutMixer != nil {
 		_ = bo.params.AudioOutMixer.Stop(ctx)
 	}
@@ -196,15 +225,15 @@ var drainMarker = &frames.OutputAudioRawFrame{}
 func (bo *BaseOutput) drainAudio(ctx context.Context) {
 	bo.bufMu.Lock()
 	ac := bo.audioCtx
+	bo.bufMu.Unlock()
 	if ac == nil {
-		bo.bufMu.Unlock()
 		return
 	}
-	if len(bo.buffer) > 0 { // pad and flush the sub-chunk tail so it plays too
-		chunk := padChunk(bo.buffer, bo.chunkSize)
-		bo.buffer = nil
-		sendAudio(ac, bo.audioOut, frames.Frame(frames.NewOutputAudioRawFrame(chunk, bo.sampleRate, bo.channels)))
-	}
+
+	// Pad and flush the sub-chunk tail so the last of the audio plays too.
+	bo.enqueueFlushedAudioBuffer()
+
+	bo.bufMu.Lock()
 	done := make(chan struct{})
 	bo.drainWait = done
 	bo.bufMu.Unlock()
@@ -276,10 +305,13 @@ func (bo *BaseOutput) sendMessage(ctx context.Context, message any) error {
 }
 
 // outputAudio extracts the PCM, sample rate and channel count from a bot audio
-// frame (a TTSAudioRawFrame or a plain OutputAudioRawFrame).
-func outputAudio(f frames.Frame) (audio []byte, sampleRate, channels int) {
+// frame (a TTSAudioRawFrame, a SpeechOutputAudioRawFrame, or a plain
+// OutputAudioRawFrame).
+func outputAudio(f frames.Frame) (pcm []byte, sampleRate, channels int) {
 	switch fr := f.(type) {
 	case *frames.TTSAudioRawFrame:
+		return fr.Audio, fr.SampleRate, fr.NumChannels
+	case *frames.SpeechOutputAudioRawFrame:
 		return fr.Audio, fr.SampleRate, fr.NumChannels
 	case *frames.OutputAudioRawFrame:
 		return fr.Audio, fr.SampleRate, fr.NumChannels
@@ -287,30 +319,99 @@ func outputAudio(f frames.Frame) (audio []byte, sampleRate, channels int) {
 	return nil, 0, 0
 }
 
+// chunkBuilder returns the constructor for f's own frame type, so a chunk sliced
+// out of f is rebuilt as the same kind of frame rather than flattened to a plain
+// OutputAudioRawFrame.
+func chunkBuilder(f frames.Frame) func(pcm []byte, sampleRate, numChannels int) frames.Frame {
+	switch f.(type) {
+	case *frames.TTSAudioRawFrame:
+		return func(pcm []byte, rate, ch int) frames.Frame {
+			return frames.NewTTSAudioRawFrame(pcm, rate, ch)
+		}
+	case *frames.SpeechOutputAudioRawFrame:
+		return func(pcm []byte, rate, ch int) frames.Frame {
+			return frames.NewSpeechOutputAudioRawFrame(pcm, rate, ch)
+		}
+	default:
+		return func(pcm []byte, rate, ch int) frames.Frame {
+			return frames.NewOutputAudioRawFrame(pcm, rate, ch)
+		}
+	}
+}
+
 // handleAudioFrame resamples incoming audio to the output rate, buffers it, and
-// emits fixed-size chunks.
-func (bo *BaseOutput) handleAudioFrame(audio []byte, sampleRate, channels int) {
+// emits fixed-size chunks, each rebuilt as the frame type it was buffered from.
+func (bo *BaseOutput) handleAudioFrame(f frames.Frame) {
 	if !bo.params.AudioOutEnabled || bo.chunkSize == 0 {
 		return
 	}
-	audio = bo.resample(audio, sampleRate, channels)
+	pcm, sampleRate, channels := outputAudio(f)
+	pcm = bo.resample(pcm, sampleRate, channels)
 
 	bo.bufMu.Lock()
-	bo.buffer = append(bo.buffer, audio...)
-	var chunks [][]byte
+	bo.newChunk = chunkBuilder(f)
+	build := bo.newChunk
+	bo.buffer = append(bo.buffer, pcm...)
+	var chunks []frames.Frame
 	for len(bo.buffer) >= bo.chunkSize {
 		chunk := make([]byte, bo.chunkSize)
 		copy(chunk, bo.buffer[:bo.chunkSize])
-		chunks = append(chunks, chunk)
+		chunks = append(chunks, build(chunk, bo.sampleRate, channels))
 		bo.buffer = bo.buffer[bo.chunkSize:]
 	}
 	ctx := bo.audioCtx
+	out := bo.audioOut
 	bo.bufMu.Unlock()
 
 	for _, chunk := range chunks {
-		out := frames.NewOutputAudioRawFrame(chunk, bo.sampleRate, bo.channels)
-		sendAudio(ctx, bo.audioOut, frames.Frame(out))
+		sendAudio(ctx, out, chunk)
 	}
+}
+
+// handleTTSStopped queues a TTSStoppedFrame behind the audio it ends, flushing
+// the trailing partial chunk first. handleAudioFrame only queues whole chunks,
+// so up to one chunk of a turn's audio can still be sitting in the buffer;
+// queueing it now plays it before the stop frame is handled, instead of leaving
+// it to be discarded when the buffer is cleared.
+func (bo *BaseOutput) handleTTSStopped(ctx context.Context, f *frames.TTSStoppedFrame) error {
+	bo.enqueueFlushedAudioBuffer()
+
+	bo.bufMu.Lock()
+	audioCtx, out := bo.audioCtx, bo.audioOut
+	bo.bufMu.Unlock()
+	if audioCtx == nil || out == nil {
+		return bo.PushFrame(ctx, f, processor.Downstream)
+	}
+	// The audio loop forwards it downstream once it reaches it, so that the stop
+	// lands after the audio it ends rather than ahead of it.
+	sendAudio(audioCtx, out, frames.Frame(f))
+	return nil
+}
+
+// enqueueFlushedAudioBuffer pads whatever is left in the buffer out to a full
+// chunk with silence and queues it for playback, as the same frame type as the
+// audio it was buffered from. It goes through the normal playback path (write,
+// error handling, bot-speaking bookkeeping) like any other chunk, and keeps its
+// order relative to whatever is queued after it.
+func (bo *BaseOutput) enqueueFlushedAudioBuffer() {
+	bo.bufMu.Lock()
+	if len(bo.buffer) == 0 || bo.chunkSize == 0 {
+		bo.bufMu.Unlock()
+		return
+	}
+	build := bo.newChunk
+	if build == nil {
+		build = chunkBuilder(nil)
+	}
+	tail := build(padChunk(bo.buffer, bo.chunkSize), bo.sampleRate, bo.channels)
+	bo.buffer = nil
+	audioCtx, out := bo.audioCtx, bo.audioOut
+	bo.bufMu.Unlock()
+
+	if audioCtx == nil || out == nil {
+		return
+	}
+	sendAudio(audioCtx, out, tail)
 }
 
 // enqueueWordFrame queues a downstream word-aligned TTSTextFrame on the audio
@@ -371,7 +472,6 @@ func (bo *BaseOutput) handleInterruption() {
 	bo.bufMu.Lock()
 	bo.buffer = nil
 	bo.bufMu.Unlock()
-	bo.flushFrame.Store(nil)
 	if bo.clockQ != nil {
 		// The frames waiting on the clock belong to audio that will never play.
 		bo.clockQ.drop()
@@ -385,124 +485,179 @@ func (bo *BaseOutput) handleInterruption() {
 	}
 }
 
-// flushTailChunk pads and emits the sub-chunk remainder left in the buffer at a
-// turn's end, so the final few milliseconds of the bot's audio play out instead
-// of being stranded until the next turn. The emitted chunk is marked so the
-// audio loop writes it without re-arming bot-speaking. It is safe against a
-// barge-in: an interruption clears the buffer before this can read it, or drains
-// the emitted chunk back out of the queue.
-func (bo *BaseOutput) flushTailChunk(ctx context.Context) {
-	bo.bufMu.Lock()
-	if len(bo.buffer) == 0 || bo.chunkSize == 0 {
-		bo.bufMu.Unlock()
+// handleBotSpeech updates the bot-speaking state from one chunk of outgoing
+// audio. The two kinds of audio end a turn differently: TTS output is ended by
+// its TTSStoppedFrame, while a speech stream carries its own silence and has to
+// be measured.
+func (bo *BaseOutput) handleBotSpeech(ctx context.Context, f frames.Frame) {
+	switch fr := f.(type) {
+	case *frames.TTSAudioRawFrame:
+		// A TTSStoppedFrame only ends the turn once TTS audio has arrived for it.
+		bo.botMu.Lock()
+		bo.ttsAudioReceived = true
+		bo.botMu.Unlock()
+		bo.botCurrentlySpeaking(ctx)
+	case *frames.SpeechOutputAudioRawFrame:
+		bo.maybeBotCurrentlySpeaking(ctx, fr)
+	}
+}
+
+// maybeBotCurrentlySpeaking tracks a speech stream, which carries silence
+// between utterances: audible audio holds the floor, and silence for longer than
+// botVADStop gives it up.
+func (bo *BaseOutput) maybeBotCurrentlySpeaking(ctx context.Context, f *frames.SpeechOutputAudioRawFrame) {
+	if !audio.IsSilence(f.Audio) {
+		bo.botCurrentlySpeaking(ctx)
 		return
 	}
-	tail := frames.NewOutputAudioRawFrame(padChunk(bo.buffer, bo.chunkSize), bo.sampleRate, bo.channels)
-	bo.buffer = nil
-	out := bo.audioOut
-	bo.bufMu.Unlock()
-
-	bo.flushFrame.Store(tail)
-	sendAudio(ctx, out, frames.Frame(tail))
+	bo.botMu.Lock()
+	last := bo.botSpeechLastAt
+	bo.botMu.Unlock()
+	if time.Since(last) > botVADStop {
+		bo.botStoppedSpeaking(ctx)
+	}
 }
 
-// markBotSpeaking emits BotStartedSpeakingFrame on the first audio chunk and
-// arms a debounce timer that emits BotStoppedSpeakingFrame once audio drains.
-// Both go upstream so the turn and idle controllers see them.
-func (bo *BaseOutput) markBotSpeaking(ctx context.Context) {
+// botCurrentlySpeaking marks the bot as holding the floor and broadcasts a
+// BotSpeakingFrame at most once per botSpeakingFramePeriod while it does.
+func (bo *BaseOutput) botCurrentlySpeaking(ctx context.Context) {
+	bo.botStartedSpeaking(ctx)
+
+	now := time.Now()
+	bo.botMu.Lock()
+	due := now.Sub(bo.botSpeakingFrameAt) >= botSpeakingFramePeriod
+	if due {
+		bo.botSpeakingFrameAt = now
+	}
+	bo.botSpeechLastAt = now
+	bo.botMu.Unlock()
+
+	if due {
+		_ = bo.Broadcast(ctx, func() frames.Frame { return frames.NewBotSpeakingFrame() })
+	}
+}
+
+// botStartedSpeaking broadcasts that the bot took the floor, once per run of
+// speech.
+func (bo *BaseOutput) botStartedSpeaking(ctx context.Context) {
+	bo.botMu.Lock()
+	if bo.botSpeaking {
+		bo.botMu.Unlock()
+		return
+	}
+	bo.botSpeaking = true
+	bo.botMu.Unlock()
+
+	_ = bo.Broadcast(ctx, func() frames.Frame { return frames.NewBotStartedSpeakingFrame() })
+}
+
+// botStoppedSpeaking broadcasts that the bot gave up the floor. Whatever is left
+// buffered is dropped rather than flushed: after an interruption, or once a turn
+// has ended, that audio is no longer wanted.
+func (bo *BaseOutput) botStoppedSpeaking(ctx context.Context) {
 	bo.botMu.Lock()
 	if !bo.botSpeaking {
-		bo.botSpeaking = true
-		_ = bo.PushFrame(ctx, frames.NewBotStartedSpeakingFrame(), processor.Upstream)
-	}
-	if bo.botStopCancel != nil {
-		bo.botStopCancel()
-	}
-	stopped := false
-	timer := time.AfterFunc(botStopDebounce, func() {
-		bo.botMu.Lock()
-		if stopped {
-			bo.botMu.Unlock()
-			return
-		}
-		bo.botSpeaking = false
-		bo.botStopCancel = nil
 		bo.botMu.Unlock()
-		// The turn has gone quiet: flush its trailing sub-chunk so the last of
-		// the bot's audio plays before we report it stopped speaking.
-		bo.flushTailChunk(ctx)
-		_ = bo.PushFrame(ctx, frames.NewBotStoppedSpeakingFrame(), processor.Upstream)
-	})
-	bo.botStopCancel = func() {
-		stopped = true
-		timer.Stop()
+		return
 	}
-	bo.botMu.Unlock()
-}
-
-// stopBotSpeaking ends bot-speaking immediately (on interruption or shutdown).
-func (bo *BaseOutput) stopBotSpeaking(ctx context.Context) {
-	bo.botMu.Lock()
-	if bo.botStopCancel != nil {
-		bo.botStopCancel()
-		bo.botStopCancel = nil
-	}
-	was := bo.botSpeaking
 	bo.botSpeaking = false
+	bo.ttsAudioReceived = false
 	bo.botMu.Unlock()
-	if was {
-		_ = bo.PushFrame(ctx, frames.NewBotStoppedSpeakingFrame(), processor.Upstream)
+
+	bo.bufMu.Lock()
+	bo.buffer = nil
+	bo.bufMu.Unlock()
+
+	_ = bo.Broadcast(ctx, func() frames.Frame { return frames.NewBotStoppedSpeakingFrame() })
+}
+
+// ttsStopped ends the bot's turn on a TTSStoppedFrame, but only when TTS audio
+// actually arrived for that turn.
+func (bo *BaseOutput) ttsStopped(ctx context.Context) {
+	bo.botMu.Lock()
+	received := bo.ttsAudioReceived
+	bo.botMu.Unlock()
+	if received {
+		bo.botStoppedSpeaking(ctx)
 	}
 }
 
-// audioLoop sends buffered chunks over the transport and forwards them
-// downstream.
+// audioLoop paces queued frames out to the transport. Receiving nothing at all
+// for botVADStopFallback is the fallback that ends the bot's turn when no
+// explicit stop reaches the output.
 func (bo *BaseOutput) audioLoop(ctx context.Context) {
 	defer bo.audioWG.Done()
+	idle := time.NewTimer(botVADStopFallback)
+	defer idle.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return
+		case <-idle.C:
+			bo.botStoppedSpeaking(ctx)
+			idle.Reset(botVADStopFallback)
 		case queued := <-bo.audioOut:
+			if !idle.Stop() {
+				select {
+				case <-idle.C:
+				default:
+				}
+			}
+			idle.Reset(botVADStopFallback)
+
 			if queued == drainMarker {
-				bo.bufMu.Lock()
-				w := bo.drainWait
-				bo.drainWait = nil
-				bo.bufMu.Unlock()
-				if w != nil {
-					close(w)
-				}
+				bo.signalDrained()
 				continue
 			}
-			// A word-aligned text frame carries no audio; it has waited behind the
-			// audio it belongs to, so forward it downstream now that that audio has
-			// played and move on.
-			if wf, ok := queued.(*frames.TTSTextFrame); ok {
-				_ = bo.PushFrame(ctx, wf, processor.Downstream)
-				continue
-			}
-			chunk, ok := queued.(*frames.OutputAudioRawFrame)
-			if !ok {
-				continue
-			}
-			// A trailing flush chunk is the tail of a turn that already ended; it
-			// plays but must not re-arm bot-speaking, or it would open a spurious
-			// speaking cycle on a floor the bot has given up.
-			trailing := bo.flushFrame.CompareAndSwap(chunk, nil)
-			audio := chunk.Audio
-			if bo.params.AudioOutMixer != nil {
-				if mixed, err := bo.params.AudioOutMixer.Mix(ctx, audio); err == nil {
-					audio = mixed
-				}
-			}
-			if err := bo.self.WriteAudio(ctx, audio); err != nil {
-				slog.Error("write audio to transport", "processor", bo.Name(), "err", err)
-				continue
-			}
-			if !trailing {
-				bo.markBotSpeaking(ctx)
-			}
-			_ = bo.PushFrame(ctx, chunk, processor.Downstream)
+			bo.handleQueuedFrame(ctx, queued)
 		}
+	}
+}
+
+// signalDrained releases a drainAudio waiter once the loop reaches its marker.
+func (bo *BaseOutput) signalDrained() {
+	bo.bufMu.Lock()
+	w := bo.drainWait
+	bo.drainWait = nil
+	bo.bufMu.Unlock()
+	if w != nil {
+		close(w)
+	}
+}
+
+// handleQueuedFrame plays one queued frame: it applies the frame's own effect,
+// writes whatever audio it carries to the transport, and forwards it downstream.
+// A frame whose audio could not be written is not forwarded, so nothing
+// downstream treats it as having been sent.
+func (bo *BaseOutput) handleQueuedFrame(ctx context.Context, f frames.Frame) {
+	pushDownstream := true
+
+	switch f.(type) {
+	case *frames.TTSAudioRawFrame, *frames.SpeechOutputAudioRawFrame, *frames.OutputAudioRawFrame:
+		bo.handleBotSpeech(ctx, f)
+
+		pcm, _, _ := outputAudio(f)
+		if bo.params.AudioOutMixer != nil {
+			if mixed, err := bo.params.AudioOutMixer.Mix(ctx, pcm); err == nil {
+				pcm = mixed
+			}
+		}
+		if err := bo.self.WriteAudio(ctx, pcm); err != nil {
+			slog.Error("write audio to transport", "processor", bo.Name(), "err", err)
+			pushDownstream = false
+		}
+	case *frames.TTSStoppedFrame:
+		bo.ttsStopped(ctx)
+	default:
+		// A frame that carries no audio has waited behind the audio it belongs
+		// to (a word-aligned text frame, say). Give the concrete transport a
+		// chance to act on it now that that audio has played.
+		if err := bo.self.WriteTransportFrame(ctx, f); err != nil {
+			slog.Error("write transport frame", "processor", bo.Name(), "frame", f.Name(), "err", err)
+		}
+	}
+
+	if pushDownstream {
+		_ = bo.PushFrame(ctx, f, processor.Downstream)
 	}
 }

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -98,6 +98,10 @@ type OutputDriver interface {
 	// SendMessage sends an application message to the client (for example over
 	// a data channel).
 	SendMessage(ctx context.Context, data []byte) error
+	// WriteTransportFrame handles a queued frame that carries no audio, once the
+	// audio ahead of it has been sent. A transport overrides it to act on frame
+	// types it carries itself; the default does nothing.
+	WriteTransportFrame(ctx context.Context, f frames.Frame) error
 }
 
 // audioFrameChanCap bounds the buffered audio channels between the media

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -265,7 +265,7 @@ func TestBaseOutputFlushesTailOnTurnEnd(t *testing.T) {
 	// One full chunk plus a half-chunk tail, marked with 0x01 so the padding is
 	// distinguishable from the audio.
 	audio := bytes.Repeat([]byte{0x01}, 1920+960)
-	task.QueueFrame(frames.NewOutputAudioRawFrame(audio, 48000, 1))
+	task.QueueFrame(frames.NewTTSAudioRawFrame(audio, 48000, 1))
 
 	// First write is the full chunk, unpadded.
 	first := recvWrite(t, o)
@@ -273,7 +273,9 @@ func TestBaseOutputFlushesTailOnTurnEnd(t *testing.T) {
 		t.Fatalf("first write = %d bytes, want 1920", len(first))
 	}
 
-	// The turn goes quiet; the debounce fires and flushes the padded tail.
+	// The turn ends: the TTS stop flushes the padded tail ahead of itself, so
+	// the last of the audio plays before the stop is handled.
+	task.QueueFrame(frames.NewTTSStoppedFrame())
 	tail := recvWrite(t, o)
 	if len(tail) != 1920 {
 		t.Fatalf("tail write = %d bytes, want 1920 (padded)", len(tail))
@@ -287,6 +289,93 @@ func TestBaseOutputFlushesTailOnTurnEnd(t *testing.T) {
 
 	task.StopWhenDone()
 	<-runDone
+}
+
+// TestBaseOutputShortTurnSignalsBotSpeaking covers a turn whose whole audio
+// never fills one chunk. It has to flush as the frame type it was buffered from,
+// so the bot-speaking bookkeeping (which dispatches on that type) still fires for
+// it instead of skipping the turn's start and stop events.
+func TestBaseOutputShortTurnSignalsBotSpeaking(t *testing.T) {
+	params := transport.DefaultParams()
+	params.AudioOutSampleRate = 48000 // 1920-byte chunks
+
+	var mu sync.Mutex
+	var down, up []frames.Frame
+	taskParams := pipeline.TaskParams{
+		OnReachedDownstream: func(f frames.Frame) {
+			mu.Lock()
+			down = append(down, f)
+			mu.Unlock()
+		},
+		OnReachedUpstream: func(f frames.Frame) {
+			mu.Lock()
+			up = append(up, f)
+			mu.Unlock()
+		},
+	}
+
+	o := newFakeOutput(params)
+	task := pipeline.NewTask(pipeline.New(o), taskParams)
+	runDone := make(chan error, 1)
+	go func() { runDone <- task.Run(context.Background()) }()
+
+	// Audio shorter than a single chunk is never queued for playback on its own;
+	// it only ever sits in the buffer until the turn ends.
+	partial := bytes.Repeat([]byte{0x03, 0x04}, 1920/4)
+	task.QueueFrame(frames.NewTTSAudioRawFrame(partial, 48000, 1))
+	task.QueueFrame(frames.NewTTSStoppedFrame())
+
+	got := recvWrite(t, o)
+	if len(got) != 1920 {
+		t.Fatalf("flushed write = %d bytes, want 1920 (padded)", len(got))
+	}
+	if !bytes.Equal(got[:len(partial)], partial) {
+		t.Errorf("flushed audio was not preserved")
+	}
+	if !bytes.Equal(got[len(partial):], make([]byte, 1920-len(partial))) {
+		t.Errorf("flush was not zero-padded with silence")
+	}
+
+	task.StopWhenDone()
+	<-runDone
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// The flushed chunk must stay a TTSAudioRawFrame rather than being flattened
+	// to a plain OutputAudioRawFrame, or the bookkeeping never recognizes it.
+	var sawTTSAudio bool
+	for _, f := range down {
+		if _, ok := f.(*frames.TTSAudioRawFrame); ok {
+			sawTTSAudio = true
+		}
+	}
+	if !sawTTSAudio {
+		t.Errorf("flushed chunk did not reach downstream as a TTSAudioRawFrame")
+	}
+
+	// Both speaking events must have fired even though no full chunk was queued,
+	// and both must be broadcast in each direction.
+	for _, dir := range []struct {
+		name string
+		got  []frames.Frame
+	}{{"downstream", down}, {"upstream", up}} {
+		var started, stopped bool
+		for _, f := range dir.got {
+			switch f.(type) {
+			case *frames.BotStartedSpeakingFrame:
+				started = true
+			case *frames.BotStoppedSpeakingFrame:
+				stopped = true
+			}
+		}
+		if !started {
+			t.Errorf("no BotStartedSpeakingFrame reached %s", dir.name)
+		}
+		if !stopped {
+			t.Errorf("no BotStoppedSpeakingFrame reached %s", dir.name)
+		}
+	}
 }
 
 // TestBaseOutputInterruptionDiscardsTail checks the other half of the contract:


### PR DESCRIPTION
The output transport rebuilt every chunk it sliced as a plain
OutputAudioRawFrame, discarding the type of the audio it came from. With
the type gone, nothing could tell TTS audio from any other output audio,
so bot speaking was tracked with a 250 ms debounce timer instead: the bot
counted as quiet whenever no chunk had arrived recently.

Rebuild each chunk as the frame type it was buffered from, and track
speaking from that type rather than from a timer. A turn now ends on its
TTSStoppedFrame, once TTS audio has actually arrived for it. A speech
stream, which carries its own silence between utterances, ends after 350
ms of it. An output that receives nothing at all falls back to 3 seconds.

A turn whose whole audio never filled a single chunk used to flush as a
plain OutputAudioRawFrame, and so signalled neither the start nor the
stop of speaking. It now flushes as its own type and signals both.

BotSpeakingFrame had a consumer in the turn processors but no producer
anywhere. It is now broadcast every 200 ms while the bot holds the floor.
The started and stopped frames go both downstream and upstream, paired by
BroadcastSiblingID, which is what the observers already expected.

Broadcast moves onto processor.Base so every processor can reach it, and
the identical copy on UserAggregator is dropped for it. Flushing the
trailing chunk on the TTS stop replaces the flushFrame pointer and the
debounce that drove it, and both are removed.

Also adds SpeechOutputAudioRawFrame, an IsSilence helper for measuring a
speech stream, and a WriteTransportFrame hook for frames that reach the
output behind the audio they belong to.
