### PR TITLE
fix(mixer): let the mixer read its own control frames

### DIFF
--- a/audio/audio.go
+++ b/audio/audio.go
@@ -1,9 +1,9 @@
 // Package audio defines the interfaces for pluggable audio processing a
 // transport applies to the media it sends and receives. A Filter transforms
-// incoming audio — for example noise reduction — before it enters the pipeline;
-// a Mixer blends auxiliary audio — for example background music — into the
-// outgoing audio. Concrete implementations live in the audio subpackages
-// (rnnoise, noise, mixer).
+// incoming audio (noise reduction, say) before it enters the pipeline; a Mixer
+// blends auxiliary audio (background music, say) into the outgoing audio.
+// Concrete implementations live in the audio subpackages (rnnoise, noise,
+// mixer).
 package audio
 
 import (
@@ -26,15 +26,14 @@ type Filter interface {
 	ProcessFrame(ctx context.Context, f frames.FilterControlFrame) error
 }
 
-// Mixer mixes auxiliary audio — for example background music or sound effects —
-// into a transport's outgoing audio. Start is called with the output sample rate
+// Mixer mixes auxiliary audio (background music or sound effects, say) into a
+// transport's outgoing audio. Start is called with the output sample rate
 // when the transport starts; Mix blends the mixer's current audio into an
-// outgoing chunk of bot audio and returns the result; Control applies a runtime
-// settings update from a MixerControlFrame; Stop is called when the transport
-// stops.
+// outgoing chunk of bot audio and returns the result; ProcessFrame applies a
+// runtime control frame; Stop is called when the transport stops.
 type Mixer interface {
 	Start(ctx context.Context, sampleRate int) error
 	Stop(ctx context.Context) error
 	Mix(ctx context.Context, pcm []byte) ([]byte, error)
-	Control(ctx context.Context, settings map[string]any) error
+	ProcessFrame(ctx context.Context, f frames.MixerControlFrame) error
 }

--- a/audio/mixer/mixer.go
+++ b/audio/mixer/mixer.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/gojargo/jargo/audio"
+	"github.com/gojargo/jargo/frames"
 )
 
 // defaultVolume scales the background when none is configured.
@@ -82,9 +83,25 @@ func (m *Loop) Mix(_ context.Context, pcm []byte) ([]byte, error) {
 	return out, nil
 }
 
-// Control applies a runtime settings update: "volume" (float64), "enabled"
-// (bool) and "background" ([]byte, 16-bit mono PCM).
-func (m *Loop) Control(_ context.Context, settings map[string]any) error {
+// ProcessFrame applies a runtime control frame. A MixerUpdateSettingsFrame
+// carries "volume" (float64), "enabled" (bool) and "background" ([]byte, 16-bit
+// mono PCM); a MixerEnableFrame turns mixing on or off without disturbing the
+// settings.
+func (m *Loop) ProcessFrame(_ context.Context, f frames.MixerControlFrame) error {
+	switch fr := f.(type) {
+	case *frames.MixerUpdateSettingsFrame:
+		m.updateSettings(fr.Settings)
+	case *frames.MixerEnableFrame:
+		m.mu.Lock()
+		m.enabled = fr.Enable
+		m.mu.Unlock()
+	}
+	return nil
+}
+
+// updateSettings applies the settings a MixerUpdateSettingsFrame carries,
+// leaving any it does not name untouched.
+func (m *Loop) updateSettings(settings map[string]any) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if v, ok := settings["volume"].(float64); ok {
@@ -97,7 +114,6 @@ func (m *Loop) Control(_ context.Context, settings map[string]any) error {
 		m.background = bg
 		m.pos = 0
 	}
-	return nil
 }
 
 // Compile-time interface check.

--- a/audio/mixer/mixer_test.go
+++ b/audio/mixer/mixer_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/gojargo/jargo/audio/mixer"
+	"github.com/gojargo/jargo/frames"
 )
 
 // pcm encodes samples as 16-bit little-endian mono PCM, the format the mixer
@@ -161,32 +162,54 @@ func TestLoopPositionPersistsAcrossChunks(t *testing.T) {
 	}
 }
 
