### PR TITLE
fix(wsserver): send call audio at the rate it plays

### DIFF
--- a/transport/output.go
+++ b/transport/output.go
@@ -93,6 +93,10 @@ func NewBaseOutput(name string, params Params, self OutputDriver) *BaseOutput {
 // SampleRate is the output sample rate in Hz, set when the transport starts.
 func (bo *BaseOutput) SampleRate() int { return bo.sampleRate }
 
+// ChunkSize is the size in bytes of the audio chunks the output writes, set when
+// the transport starts.
+func (bo *BaseOutput) ChunkSize() int { return bo.chunkSize }
+
 // Params returns the transport parameters.
 func (bo *BaseOutput) Params() Params { return bo.params }
 

--- a/transport/wsserver/wsserver.go
+++ b/transport/wsserver/wsserver.go
@@ -13,6 +13,7 @@ import (
 	"log/slog"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/coder/websocket"
 	"github.com/gojargo/jargo/frames"
@@ -232,6 +233,27 @@ type outputTransport struct {
 	*transport.BaseOutput
 	sess *Session
 	ser  Serializer
+
+	// WriteAudio is called as soon as audio is produced, by the TTS say, and
+	// this is only a network connection, so audio would otherwise go out far
+	// faster than it plays. Blocking for as long as a chunk takes to play
+	// emulates an audio device, keeping the provider's playout buffer shallow so
+	// a barge-in cuts audio that has not been handed over yet.
+	paceMu sync.Mutex
+	// sendInterval is how long one chunk takes to play, set on the StartFrame.
+	sendInterval time.Duration
+	// nextSend is when the next chunk is due. The zero time means send now and
+	// start the clock from there.
+	nextSend time.Time
+}
+
+// chunkDuration is how long one chunk of 16-bit PCM takes to play.
+func chunkDuration(chunkSize, sampleRate, numChannels int) time.Duration {
+	bytesPerSec := sampleRate * numChannels * 2
+	if chunkSize <= 0 || bytesPerSec <= 0 {
+		return 0
+	}
+	return time.Duration(chunkSize) * time.Second / time.Duration(bytesPerSec)
 }
 
 func newOutput(sess *Session, ser Serializer, params transport.Params) *outputTransport {
@@ -250,7 +272,47 @@ func (out *outputTransport) WriteAudio(ctx context.Context, pcm []byte) error {
 	if msg == nil {
 		return nil
 	}
-	return out.sess.write(ctx, msg)
+	if err := out.sess.write(ctx, msg); err != nil {
+		return err
+	}
+	out.writeAudioSleep(ctx)
+	return nil
+}
+
+// writeAudioSleep blocks until the next chunk is due, so audio leaves at the
+// rate it plays rather than the rate it is produced.
+func (out *outputTransport) writeAudioSleep(ctx context.Context) {
+	out.paceMu.Lock()
+	interval, next := out.sendInterval, out.nextSend
+	out.paceMu.Unlock()
+	if interval <= 0 {
+		return
+	}
+
+	if wait := time.Until(next); wait > 0 {
+		timer := time.NewTimer(wait)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+		}
+
+		out.paceMu.Lock()
+		// An interruption may have reset the clock while this waited. Leave the
+		// reset alone if so, or the next chunk would wait on a stale schedule
+		// instead of going out at once.
+		if out.nextSend.Equal(next) {
+			out.nextSend = next.Add(interval)
+		}
+		out.paceMu.Unlock()
+		return
+	}
+
+	// At or behind schedule: send now and time the next chunk from here.
+	out.paceMu.Lock()
+	out.nextSend = time.Now().Add(interval)
+	out.paceMu.Unlock()
 }
 
 // SendMessage sends an already-encoded application message.
@@ -269,11 +331,31 @@ func (out *outputTransport) ProcessFrame(ctx context.Context, f frames.Frame, di
 		return nil
 	}
 	switch f.(type) {
-	case *frames.InterruptionFrame, *frames.EndFrame, *frames.CancelFrame:
-		msg, err := out.ser.Serialize(f)
-		if err == nil && msg != nil {
-			_ = out.sess.write(ctx, msg)
-		}
+	case *frames.StartFrame:
+		// The base has sized the chunks by now, so the playout clock can be
+		// derived from them.
+		out.paceMu.Lock()
+		out.sendInterval = chunkDuration(out.ChunkSize(), out.SampleRate(), channels(out.Params().AudioOutChannels))
+		out.nextSend = time.Time{}
+		out.paceMu.Unlock()
+	case *frames.InterruptionFrame:
+		out.sendControl(ctx, f)
+		// Restart the playout clock on a barge-in so the next turn's audio goes
+		// out at once rather than waiting on the cut-off turn's schedule.
+		out.paceMu.Lock()
+		out.nextSend = time.Time{}
+		out.paceMu.Unlock()
+	case *frames.EndFrame, *frames.CancelFrame:
+		out.sendControl(ctx, f)
 	}
 	return nil
+}
+
+// sendControl serializes a control frame to the provider's own message, if the
+// serializer has one for it, and sends it.
+func (out *outputTransport) sendControl(ctx context.Context, f frames.Frame) {
+	msg, err := out.ser.Serialize(f)
+	if err == nil && msg != nil {
+		_ = out.sess.write(ctx, msg)
+	}
 }

--- a/transport/wsserver/wsserver_test.go
+++ b/transport/wsserver/wsserver_test.go
@@ -477,6 +477,38 @@ func TestOutboundAudioDropped(t *testing.T) {
 	}
 }
 
