### PR TITLE
fix(transport): act on the input's control frames

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -150,6 +150,12 @@ linters:
       - linters:
           - forbidigo
         path: cmd
+      # The filter and mixer control frames are deliberately parallel families:
+      # the same shape applied to a different subject. Collapsing them would
+      # hide that symmetry rather than remove real duplication.
+      - linters:
+          - dupl
+        path: frames/(filter|mixer)\.go
 formatters:
   enable:
     - gci              # Gci control golang package import order and make it always deterministic.

--- a/audio/audio.go
+++ b/audio/audio.go
@@ -6,17 +6,24 @@
 // (rnnoise, noise, mixer).
 package audio
 
-import "context"
+import (
+	"context"
+
+	"github.com/gojargo/jargo/frames"
+)
 
 // Filter transforms input audio before it enters the pipeline. Start is called
 // with the input sample rate when the transport starts, Filter is called for
 // each received chunk of 16-bit mono PCM, and Stop is called when the transport
 // stops. Filter may buffer internally and return fewer (or more) samples than it
 // was given; it returns an empty slice when it has nothing to emit yet.
+// ProcessFrame applies a runtime control frame, so the filter can be retuned or
+// switched off without being torn down.
 type Filter interface {
 	Start(ctx context.Context, sampleRate int) error
 	Stop(ctx context.Context) error
 	Filter(ctx context.Context, pcm []byte) ([]byte, error)
+	ProcessFrame(ctx context.Context, f frames.FilterControlFrame) error
 }
 
 // Mixer mixes auxiliary audio — for example background music or sound effects —

--- a/audio/chain.go
+++ b/audio/chain.go
@@ -1,6 +1,10 @@
 package audio
 
-import "context"
+import (
+	"context"
+
+	"github.com/gojargo/jargo/frames"
+)
 
 // Chain applies several Filters in sequence, composing multiple input-audio
 // stages — noise reduction, gating, conditioning — into one Filter that a
@@ -45,6 +49,18 @@ func (c *Chain) Filter(ctx context.Context, pcm []byte) ([]byte, error) {
 		}
 	}
 	return pcm, nil
+}
+
+// ProcessFrame applies a control frame to every filter, returning the last error
+// if any. Each filter decides for itself which controls it recognizes.
+func (c *Chain) ProcessFrame(ctx context.Context, f frames.FilterControlFrame) error {
+	var err error
+	for _, flt := range c.filters {
+		if e := flt.ProcessFrame(ctx, f); e != nil {
+			err = e
+		}
+	}
+	return err
 }
 
 // Compile-time interface check.

--- a/audio/chain_test.go
+++ b/audio/chain_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/gojargo/jargo/audio"
+	"github.com/gojargo/jargo/frames"
 )
 
 // The failures the fake filters report.
