### PR TITLE
fix(transport): keep auxiliary audio playing between turns

### DIFF
--- a/transport/localaudio/localaudio.go
+++ b/transport/localaudio/localaudio.go
@@ -15,6 +15,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/gojargo/jargo/frames"
 	"github.com/gojargo/jargo/processor"
@@ -223,16 +224,42 @@ func (out *outputTransport) openStream() error {
 	return nil
 }
 
-// WriteAudio queues one chunk of S16 PCM for playback. PulseAudio pulls it back
-// out through fill at the device's pace.
-func (out *outputTransport) WriteAudio(_ context.Context, pcm []byte) error {
+// drainPoll is how often WriteAudio rechecks the playback backlog while waiting
+// for the device to take what it queued.
+const drainPoll = 2 * time.Millisecond
+
+// WriteAudio queues one chunk of S16 PCM for playback and waits until the device
+// has taken all but the last chunk of it, so audio is written at the rate it
+// plays rather than the rate it is produced. Without that wait a whole turn is
+// queued at once, and a barge-in can only drop what the device has not already
+// consumed.
+//
+// PulseAudio pulls through fill rather than accepting a blocking write, so the
+// wait is on the backlog draining instead of on a write returning. It ends early
+// if the stream closes or the pipeline stops, so a stop is never held up.
+func (out *outputTransport) WriteAudio(ctx context.Context, pcm []byte) error {
 	out.mu.Lock()
 	out.buf = append(out.buf, pcm...)
 	if limit := maxBufferBytes(out.SampleRate()); len(out.buf) > limit {
 		out.buf = out.buf[len(out.buf)-limit:]
 	}
 	out.mu.Unlock()
-	return nil
+
+	// One chunk of slack, so the device always has something to pull and never
+	// underruns between callbacks.
+	for {
+		out.mu.Lock()
+		queued, open := len(out.buf), out.stream != nil
+		out.mu.Unlock()
+		if !open || queued <= len(pcm) {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(drainPoll):
+		}
+	}
 }
 
 // SendMessage is a no-op: the local transport has no client data channel.

--- a/transport/output.go
+++ b/transport/output.go
@@ -315,6 +315,19 @@ func outputAudio(f frames.Frame) (pcm []byte, sampleRate, channels int) {
 	return nil, 0, 0
 }
 
+// setOutputAudio replaces the PCM a bot audio frame carries, leaving everything
+// else about the frame alone.
+func setOutputAudio(f frames.Frame, pcm []byte) {
+	switch fr := f.(type) {
+	case *frames.TTSAudioRawFrame:
+		fr.Audio = pcm
+	case *frames.SpeechOutputAudioRawFrame:
+		fr.Audio = pcm
+	case *frames.OutputAudioRawFrame:
+		fr.Audio = pcm
+	}
+}
+
 // chunkBuilder returns the constructor for f's own frame type, so a chunk sliced
 // out of f is rebuilt as the same kind of frame rather than flattened to a plain
 // OutputAudioRawFrame.
@@ -578,11 +591,62 @@ func (bo *BaseOutput) ttsStopped(ctx context.Context) {
 	}
 }
 