+// TestOutboundAudioIsPaced checks audio leaves at the rate it plays rather than
+// the rate it is produced. Without pacing a whole utterance lands in the
+// provider's playout buffer at once, and a barge-in then cuts only audio that
+// has not been handed over yet, so the caller keeps hearing the bot. Upstream
+// has no test for this.
+func TestOutboundAudioIsPaced(t *testing.T) {
+	p := params()
+	p.AudioOut10msChunks = 10 // 100 ms chunks, long enough to time reliably
+	c := dial(t, &testSerializer{}, p)
+	defer c.shutdown(t)
+
+	// One 100 ms chunk at 8 kHz mono 16-bit is 1600 bytes. Queue four at once,
+	// so pacing is the only thing that can spread them out.
+	const chunk = 1600
+	c.task.QueueFrame(frames.NewTTSAudioRawFrame(make([]byte, chunk*4), 8000, 1))
+
+	start := time.Now()
+	for i := range 4 {
+		if got := c.expect(t); got.Kind != "audio" {
+			t.Fatalf("message %d kind = %q, want audio", i, got.Kind)
+		}
+	}
+	elapsed := time.Since(start)
+
+	// Each chunk is sent and only then does the clock wait, so the first two go
+	// out back to back and every later one waits a full interval. Four chunks
+	// therefore take about two intervals to all arrive.
+	if want := 150 * time.Millisecond; elapsed < want {
+		t.Errorf("four 100 ms chunks arrived in %v, want at least %v: output is not paced", elapsed, want)
+	}
+}
+
 // TestInterruptionSendsClear covers barge-in: the provider must be told to
 // discard the audio it has already buffered, or the bot keeps talking over the
 // caller.


### PR DESCRIPTION
WriteAudio is called as soon as audio is produced, by the TTS say, and a
WebSocket is only a network connection, so a whole utterance was handed
to the provider almost at once. Two things follow from that. The
provider's playout buffer holds audio the caller has not heard yet, and a
barge-in only clears what has not been handed over, so the caller keeps
hearing the bot after interrupting it.

Block for as long as a chunk takes to play, emulating an audio device.
The chunk duration is derived from the chunk size the base output settled
on, so it tracks the configured chunk count rather than being a constant
here. Sending happens first and the clock waits after, so the first two
chunks still go out back to back and only later ones wait.

An interruption restarts the clock, so the next turn's audio goes out at
once instead of waiting on the schedule of the turn that was cut off.

The clock is read on the audio goroutine and reset on the processor
goroutine, so it is guarded. A reset landing while a write is waiting is
kept rather than overwritten, or the next chunk would wait on a schedule
the barge-in was meant to discard.

This affects every provider the WebSocket transport serves, since they
all share it.

The two WebRTC transports already paced themselves and are unchanged.