@@ -21,12 +22,19 @@ var (
 type fake struct {
 	tag byte
 
-	started   int
-	stopped   int
-	filtered  int
-	startErr  error
-	stopErr   error
-	filterErr error
+	started    int
+	stopped    int
+	filtered   int
+	controlled int
+	startErr   error
+	stopErr    error
+	filterErr  error
+	controlErr error
+}
+
+func (f *fake) ProcessFrame(context.Context, frames.FilterControlFrame) error {
+	f.controlled++
+	return f.controlErr
 }
 
 func (f *fake) Start(context.Context, int) error {

--- a/audio/noise/gate/gate.go
+++ b/audio/noise/gate/gate.go
@@ -8,8 +8,10 @@ import (
 	"context"
 	"encoding/binary"
 	"math"
+	"sync"
 
 	"github.com/gojargo/jargo/audio"
+	"github.com/gojargo/jargo/frames"
 )
 
 // defaultThresholdDB is the default gate level.
@@ -17,8 +19,10 @@ const defaultThresholdDB = -50.0
 
 // Gate silences audio quieter than its threshold.
 type Gate struct {
+	mu          sync.Mutex
 	thresholdDB float64
 	gate        float64
+	filtering   bool // false once a FilterEnableFrame switches gating off
 }
 
 // New builds a noise gate at thresholdDB dBFS; 0 uses -50 dBFS. Audio quieter
@@ -27,7 +31,18 @@ func New(thresholdDB float64) *Gate {
 	if thresholdDB == 0 {
 		thresholdDB = defaultThresholdDB
 	}
-	return &Gate{thresholdDB: thresholdDB}
+	return &Gate{thresholdDB: thresholdDB, filtering: true}
+}
+
+// ProcessFrame applies a runtime control frame. A FilterEnableFrame switches
+// gating on or off, leaving the threshold in place so it can be switched back.
+func (g *Gate) ProcessFrame(_ context.Context, f frames.FilterControlFrame) error {
+	if enable, ok := f.(*frames.FilterEnableFrame); ok {
+		g.mu.Lock()
+		g.filtering = enable.Enable
+		g.mu.Unlock()
+	}
+	return nil
 }
 
 // Start computes the normalized RMS gate from the threshold.
@@ -42,8 +57,12 @@ func (g *Gate) Stop(context.Context) error { return nil }
 // Filter silences pcm when its RMS energy is below the gate, else passes it
 // through unchanged.
 func (g *Gate) Filter(_ context.Context, pcm []byte) ([]byte, error) {
+	g.mu.Lock()
+	filtering := g.filtering
+	g.mu.Unlock()
+
 	n := len(pcm) / 2
-	if n == 0 {
+	if n == 0 || !filtering {
 		return pcm, nil
 	}
 	var sumSq float64

--- a/audio/noise/rnnoise/rnnoise.go
+++ b/audio/noise/rnnoise/rnnoise.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ebitengine/purego"
 	"github.com/gojargo/jargo/audio"
 	"github.com/gojargo/jargo/audio/resample"
+	"github.com/gojargo/jargo/frames"
 )
 
 // rnnoiseRate is the only sample rate RNNoise operates at.
@@ -93,13 +94,14 @@ func New() (audio.Filter, error) {
 	if err := load(); err != nil {
 		return nil, err
 	}
-	return &filter{}, nil
+	return &filter{filtering: true}, nil
 }
 
 type filter struct {
-	mu    sync.Mutex
-	st    uintptr // RNNoise DenoiseState*
-	frame int     // samples RNNoise consumes per call (480)
+	mu        sync.Mutex
+	st        uintptr // RNNoise DenoiseState*
+	frame     int     // samples RNNoise consumes per call (480)
+	filtering bool    // false once a FilterEnableFrame switches denoising off
 
 	up   *resample.Resampler // input rate -> 48 kHz
 	down *resample.Resampler // 48 kHz -> input rate
@@ -159,6 +161,18 @@ func (f *filter) Stop(context.Context) error {
 	return nil
 }
 
+// ProcessFrame applies a runtime control frame. A FilterEnableFrame switches
+// denoising on or off, leaving the RNNoise state in place so it can be switched
+// back without reloading.
+func (f *filter) ProcessFrame(_ context.Context, fr frames.FilterControlFrame) error {
+	if enable, ok := fr.(*frames.FilterEnableFrame); ok {
+		f.mu.Lock()
+		f.filtering = enable.Enable
+		f.mu.Unlock()
+	}
+	return nil
+}
+
 // Filter denoises pcm. It resamples to 48 kHz, processes every complete 480-sample
 // frame (buffering any remainder for the next call), resamples back to the input
 // rate, and returns the result — empty when no whole frame was available yet.
@@ -166,8 +180,8 @@ func (f *filter) Filter(_ context.Context, pcm []byte) ([]byte, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
-	if f.st == 0 {
-		return pcm, nil // not started: passthrough
+	if f.st == 0 || !f.filtering {
+		return pcm, nil // not started, or switched off: passthrough
 	}
 
 	wide := pcm

--- a/frames/filter.go
+++ b/frames/filter.go
@@ -1,0 +1,67 @@
+package frames
+
+import "fmt"
+
+// FilterControlFrame is the base for the frames that drive an input transport's
+// audio filter at runtime. Assert this interface to test whether a frame is a
+// filter control; embed FilterControlBase to define one. It is a control frame,
+// so a filter change is ordered against the audio around it.
+type FilterControlFrame interface {
+	ControlFrame
+	isFilterControlFrame()
+}
+
+// FilterControlBase is embedded by filter control frames.
+type FilterControlBase struct{ BaseControlFrame }
+
+func (*FilterControlBase) isFilterControlFrame() {}
+
+// FilterUpdateSettingsFrame updates the filter's settings, for example to change
+// how strongly it suppresses noise. The Settings are interpreted by the filter
+// implementation.
+type FilterUpdateSettingsFrame struct {
+	FilterControlBase
+	// Settings are the filter settings to apply.
+	Settings map[string]any
+}
+
+// NewFilterUpdateSettingsFrame builds a FilterUpdateSettingsFrame carrying
+// settings.
+func NewFilterUpdateSettingsFrame(settings map[string]any) *FilterUpdateSettingsFrame {
+	return &FilterUpdateSettingsFrame{
+		FilterControlBase: FilterControlBase{NewBaseControlFrame("FilterUpdateSettingsFrame")},
+		Settings:          settings,
+	}
+}
+
+// String implements fmt.Stringer.
+func (f *FilterUpdateSettingsFrame) String() string {
+	return fmt.Sprintf("%s(settings: %d)", f.Name(), len(f.Settings))
+}
+
+// FilterEnableFrame turns the filter on or off at runtime, passing incoming
+// audio through untouched without tearing the filter down.
+type FilterEnableFrame struct {
+	FilterControlBase
+	// Enable reports whether the filter should be enabled.
+	Enable bool
+}
+
+// NewFilterEnableFrame builds a FilterEnableFrame.
+func NewFilterEnableFrame(enable bool) *FilterEnableFrame {
+	return &FilterEnableFrame{
+		FilterControlBase: FilterControlBase{NewBaseControlFrame("FilterEnableFrame")},
+		Enable:            enable,
+	}
+}
+
+// String implements fmt.Stringer.
+func (f *FilterEnableFrame) String() string {
+	return fmt.Sprintf("%s(enable: %t)", f.Name(), f.Enable)
+}
+
+// Compile-time interface checks.
+var (
+	_ FilterControlFrame = (*FilterUpdateSettingsFrame)(nil)
+	_ FilterControlFrame = (*FilterEnableFrame)(nil)
+)

--- a/frames/transport.go
+++ b/frames/transport.go
@@ -24,6 +24,23 @@ func (f *InputTransportMessageFrame) String() string {
 	return fmt.Sprintf("%s(size: %d)", f.Name(), len(f.Message))
 }
 
+// InputTransportStartAudioStreamingFrame asks the input transport to start
+// streaming audio from its source. It is pushed downstream (by the RTVI
+// processor once the client is ready, say) so that starting the stream stays
+// frame-based rather than a direct call across processors. It is a control
+// frame.
+type InputTransportStartAudioStreamingFrame struct {
+	BaseControlFrame
+}
+
+// NewInputTransportStartAudioStreamingFrame builds an
+// InputTransportStartAudioStreamingFrame.
+func NewInputTransportStartAudioStreamingFrame() *InputTransportStartAudioStreamingFrame {
+	return &InputTransportStartAudioStreamingFrame{
+		BaseControlFrame: NewBaseControlFrame("InputTransportStartAudioStreamingFrame"),
+	}
+}
+
 // OutputTransportMessageFrame carries an application message to send to the
 // client over the transport — for example an RTVI message onto a WebRTC data
 // channel. Message is serialized by the output transport. It is a data frame, so

--- a/transport/input.go
+++ b/transport/input.go
@@ -22,6 +22,13 @@ type BaseInput struct {
 	sampleRate   int
 	filterActive bool
 
+	// lifeMu serializes the streaming lifecycle (start, pause, stop) so that the
+	// audio goroutine is only ever torn down and recreated by one caller at a
+	// time. Without it a pause racing a teardown would add to the wait group
+	// while the other was waiting on it. It is never held by PushAudioFrame, so
+	// a driver blocked delivering audio cannot deadlock a stop.
+	lifeMu sync.Mutex
+
 	mu          sync.Mutex
 	paused      bool
 	audioIn     chan *frames.InputAudioRawFrame
@@ -49,6 +56,10 @@ func (bi *BaseInput) StartReading(context.Context) error { return nil }
 
 // StopReading is the default no-op; a concrete transport overrides it.
 func (bi *BaseInput) StopReading(context.Context) error { return nil }
+
+// StartAudioStreaming is the default no-op; a concrete transport overrides it to
+// begin streaming audio from its source.
+func (bi *BaseInput) StartAudioStreaming(context.Context) error { return nil }
 
 // PushAudioFrame queues a received audio frame to be pushed downstream. The
 // driver calls it for each chunk of audio it reads from the transport.
@@ -85,15 +96,36 @@ func (bi *BaseInput) ProcessFrame(ctx context.Context, f frames.Frame, dir proce
 			return err
 		}
 		return bi.startStreaming(ctx, fr)
+	case *frames.CancelFrame:
+		bi.stopStreaming(ctx)
+		return bi.PushFrame(ctx, f, dir)
+	case *frames.InputAudioRawFrame:
+		// Audio pushed in from upstream (by the RTVI processor, say) goes down
+		// the same filtering path as audio read from the transport itself,
+		// rather than being forwarded on as a plain frame.
+		bi.PushAudioFrame(ctx, fr)
+		return nil
 	case *frames.EndFrame:
+		// Push EndFrame before stopping, because stopping waits for the audio
+		// goroutine to finish.
 		if err := bi.PushFrame(ctx, f, dir); err != nil {
 			return err
 		}
 		bi.stopStreaming(ctx)
 		return nil
-	case *frames.CancelFrame:
-		bi.stopStreaming(ctx)
-		return bi.PushFrame(ctx, f, dir)
+	case *frames.StopFrame:
+		if err := bi.PushFrame(ctx, f, dir); err != nil {
+			return err
+		}
+		bi.pause(ctx)
+		return nil
+	case *frames.InputTransportStartAudioStreamingFrame:
+		return bi.self.StartAudioStreaming(ctx)
+	case *frames.FilterUpdateSettingsFrame:
+		if bi.filter == nil {
+			return nil
+		}
+		return bi.filter.ProcessFrame(ctx, fr)
 	default:
 		return bi.PushFrame(ctx, f, dir)
 	}
@@ -106,6 +138,9 @@ func (bi *BaseInput) Cleanup(ctx context.Context) error {
 }
 
 func (bi *BaseInput) startStreaming(ctx context.Context, f *frames.StartFrame) error {
+	bi.lifeMu.Lock()
+	defer bi.lifeMu.Unlock()
+
 	bi.sampleRate = pick(bi.params.AudioInSampleRate, f.AudioInSampleRate)
 
 	// Start the input filter before the audio goroutine so audioLoop observes a
@@ -132,7 +167,40 @@ func (bi *BaseInput) startStreaming(ctx context.Context, f *frames.StartFrame) e
 	return bi.self.StartReading(audioCtx)
 }
 
+// pause stops received audio from reaching the pipeline while leaving the
+// transport reading, so the pipeline can be stopped and started again without
+// tearing the connection down. Canceling the audio goroutine and starting a
+// fresh one also drops whatever was already queued, so a restart does not replay
+// audio from before the stop.
+func (bi *BaseInput) pause(ctx context.Context) {
+	bi.lifeMu.Lock()
+	defer bi.lifeMu.Unlock()
+
+	bi.mu.Lock()
+	bi.paused = true
+	cancel := bi.audioCancel
+	bi.audioCancel = nil
+	bi.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+		bi.audioWG.Wait()
+	}
+
+	bi.mu.Lock()
+	bi.audioCtx, bi.audioCancel = context.WithCancel(ctx)
+	bi.audioIn = make(chan *frames.InputAudioRawFrame, audioFrameChanCap)
+	audioCtx := bi.audioCtx
+	bi.mu.Unlock()
+
+	bi.audioWG.Add(1)
+	go bi.audioLoop(audioCtx)
+}
+
 func (bi *BaseInput) stopStreaming(ctx context.Context) {
+	bi.lifeMu.Lock()
+	defer bi.lifeMu.Unlock()
+
 	_ = bi.self.StopReading(ctx)
 
 	bi.mu.Lock()

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -87,6 +87,11 @@ type InputDriver interface {
 	StartReading(ctx context.Context) error
 	// StopReading stops reading media from the transport.
 	StopReading(ctx context.Context) error
+	// StartAudioStreaming begins streaming audio from the transport's source,
+	// for a transport that does not start streaming as soon as it connects. It
+	// is driven by an InputTransportStartAudioStreamingFrame; the default does
+	// nothing.
+	StartAudioStreaming(ctx context.Context) error
 }
 
 // OutputDriver is implemented by a concrete output transport so the base can

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -20,12 +20,20 @@ import (
 type fakeInput struct {
 	*transport.BaseInput
 	frames int
+
+	// streaming records calls to StartAudioStreaming.
+	streaming chan struct{}
 }
 
 func newFakeInput(p transport.Params, n int) *fakeInput {
-	in := &fakeInput{frames: n}
+	in := &fakeInput{frames: n, streaming: make(chan struct{}, 4)}
 	in.BaseInput = transport.NewBaseInput("FakeInput", p, in)
 	return in
+}
+
+func (in *fakeInput) StartAudioStreaming(context.Context) error {
+	in.streaming <- struct{}{}
+	return nil
 }
 
 func (in *fakeInput) StartReading(ctx context.Context) error {
@@ -70,6 +78,154 @@ func TestBaseInputPushesAudioDownstream(t *testing.T) {
 	<-runDone
 }
 
+// TestBaseInputRoutesUpstreamAudioThroughFilter covers audio pushed into the
+// input from elsewhere in the pipeline (by the RTVI processor, say). It has to go
+// down the same filtering path as audio read from the transport itself, rather
+// than being forwarded on untouched as a plain frame.
+func TestBaseInputRoutesUpstreamAudioThroughFilter(t *testing.T) {
+	params := transport.DefaultParams()
+	params.AudioInSampleRate = 48000
+	filter := &fakeFilter{}
+	params.AudioInFilter = filter
+
+	got := make(chan []byte, 4)
+	taskParams := pipeline.TaskParams{
+		OnReachedDownstream: func(fr frames.Frame) {
+			if af, ok := fr.(*frames.InputAudioRawFrame); ok {
+				got <- af.Audio
+			}
+		},
+	}
+
+	// No frames of its own: the only audio is the one queued below.
+	in := newFakeInput(params, 0)
+	task := pipeline.NewTask(pipeline.New(in), taskParams)
+	runDone := make(chan error, 1)
+	go func() { runDone <- task.Run(context.Background()) }()
+
+	task.QueueFrame(frames.NewInputAudioRawFrame([]byte{1, 2, 3, 4}, 48000, 1))
+
+	select {
+	case audio := <-got:
+		// fakeFilter increments every byte, so filtered audio proves the frame
+		// went through the audio path instead of straight downstream.
+		if !bytes.Equal(audio, []byte{2, 3, 4, 5}) {
+			t.Errorf("audio = %v, want %v (upstream audio bypassed the filter)", audio, []byte{2, 3, 4, 5})
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("upstream audio never reached downstream")
+	}
+
+	task.StopWhenDone()
+	<-runDone
+}
+
+// TestBaseInputStartAudioStreamingFrame checks that the frame reaches the
+// transport's streaming hook, so starting the stream stays frame-based rather
+// than a direct call across processors.
+func TestBaseInputStartAudioStreamingFrame(t *testing.T) {
+	params := transport.DefaultParams()
+	params.AudioInSampleRate = 48000
+
+	in := newFakeInput(params, 0)
+	task := pipeline.NewTask(pipeline.New(in), pipeline.TaskParams{})
+	runDone := make(chan error, 1)
+	go func() { runDone <- task.Run(context.Background()) }()
+
+	task.QueueFrame(frames.NewInputTransportStartAudioStreamingFrame())
+
+	select {
+	case <-in.streaming:
+	case <-time.After(3 * time.Second):
+		t.Fatal("InputTransportStartAudioStreamingFrame did not reach StartAudioStreaming")
+	}
+
+	task.StopWhenDone()
+	<-runDone
+}
+
+// TestBaseInputStopFramePausesAudio covers the pause: a StopFrame stops the
+// pipeline while leaving its processors running, so the transport keeps reading
+// but what it receives must no longer reach the pipeline. Upstream has no test
+// for this; it covers the ported behavior.
+func TestBaseInputStopFramePausesAudio(t *testing.T) {
+	params := transport.DefaultParams()
+	params.AudioInSampleRate = 48000
+
+	// The filter counter is what makes this observable: a StopFrame ends the
+	// task, so nothing reaches the end of the pipeline afterwards either way,
+	// but the filter only runs for audio the input actually accepted.
+	filter := &fakeFilter{}
+	params.AudioInFilter = filter
+
+	in := newFakeInput(params, 0)
+	task := pipeline.NewTask(pipeline.New(in), pipeline.TaskParams{})
+	runDone := make(chan error, 1)
+	go func() { runDone <- task.Run(context.Background()) }()
+
+	ctx := context.Background()
+	audio := func() *frames.InputAudioRawFrame {
+		return frames.NewInputAudioRawFrame(make([]byte, 320), 48000, 1)
+	}
+
+	// Settle first, so the StartFrame has been processed and the input is
+	// actually accepting audio.
+	if err := task.Flush(ctx); err != nil {
+		t.Fatalf("flush after start: %v", err)
+	}
+
+	in.PushAudioFrame(ctx, audio())
+	deadline := time.Now().Add(3 * time.Second)
+	for filter.filtered.Load() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("audio was not filtered before the stop")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// Stopping the pipeline pauses the input: the transport keeps reading, but
+	// what it receives no longer enters the pipeline. The StopFrame is pushed on
+	// before the pause runs, so give the pause a moment to land.
+	task.QueueFrame(frames.NewStopFrame())
+	<-runDone
+	time.Sleep(50 * time.Millisecond)
+
+	before := filter.filtered.Load()
+	in.PushAudioFrame(ctx, audio())
+	time.Sleep(300 * time.Millisecond)
+	if got := filter.filtered.Load(); got != before {
+		t.Errorf("filter ran %d more times: audio was not dropped while paused", got-before)
+	}
+}
+
+// TestBaseInputRoutesFilterSettings checks that a filter settings frame reaches
+// the filter, so it can be retuned at runtime without being torn down.
+func TestBaseInputRoutesFilterSettings(t *testing.T) {
+	params := transport.DefaultParams()
+	params.AudioInSampleRate = 48000
+	filter := &fakeFilter{controls: make(chan *frames.FilterUpdateSettingsFrame, 4)}
+	params.AudioInFilter = filter
+
+	in := newFakeInput(params, 0)
+	task := pipeline.NewTask(pipeline.New(in), pipeline.TaskParams{})
+	runDone := make(chan error, 1)
+	go func() { runDone <- task.Run(context.Background()) }()
+
+	task.QueueFrame(frames.NewFilterUpdateSettingsFrame(map[string]any{"level": 3}))
+
+	select {
+	case settings := <-filter.controls:
+		if settings.Settings["level"] != 3 {
+			t.Errorf("settings = %v, want level 3", settings.Settings)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("FilterUpdateSettingsFrame never reached the filter")
+	}
+
+	task.StopWhenDone()
+	<-runDone
+}
+
 // fakeOutput is an output transport that records the audio chunks it is asked
 // to send.
 type fakeOutput struct {
@@ -97,6 +253,16 @@ type fakeFilter struct {
 	stopped  atomic.Int32
 	rate     atomic.Int32
 	filtered atomic.Int32
+
+	// controls records the settings frames routed to the filter at runtime.
+	controls chan *frames.FilterUpdateSettingsFrame
+}
+
+func (f *fakeFilter) ProcessFrame(_ context.Context, fr frames.FilterControlFrame) error {
+	if settings, ok := fr.(*frames.FilterUpdateSettingsFrame); ok && f.controls != nil {
+		f.controls <- settings
+	}
+	return nil
 }
 
 func (f *fakeFilter) Start(_ context.Context, sampleRate int) error {


### PR DESCRIPTION
The base input forwarded everything it did not recognize straight
downstream, so four control paths did nothing at all.

Audio pushed in from elsewhere in the pipeline, by the RTVI processor for
instance, was forwarded on untouched instead of going down the same path
as audio read from the transport, which meant it skipped the input filter
entirely.

A StopFrame stops the pipeline while leaving its processors running,
ready for another run, but the input never paused: it kept feeding the
pipeline audio the transport was still receiving. The paused field was
read on every received chunk and never once set, so it could not have
paused anything. Pausing now also drops what was already queued, so a
restart does not replay audio from before the stop.

A filter had no way to be reconfigured while running, since the Filter
interface had no control entry point at all. It gains one, along with the
settings and enable frames that drive it, mirroring the mixer's existing
control frames. Only the settings frame is routed by the transport, which
is where the enable frame is routed from today as well: filters recognize
it, nothing sends it to them.

An input that does not start streaming as soon as it connects had no way
to be told to start. It gains a hook, driven by a frame so that starting
stays frame-based rather than a direct call across processors.

Serializing the lifecycle is what makes the pause safe: pausing tears the
audio goroutine down and starts a fresh one, and a teardown running at
the same time would add to the wait group while the other waited on it.
Start, pause and stop now take a lifecycle lock, which delivery never
holds, so a driver blocked handing over audio cannot deadlock a stop.