-// audioLoop paces queued frames out to the transport. Receiving nothing at all
-// for botVADStopFallback is the fallback that ends the bot's turn when no
-// explicit stop reaches the output.
+// audioLoop paces queued frames out to the transport. A mixer changes how the
+// gaps between frames are handled, so the two cases are separate loops.
 func (bo *BaseOutput) audioLoop(ctx context.Context) {
 	defer bo.audioWG.Done()
+	if bo.params.AudioOutMixer != nil {
+		bo.audioLoopWithMixer(ctx)
+		return
+	}
+	bo.audioLoopWithoutMixer(ctx)
+}
+
+// audioLoopWithMixer blends the mixer into queued audio and fills the gaps
+// between frames with the mixer's own audio. Without that filling, auxiliary
+// audio would only be audible while the bot speaks and would cut out between
+// turns. The generated audio is plain output audio, so it paces the loop through
+// the transport without ever marking the bot as speaking.
+func (bo *BaseOutput) audioLoopWithMixer(ctx context.Context) {
+	mixer := bo.params.AudioOutMixer
+	silence := make([]byte, bo.chunkSize)
+	var lastAudioAt time.Time
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case queued := <-bo.audioOut:
+			if queued == drainMarker {
+				bo.signalDrained()
+				continue
+			}
+			if pcm, _, _ := outputAudio(queued); pcm != nil {
+				if mixed, err := mixer.Mix(ctx, pcm); err == nil {
+					setOutputAudio(queued, mixed)
+				}
+				lastAudioAt = time.Now()
+			}
+			bo.handleQueuedFrame(ctx, queued)
+		default:
+			// Nothing is queued. The bot has stopped speaking once it has been
+			// quiet for long enough, and the mixer plays on regardless.
+			if time.Since(lastAudioAt) > botVADStopFallback {
+				bo.botStoppedSpeaking(ctx)
+			}
+			mixed, err := mixer.Mix(ctx, silence)
+			if err != nil {
+				mixed = silence
+			}
+			bo.handleQueuedFrame(ctx, frames.NewOutputAudioRawFrame(mixed, bo.sampleRate, bo.channels))
+		}
+	}
+}
+
+// audioLoopWithoutMixer paces queued frames out to the transport. Receiving
+// nothing at all for botVADStopFallback is the fallback that ends the bot's turn
+// when no explicit stop reaches the output.
+func (bo *BaseOutput) audioLoopWithoutMixer(ctx context.Context) {
 	idle := time.NewTimer(botVADStopFallback)
 	defer idle.Stop()
 	for {
@@ -632,12 +696,9 @@ func (bo *BaseOutput) handleQueuedFrame(ctx context.Context, f frames.Frame) {
 	case *frames.TTSAudioRawFrame, *frames.SpeechOutputAudioRawFrame, *frames.OutputAudioRawFrame:
 		bo.handleBotSpeech(ctx, f)
 
+		// The mixer has already been blended in by the loop that sourced this
+		// frame, so what the frame carries is what goes out.
 		pcm, _, _ := outputAudio(f)
-		if bo.params.AudioOutMixer != nil {
-			if mixed, err := bo.params.AudioOutMixer.Mix(ctx, pcm); err == nil {
-				pcm = mixed
-			}
-		}
 		if err := bo.self.WriteAudio(ctx, pcm); err != nil {
 			slog.Error("write audio to transport", "processor", bo.Name(), "err", err)
 			pushDownstream = false

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -544,6 +544,53 @@ func TestBaseOutputShortTurnSignalsBotSpeaking(t *testing.T) {
 	}
 }
 
+// passthroughMixer returns the audio it is given, so the only thing a test can
+// read from it is whether the output asked it to mix at all.
+type passthroughMixer struct{}
+
+func (passthroughMixer) Start(context.Context, int) error { return nil }
+func (passthroughMixer) Stop(context.Context) error       { return nil }
+
+func (passthroughMixer) Mix(_ context.Context, pcm []byte) ([]byte, error) { return pcm, nil }
+
+func (passthroughMixer) ProcessFrame(context.Context, frames.MixerControlFrame) error { return nil }
+
+// TestBaseOutputMixerFillsGaps covers auxiliary audio between turns: with a
+// mixer configured, mixer-only audio has to keep flowing while nothing is
+// queued, and keep flowing across an interruption. Otherwise background audio
+// would only ever be audible underneath the bot's speech and would cut out the
+// moment it stopped.
+func TestBaseOutputMixerFillsGaps(t *testing.T) {
+	params := transport.DefaultParams()
+	params.AudioOutSampleRate = 48000
+	params.AudioOutMixer = passthroughMixer{}
+
+	o := newFakeOutput(params)
+	task := pipeline.NewTask(pipeline.New(o), pipeline.TaskParams{})
+	runDone := make(chan error, 1)
+	go func() { runDone <- task.Run(context.Background()) }()
+
+	// Nothing is queued at any point: every write below is the mixer's own audio.
+	for i := range 3 {
+		if got := recvWrite(t, o); len(got) == 0 {
+			t.Fatalf("mixer write %d was empty", i)
+		}
+	}
+
+	task.QueueFrame(frames.NewInterruptionFrame())
+
+	// The mixer keeps playing across a barge-in: it is not the bot's turn that
+	// was interrupted, it is the background.
+	for i := range 3 {
+		if got := recvWrite(t, o); len(got) == 0 {
+			t.Fatalf("mixer write %d after the interruption was empty", i)
+		}
+	}
+
+	task.Cancel()
+	<-runDone
+}
+
 // TestBaseOutputInterruptionDiscardsTail checks the other half of the contract:
 // a barge-in must drop the pending sub-chunk tail, not play it after the fact.
 func TestBaseOutputInterruptionDiscardsTail(t *testing.T) {


### PR DESCRIPTION
The output only mixed audio it was already sending, so a mixer was
audible underneath the bot's speech and silent the moment it stopped.
Background music cut out between every turn.

Fill the gaps instead. When a mixer is configured and nothing is queued,
the output asks the mixer to mix a chunk of silence and sends that, so
the auxiliary audio plays on its own between turns and across a barge-in.
The generated audio is plain output audio, which is what keeps it from
ever marking the bot as speaking.

Mixing moves from the send step to the step that sources the frame, so
queued audio and generated audio go through one path, and a frame carries
what will actually be heard by the time anything writes it.

Gap filling is paced by the transport accepting the audio, which is why
the local transport now waits as well. It hands audio to a device that
pulls, so it waits for the backlog to drain to one chunk rather than
returning the instant it has queued it. Without that the gap filling
would have nothing to pace it there and would run as fast as the CPU
allowed. The wait ends early if the stream closes or the pipeline stops,
so it cannot hold a shutdown up.

A turn is still ended by the same quiet period as before, now measured
from the last real audio rather than from an idle queue, since with a
mixer the queue is never idle for long.