-// TestControl covers the runtime updates a MixerControlFrame carries.
-func TestControl(t *testing.T) {
-	t.Run("enable and disable", func(t *testing.T) {
+// TestProcessFrame covers the runtime updates a MixerControlFrame carries.
+func TestProcessFrame(t *testing.T) {
+	t.Run("enable frame enables and disables", func(t *testing.T) {
 		m := mixer.NewLoop(mixer.LoopConfig{Background: pcm(1000), Volume: 1})
 
 		if got := mix(t, m, pcm(0)); !equal(got, 0) {
 			t.Fatalf("samples = %v, want silence while disabled", got)
 		}
-		if err := m.Control(t.Context(), map[string]any{"enabled": true}); err != nil {
-			t.Fatalf("Control: %v", err)
+		if err := m.ProcessFrame(t.Context(), frames.NewMixerEnableFrame(true)); err != nil {
+			t.Fatalf("ProcessFrame: %v", err)
 		}
 		if got := mix(t, m, pcm(0)); !equal(got, 1000) {
 			t.Errorf("samples = %v, want the background once enabled", got)
 		}
-		if err := m.Control(t.Context(), map[string]any{"enabled": false}); err != nil {
-			t.Fatalf("Control: %v", err)
+		if err := m.ProcessFrame(t.Context(), frames.NewMixerEnableFrame(false)); err != nil {
+			t.Fatalf("ProcessFrame: %v", err)
 		}
 		if got := mix(t, m, pcm(0)); !equal(got, 0) {
 			t.Errorf("samples = %v, want silence once disabled again", got)
 		}
 	})
 
+	t.Run("enable frame leaves the other settings alone", func(t *testing.T) {
+		m := mixer.NewLoop(mixer.LoopConfig{Background: pcm(1000), Volume: 0.5, Enabled: true})
+		if err := m.ProcessFrame(t.Context(), frames.NewMixerEnableFrame(true)); err != nil {
+			t.Fatalf("ProcessFrame: %v", err)
+		}
+		if got := mix(t, m, pcm(0)); !equal(got, 500) {
+			t.Errorf("samples = %v, want the configured volume kept", got)
+		}
+	})
+
+	t.Run("settings frame carries enabled too", func(t *testing.T) {
+		m := mixer.NewLoop(mixer.LoopConfig{Background: pcm(1000), Volume: 1})
+		settings := frames.NewMixerUpdateSettingsFrame(map[string]any{"enabled": true})
+		if err := m.ProcessFrame(t.Context(), settings); err != nil {
+			t.Fatalf("ProcessFrame: %v", err)
+		}
+		if got := mix(t, m, pcm(0)); !equal(got, 1000) {
+			t.Errorf("samples = %v, want the background once enabled", got)
+		}
+	})
+
 	t.Run("volume", func(t *testing.T) {
 		m := mixer.NewLoop(mixer.LoopConfig{Background: pcm(1000), Volume: 1, Enabled: true})
-		if err := m.Control(t.Context(), map[string]any{"volume": 0.5}); err != nil {
-			t.Fatalf("Control: %v", err)
+		settings := frames.NewMixerUpdateSettingsFrame(map[string]any{"volume": 0.5})
+		if err := m.ProcessFrame(t.Context(), settings); err != nil {
+			t.Fatalf("ProcessFrame: %v", err)
 		}
 		if got := mix(t, m, pcm(0)); !equal(got, 500) {
 			t.Errorf("samples = %v, want the new volume applied", got)
@@ -197,8 +220,9 @@ func TestControl(t *testing.T) {
 		m := mixer.NewLoop(mixer.LoopConfig{Background: pcm(10, 20), Volume: 1, Enabled: true})
 		mix(t, m, pcm(0)) // advance into the current track
 
-		if err := m.Control(t.Context(), map[string]any{"background": pcm(70, 80)}); err != nil {
-			t.Fatalf("Control: %v", err)
+		settings := frames.NewMixerUpdateSettingsFrame(map[string]any{"background": pcm(70, 80)})
+		if err := m.ProcessFrame(t.Context(), settings); err != nil {
+			t.Fatalf("ProcessFrame: %v", err)
 		}
 		// A new track must start at its beginning, not at the old offset.
 		if got := mix(t, m, pcm(0, 0)); !equal(got, 70, 80) {
@@ -208,13 +232,13 @@ func TestControl(t *testing.T) {
 
 	t.Run("unknown and mistyped settings are ignored", func(t *testing.T) {
 		m := mixer.NewLoop(mixer.LoopConfig{Background: pcm(1000), Volume: 1, Enabled: true})
-		err := m.Control(t.Context(), map[string]any{
+		settings := frames.NewMixerUpdateSettingsFrame(map[string]any{
 			"volume":  "loud", // wrong type
 			"enabled": 1,      // wrong type
 			"unknown": true,
 		})
-		if err != nil {
-			t.Fatalf("Control: %v", err)
+		if err := m.ProcessFrame(t.Context(), settings); err != nil {
+			t.Fatalf("ProcessFrame: %v", err)
 		}
 		if got := mix(t, m, pcm(0)); !equal(got, 1000) {
 			t.Errorf("samples = %v, want the settings unchanged", got)

--- a/transport/output.go
+++ b/transport/output.go
@@ -246,23 +246,15 @@ func (bo *BaseOutput) drainAudio(ctx context.Context) {
 	}
 }
 
-// handleMixerControl applies a mixer control frame to the output mixer and
-// forwards it. The mixer's settings map is its whole control surface, so
-// enabling is expressed as the "enabled" setting.
+// handleMixerControl hands a mixer control frame to the output mixer and
+// forwards it on. The mixer reads the frame itself, so a control the mixer
+// understands does not have to be translated on the way through, and a new one
+// needs no change here.
 func (bo *BaseOutput) handleMixerControl(
 	ctx context.Context, f frames.MixerControlFrame, dir processor.Direction,
 ) error {
 	if bo.params.AudioOutMixer != nil {
-		var settings map[string]any
-		switch fr := f.(type) {
-		case *frames.MixerUpdateSettingsFrame:
-			settings = fr.Settings
-		case *frames.MixerEnableFrame:
-			settings = map[string]any{"enabled": fr.Enable}
-		}
-		if settings != nil {
-			_ = bo.params.AudioOutMixer.Control(ctx, settings)
-		}
+		_ = bo.params.AudioOutMixer.ProcessFrame(ctx, f)
 	}
 	return bo.PushFrame(ctx, f, dir)
 }


### PR DESCRIPTION
The output transport translated every mixer control frame into a settings
map before handing it over, so that map was the mixer's whole control
surface: enabling was expressed as an "enabled" key rather than as the
enable frame that carries it. Any new control would have needed a
translation in the transport as well as handling in the mixer, and a
control the transport did not recognize never reached the mixer at all.

Hand the frame over instead. The mixer dispatches on it directly, the
same way an input filter now does with its own controls.

Loop keeps the settings keys it already had, and gains the enable frame
as a separate path that turns mixing on or off without disturbing them.
