### PR TITLE
feat(adapter): port the LLM adapter layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,18 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- **Perplexity is sent a conversation it accepts.** Perplexity is stricter than
+  OpenAI about the shape of a message history in three ways, and jargo honored
+  none of them, so a conversation it could not read was sent as though it could:
+  roles must strictly alternate, a system message is only accepted at the start,
+  and the last message must be a user or tool message. Its adapter now demotes a
+  late system message, merges each run of same-role messages into one carrying
+  both contents, and drops a trailing assistant message (which is what OpenAI
+  does with one server-side, so the turn reads the same either way). A trailing
+  system message is deliberately left alone: demoting it would depend on how much
+  of the conversation had happened so far, and Perplexity rejects a message whose
+  role changes between turns.
+
 - **Every OpenAI-compatible provider reports its token usage.** The
   chat-completions service never asked for the counts and never reported any, so
   eighteen providers produced no LLM usage metrics at all while the other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- **A toolset can carry tools written in one provider's own format.**
+  `frames.ToolsSchema` holds the standard tools every provider is offered
+  alongside custom ones keyed by `frames.AdapterType`, and
+  `LLMContext.SetToolsSchema` / `LLMContext.ToolsSchema` are how it is set and
+  read. It is what advertises a tool the provider implements itself, which no
+  common description fits: Gemini search grounding, an OpenAI hosted tool. Each
+  provider is sent only the custom tools written for its own format, so a
+  conversation carrying them stays usable everywhere. `openai.Tool` and
+  `responses.Tool` grew a `Raw` field for a tool the function schema has no
+  place for. Anthropic reads no custom tools, so anything keyed for another
+  format is left out there.
+
 - **A conversation can carry a message written in one provider's own format.**
   `frames.NewLLMSpecificMessage` builds a message for a named provider, and
   `LLMContext.MessagesFor` returns what one provider is sent: every universal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- **The Responses API is sent a developer message, not a system one.** A
+  `RoleSystem` message in the conversation went out under the role "system",
+  which the Responses API does not define. It is now sent as a developer
+  message, the role the API reserves for instructions given out of band. A
+  conversation with nothing said yet carries its instructions as a developer
+  message too, rather than beside an empty input list, which the API refuses.
+
 - **Gemini answers a conversation of nothing but tool turns.** Gemini reads the
   system instruction as framing rather than as something to act on, so a
   conversation whose messages are all tool calls and results gave the model

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,23 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- **Anthropic no longer drops a system message from the conversation.** A
+  `RoleSystem` message in the message list was skipped outright, on the grounds
+  that the system prompt is sent beside the conversation, so anything a caller
+  put there was silently lost. Anthropic has no system input role, so such a
+  message now enters as the user, which is where its content belongs. A
+  conversation carrying nothing but a system prompt is sent the same way rather
+  than reaching the API with an empty message list, which it rejects.
+
+- **Anthropic caches the conversation, not just the system prompt.** The
+  ephemeral cache breakpoint was placed only on the system prompt, so everything
+  said in the conversation was re-read on every turn. The two most recent user
+  messages are now marked as well: the marker on the last tells Anthropic to
+  cache the prompt up to that point, and the one before it tells Anthropic to
+  read back the cache written on the previous turn. Marking only the last would
+  write a cache every turn and never read one. The system-prompt breakpoint is
+  unchanged, so recalled context still sits outside the cached prefix.
+
 - **Perplexity is sent a conversation it accepts.** Perplexity is stricter than
   OpenAI about the shape of a message history in three ways, and jargo honored
   none of them, so a conversation it could not read was sent as though it could:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,16 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
+- **A tool the LLM service implements itself lives on its adapter, not on the
+  conversation.** `LLMContext.SetServiceTools`, `LLMContext.SetServiceInstructions`
+  and `LLMContext.AppTools` are gone, and `LLMContext.Tools` returns exactly what
+  the application advertised. The built-in async-cancellation tool was written
+  into the shared conversation, which edited a context the application owns and
+  offered the tool to every other service reading that conversation. It now sits
+  on the adapter the service converts through, which renders it in that
+  provider's own format. A service that wants to offer one implements
+  `llm.AdapterHolder`; every jargo LLM service does.
+
 - **An OpenAI-compatible endpoint states its adapter rather than a message
   hook.** `chat.Compat.ShapeMessages` is gone; `chat.Compat.Adapter` takes an
   `adapter.LLMAdapter[openai.Params, openai.Tool]` instead. An endpoint that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,16 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Changed
 
+- **An OpenAI-compatible endpoint states its adapter rather than a message
+  hook.** `chat.Compat.ShapeMessages` is gone; `chat.Compat.Adapter` takes an
+  `adapter.LLMAdapter[openai.Params, openai.Tool]` instead. An endpoint that
+  constrains the shape of a conversation embeds the OpenAI adapter and rewrites
+  what it produced, which puts the whole conversion in one place instead of
+  splitting it between a shared function and a hook that patched up the result.
+  The chat-completions wire types (`chat.Message`, `chat.ToolCall`,
+  `chat.ToolCallFunction`) now live in `adapter/openai` and are aliased under
+  their old names, so referring to them is unaffected.
+
 - **A summarizer and a judge are built on a service that answers once, not on a
   streaming generator.** `llm.NewSummarizer` and `eval.NewLLMJudge` take an
   `llm.Inferencer`. Every jargo LLM service satisfies it, so a caller passing one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- **A conversation can carry a message written in one provider's own format.**
+  `frames.NewLLMSpecificMessage` builds a message for a named provider, and
+  `LLMContext.MessagesFor` returns what one provider is sent: every universal
+  message plus its own, and none written for another. It is how an application
+  says something the universal conversation has no representation for without
+  the conversation becoming unusable with every other provider. Anthropic reads
+  a reasoning block written with `anthropic.NewThought`, handing it back as a
+  thinking block so the model keeps its reasoning across a turn; one without a
+  signature is left out, since the API decrypts a thinking block by that
+  signature and refuses one without.
+
 - **A one-shot inference, off to the side of the pipeline.** `RunInference`
   answers a conversation once and returns the text: no streaming, no frames, an
   instruction and a token bound of its own. Every LLM service has it now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- **Gemini answers a conversation of nothing but tool turns.** Gemini reads the
+  system instruction as framing rather than as something to act on, so a
+  conversation whose messages are all tool calls and results gave the model
+  nothing to reply to. The instruction is now said again as a user message when
+  that is all the conversation holds. Contents carrying no parts are dropped
+  rather than sent, which Gemini rejects.
+
 - **Anthropic no longer drops a system message from the conversation.** A
   `RoleSystem` message in the message list was skipped outright, on the grounds
   that the system prompt is sent beside the conversation, so anything a caller

--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -1,0 +1,152 @@
+// Package adapter converts jargo's universal conversation context into the
+// request each LLM provider takes.
+//
+// A provider's wire format is its own: one takes the system prompt as a leading
+// message and another as a field beside the conversation, one names a tool
+// result by an id and another by the call it answers. An adapter is where that
+// translation lives, and it is a plain value the service owns and calls rather
+// than a base the service inherits from. That keeps the conversion a pure
+// function of the conversation, so it can be tested by comparing what went in
+// with what came out, with no endpoint to stand up.
+//
+// Each provider adapter lives in its own package under this one and satisfies
+// [LLMAdapter] for its parameter and tool types.
+package adapter
+
+import (
+	"fmt"
+	"log/slog"
+	"sync/atomic"
+
+	"github.com/gojargo/jargo/frames"
+)
+
+// ConversionError reports that a conversation could not be mapped into a
+// provider's message format. An adapter returns it from its conversion, and the
+// LLM service reports it as a generation failure, so a context the provider
+// cannot represent is told apart from the provider itself failing.
+type ConversionError struct {
+	// Cause is the error the conversion failed with.
+	Cause error
+}
+
+// Error implements error.
+func (e *ConversionError) Error() string {
+	return fmt.Sprintf("error mapping context messages to provider format: %v", e.Cause)
+}
+
+// Unwrap returns the underlying conversion failure.
+func (e *ConversionError) Unwrap() error { return e.Cause }
+
+// Options tunes one conversion. The zero value converts the conversation as the
+// provider's own API takes it.
+type Options struct {
+	// SystemInstruction is the instruction this call was given, which stands
+	// beside the conversation's own system prompt. It is what a one-shot
+	// inference runs under (see llm.InferenceOptions). Empty leaves the
+	// conversation's prompt to stand alone.
+	SystemInstruction string
+	// ConvertDeveloperToUser sends a developer message as a user message, for a
+	// provider with no developer role. What the role carries, the late results of
+	// an asynchronous tool, is worth more to the model than the role it arrives
+	// under.
+	ConvertDeveloperToUser bool
+}
+
+// LLMAdapter converts a universal conversation into one provider's invocation
+// parameters. P is the parameter type that provider's API takes and T its tool
+// type, both of which the adapter's own package defines.
+type LLMAdapter[P, T any] interface {
+	// IDForLLMSpecificMessages is the identifier this provider's messages are
+	// held under in a universal context, so a message written in one provider's
+	// native format reaches that provider and no other.
+	IDForLLMSpecificMessages() string
+	// LLMInvocationParams converts the conversation into what this provider's API
+	// takes. It returns a [ConversionError] for a conversation the provider has
+	// no representation for.
+	LLMInvocationParams(convo *frames.LLMContext, opts Options) (P, error)
+	// ToProviderToolsFormat renders the advertised tools in this provider's
+	// format.
+	ToProviderToolsFormat(tools []frames.Tool) []T
+	// MessagesForLogging renders the conversation as this provider will see it,
+	// for a log or a trace.
+	MessagesForLogging(convo *frames.LLMContext) []map[string]any
+}
+
+// Base carries the state an adapter keeps between conversions, and the handling
+// of a system prompt that every provider shares. Embed it in a provider adapter
+// to inherit both.
+//
+// It is safe for concurrent use: a one-shot inference runs off to the side of
+// the pipeline and so may convert a conversation while a generation is
+// converting another.
+type Base struct {
+	// warnedSystemInstruction records that the conflict between an instruction
+	// given for a call and the conversation's own prompt has been reported, so it
+	// is reported once rather than on every generation of the session.
+	warnedSystemInstruction atomic.Bool
+}
+
+// ExtractInitialSystem reports the system prompt a provider should send beside
+// the conversation, and the messages to send with it.
+//
+// A conversation carrying nothing but a system prompt is the case this exists
+// for. Sending the prompt on its own would leave the message list empty, which
+// a provider that requires at least one non-system message rejects, so the
+// prompt is sent as a user message instead and no separate instruction goes
+// out. systemInstruction is only read to decide whether that displaced a prompt
+// the caller also gave.
+func (b *Base) ExtractInitialSystem(
+	system, systemInstruction string, msgs []frames.Message,
+) (string, []frames.Message) {
+	if system == "" || len(msgs) > 0 {
+		return system, msgs
+	}
+	if systemInstruction != "" {
+		b.warnOnce("both an instruction for this call and a system prompt on the conversation" +
+			" are set; using the instruction. The conversation's prompt is being sent as a user" +
+			" message so the provider is not given an empty conversation")
+	}
+	return "", []frames.Message{{Role: frames.RoleUser, Text: system}}
+}
+
+// ResolveSystemInstruction settles which system prompt a provider is sent when
+// the conversation carries one and the call was given another.
+//
+// discardContextSystem says what the provider does with the conversation's own
+// prompt when both are set. A provider that takes the prompt beside the
+// conversation has one field to put it in, so the instruction given for the call
+// replaces it. A provider that takes it as a leading message can carry both, and
+// keeping both is what lets an instruction supplement the conversation's prompt
+// rather than silently replace it; there the returned prompt is empty, because
+// the conversation's own is already in the messages.
+func (b *Base) ResolveSystemInstruction(
+	fromContext, systemInstruction string, discardContextSystem bool,
+) string {
+	if fromContext != "" && systemInstruction != "" {
+		if discardContextSystem {
+			b.warnOnce("both an instruction for this call and a system prompt on the" +
+				" conversation are set; using the instruction")
+		} else {
+			b.warnOnce("both an instruction for this call and a system prompt on the" +
+				" conversation are set, which may be unintended. Both are being sent; consider" +
+				" giving system-level instructions on the conversation and keeping the call's" +
+				" instruction for supplementary guidance")
+		}
+	}
+	if systemInstruction != "" {
+		return systemInstruction
+	}
+	if discardContextSystem {
+		return fromContext
+	}
+	// The prompt is already in the messages; there is nothing to send beside them.
+	return ""
+}
+
+// warnOnce reports msg the first time it is reached and stays quiet after that.
+func (b *Base) warnOnce(msg string) {
+	if b.warnedSystemInstruction.CompareAndSwap(false, true) {
+		slog.Warn(msg)
+	}
+}

--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -51,6 +51,13 @@ type Options struct {
 	// an asynchronous tool, is worth more to the model than the role it arrives
 	// under.
 	ConvertDeveloperToUser bool
+	// EnablePromptCaching marks the conversation so the provider caches the
+	// prompt and reads the cache back on the next turn.
+	EnablePromptCaching bool
+	// EnsureLastMessageIsUser appends a minimal user message when the converted
+	// conversation ends on an assistant message. It is for a model without
+	// assistant-prefill support, which rejects a request ending that way.
+	EnsureLastMessageIsUser bool
 }
 
 // LLMAdapter converts a universal conversation into one provider's invocation

--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -16,6 +16,9 @@ package adapter
 import (
 	"fmt"
 	"log/slog"
+	"slices"
+	"strings"
+	"sync"
 	"sync/atomic"
 
 	"github.com/gojargo/jargo/frames"
@@ -92,6 +95,96 @@ type Base struct {
 	// given for a call and the conversation's own prompt has been reported, so it
 	// is reported once rather than on every generation of the session.
 	warnedSystemInstruction atomic.Bool
+
+	// mu guards the built-in tools below, which the service adds and withdraws
+	// as its registrations change while generations are converting.
+	mu sync.RWMutex
+	// builtins are the tools the service implements itself, sent on every
+	// request without the application having advertised them, each with the
+	// instructions that go with it. They are keyed by tool name.
+	builtins map[string]Builtin
+	// builtinOrder keeps the order they were added in, so a request carries them
+	// the same way twice running and a cached prompt prefix stays byte-identical.
+	builtinOrder []string
+}
+
+// Builtin is a tool the LLM service implements itself, and whatever the model
+// has to be told to use it.
+type Builtin struct {
+	// Tool is the declaration advertised to the model.
+	Tool frames.Tool
+	// Instructions are appended to the system prompt while the tool is offered.
+	// Empty adds nothing.
+	Instructions string
+}
+
+// SetBuiltin adds a tool the service implements itself, replacing any already
+// registered under the same name. It is sent on every request from now on,
+// without the application having to advertise it.
+//
+// It lives here rather than on the conversation because it belongs to the
+// service: a conversation is shared, and writing the tool into it would offer
+// it to every other service reading that conversation, and edit a context the
+// application owns.
+func (b *Base) SetBuiltin(builtin Builtin) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.builtins == nil {
+		b.builtins = make(map[string]Builtin)
+	}
+	if _, seen := b.builtins[builtin.Tool.Name]; !seen {
+		b.builtinOrder = append(b.builtinOrder, builtin.Tool.Name)
+	}
+	b.builtins[builtin.Tool.Name] = builtin
+}
+
+// RemoveBuiltin withdraws the tool registered under name, reporting whether
+// there was one.
+func (b *Base) RemoveBuiltin(name string) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if _, ok := b.builtins[name]; !ok {
+		return false
+	}
+	delete(b.builtins, name)
+	b.builtinOrder = slices.DeleteFunc(b.builtinOrder, func(s string) bool { return s == name })
+	return true
+}
+
+// WithBuiltins returns the conversation's tools followed by the ones the
+// service implements itself. An adapter renders the result, so a built-in tool
+// reaches the model in the provider's own format rather than in one shape that
+// has to suit every provider.
+func (b *Base) WithBuiltins(tools []frames.Tool) []frames.Tool {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	if len(b.builtinOrder) == 0 {
+		return tools
+	}
+	out := make([]frames.Tool, 0, len(tools)+len(b.builtinOrder))
+	out = append(out, tools...)
+	for _, name := range b.builtinOrder {
+		out = append(out, b.builtins[name].Tool)
+	}
+	return out
+}
+
+// SystemWithBuiltins appends the instructions of every built-in tool currently
+// offered to the system prompt, so the model is told how to use what it is being
+// sent. It returns system unchanged when there are none.
+func (b *Base) SystemWithBuiltins(system string) string {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	parts := make([]string, 0, len(b.builtinOrder)+1)
+	if system != "" {
+		parts = append(parts, system)
+	}
+	for _, name := range b.builtinOrder {
+		if text := b.builtins[name].Instructions; text != "" {
+			parts = append(parts, text)
+		}
+	}
+	return strings.Join(parts, "\n\n")
 }
 
 // ExtractInitialSystem reports the system prompt a provider should send beside

--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -83,6 +83,52 @@ type LLMAdapter[P, T any] interface {
 	MessagesForLogging(convo *frames.LLMContext) []map[string]any
 }
 
+// Identifier is the part of an adapter that names the provider it converts for.
+// Every [LLMAdapter] satisfies it.
+type Identifier interface {
+	IDForLLMSpecificMessages() string
+}
+
+// CreateLLMSpecificMessage builds a conversation message written in a's
+// provider's own format, for something the universal conversation has no
+// representation for. Only a's provider is sent it; every other adapter leaves
+// it out.
+//
+// native must be the message type a's own package defines, which is what its
+// conversion reads back. Anything else is reported as a conversion failure when
+// the conversation is sent.
+func CreateLLMSpecificMessage(a Identifier, native any) frames.Message {
+	return frames.NewLLMSpecificMessage(a.IDForLLMSpecificMessages(), native)
+}
+
+// NativeMessage reads a provider-native message back as the type that
+// provider's adapter defines, reporting a conversion failure when it holds
+// something else. An adapter calls it on a message it has already established
+// is its own.
+func NativeMessage[T any](m frames.Message) (T, error) {
+	native, ok := m.Native.(T)
+	if !ok {
+		var want T
+		return want, &ConversionError{Cause: &nativeTypeError{
+			llm: m.LLM, got: fmt.Sprintf("%T", m.Native), want: fmt.Sprintf("%T", want),
+		}}
+	}
+	return native, nil
+}
+
+// nativeTypeError reports a provider-native message holding something its own
+// adapter cannot read.
+type nativeTypeError struct {
+	llm  string
+	got  string
+	want string
+}
+
+// Error implements error.
+func (e *nativeTypeError) Error() string {
+	return fmt.Sprintf("message for %q holds %s, want %s", e.llm, e.got, e.want)
+}
+
 // Base carries the state an adapter keeps between conversions, and the handling
 // of a system prompt that every provider shares. Embed it in a provider adapter
 // to inherit both.

--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -75,9 +75,10 @@ type LLMAdapter[P, T any] interface {
 	// takes. It returns a [ConversionError] for a conversation the provider has
 	// no representation for.
 	LLMInvocationParams(convo *frames.LLMContext, opts Options) (P, error)
-	// ToProviderToolsFormat renders the advertised tools in this provider's
-	// format.
-	ToProviderToolsFormat(tools []frames.Tool) []T
+	// ToProviderToolsFormat renders the advertised toolset in this provider's
+	// format, including the custom tools written for it and leaving out those
+	// written for another.
+	ToProviderToolsFormat(schema frames.ToolsSchema) []T
 	// MessagesForLogging renders the conversation as this provider will see it,
 	// for a log or a trace.
 	MessagesForLogging(convo *frames.LLMContext) []map[string]any
@@ -197,22 +198,57 @@ func (b *Base) RemoveBuiltin(name string) bool {
 	return true
 }
 
-// WithBuiltins returns the conversation's tools followed by the ones the
-// service implements itself. An adapter renders the result, so a built-in tool
-// reaches the model in the provider's own format rather than in one shape that
-// has to suit every provider.
-func (b *Base) WithBuiltins(tools []frames.Tool) []frames.Tool {
+// WithBuiltins returns the toolset with the tools the service implements itself
+// appended to the standard ones. An adapter renders the result, so a built-in
+// tool reaches the model in the provider's own format rather than in one shape
+// that has to suit every provider.
+func (b *Base) WithBuiltins(schema frames.ToolsSchema) frames.ToolsSchema {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 	if len(b.builtinOrder) == 0 {
-		return tools
+		return schema
 	}
-	out := make([]frames.Tool, 0, len(tools)+len(b.builtinOrder))
-	out = append(out, tools...)
+	out := schema
+	out.Standard = make([]frames.Tool, 0, len(schema.Standard)+len(b.builtinOrder))
+	out.Standard = append(out.Standard, schema.Standard...)
 	for _, name := range b.builtinOrder {
-		out = append(out, b.builtins[name].Tool)
+		out.Standard = append(out.Standard, b.builtins[name].Tool)
 	}
 	return out
+}
+
+// CustomToolsFor reads the custom tools written for one format back as the tool
+// type that adapter defines, reporting a conversion failure for anything else.
+func CustomToolsFor[T any](schema frames.ToolsSchema, t frames.AdapterType) ([]T, error) {
+	raw := schema.CustomFor(t)
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	out := make([]T, 0, len(raw))
+	for _, v := range raw {
+		tool, ok := v.(T)
+		if !ok {
+			var want T
+			return nil, &ConversionError{Cause: &customToolTypeError{
+				adapter: string(t), got: fmt.Sprintf("%T", v), want: fmt.Sprintf("%T", want),
+			}}
+		}
+		out = append(out, tool)
+	}
+	return out, nil
+}
+
+// customToolTypeError reports a custom tool holding something its adapter
+// cannot read.
+type customToolTypeError struct {
+	adapter string
+	got     string
+	want    string
+}
+
+// Error implements error.
+func (e *customToolTypeError) Error() string {
+	return fmt.Sprintf("custom tool for %q holds %s, want %s", e.adapter, e.got, e.want)
 }
 
 // SystemWithBuiltins appends the instructions of every built-in tool currently

--- a/adapter/adapter_test.go
+++ b/adapter/adapter_test.go
@@ -38,7 +38,7 @@ func TestBuiltinsFollowTheConversationsOwn(t *testing.T) {
 	var b adapter.Base
 	b.SetBuiltin(adapter.Builtin{Tool: frames.Tool{Name: "cancel"}})
 
-	wantNames(t, b.WithBuiltins([]frames.Tool{{Name: "watch"}}), "watch", "cancel")
+	wantNames(t, b.WithBuiltins(frames.ToolsSchema{Standard: []frames.Tool{{Name: "watch"}}}).Standard, "watch", "cancel")
 }
 
 // TestBuiltinsKeepTheirOrder checks two built-in tools are sent the same way
@@ -50,7 +50,7 @@ func TestBuiltinsKeepTheirOrder(t *testing.T) {
 	b.SetBuiltin(adapter.Builtin{Tool: frames.Tool{Name: "second"}})
 
 	for range 3 {
-		wantNames(t, b.WithBuiltins(nil), "first", "second")
+		wantNames(t, b.WithBuiltins(frames.ToolsSchema{}).Standard, "first", "second")
 	}
 }
 
@@ -62,7 +62,7 @@ func TestSetBuiltinReplacesWithoutReordering(t *testing.T) {
 	b.SetBuiltin(adapter.Builtin{Tool: frames.Tool{Name: "second"}})
 	b.SetBuiltin(adapter.Builtin{Tool: frames.Tool{Name: "first", Description: "updated"}})
 
-	tools := b.WithBuiltins(nil)
+	tools := b.WithBuiltins(frames.ToolsSchema{}).Standard
 	wantNames(t, tools, "first", "second")
 	if tools[0].Description != "updated" {
 		t.Errorf("description = %q, want the re-registered tool's", tools[0].Description)
@@ -78,7 +78,7 @@ func TestRemoveBuiltin(t *testing.T) {
 	if !b.RemoveBuiltin("cancel") {
 		t.Error("RemoveBuiltin said there was no such tool, want it removed")
 	}
-	wantNames(t, b.WithBuiltins([]frames.Tool{{Name: "watch"}}), "watch")
+	wantNames(t, b.WithBuiltins(frames.ToolsSchema{Standard: []frames.Tool{{Name: "watch"}}}).Standard, "watch")
 
 	if b.RemoveBuiltin("cancel") {
 		t.Error("RemoveBuiltin said it removed a tool that was not registered")
@@ -92,7 +92,7 @@ func TestWithBuiltinsLeavesTheConversationAlone(t *testing.T) {
 	b.SetBuiltin(adapter.Builtin{Tool: frames.Tool{Name: "cancel"}})
 
 	tools := []frames.Tool{{Name: "watch"}}
-	b.WithBuiltins(tools)
+	b.WithBuiltins(frames.ToolsSchema{Standard: tools})
 	wantNames(t, tools, "watch")
 }
 

--- a/adapter/adapter_test.go
+++ b/adapter/adapter_test.go
@@ -1,0 +1,146 @@
+package adapter_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gojargo/jargo/adapter"
+	"github.com/gojargo/jargo/frames"
+)
+
+// names returns the name of each tool, which is what these tests compare.
+func names(tools []frames.Tool) []string {
+	out := make([]string, 0, len(tools))
+	for _, t := range tools {
+		out = append(out, t.Name)
+	}
+	return out
+}
+
+// wantNames fails unless the tools carry exactly the given names in order.
+func wantNames(t *testing.T, tools []frames.Tool, want ...string) {
+	t.Helper()
+	got := names(tools)
+	if len(got) != len(want) {
+		t.Fatalf("tools = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("tool %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestBuiltinsFollowTheConversationsOwn checks a tool the service implements is
+// sent after the ones the application advertised, so what the application asked
+// for reaches the model in the order it stated.
+func TestBuiltinsFollowTheConversationsOwn(t *testing.T) {
+	var b adapter.Base
+	b.SetBuiltin(adapter.Builtin{Tool: frames.Tool{Name: "cancel"}})
+
+	wantNames(t, b.WithBuiltins([]frames.Tool{{Name: "watch"}}), "watch", "cancel")
+}
+
+// TestBuiltinsKeepTheirOrder checks two built-in tools are sent the same way
+// twice running. A request that reorders them would rewrite a cached prompt
+// prefix on every turn and never read one back.
+func TestBuiltinsKeepTheirOrder(t *testing.T) {
+	var b adapter.Base
+	b.SetBuiltin(adapter.Builtin{Tool: frames.Tool{Name: "first"}})
+	b.SetBuiltin(adapter.Builtin{Tool: frames.Tool{Name: "second"}})
+
+	for range 3 {
+		wantNames(t, b.WithBuiltins(nil), "first", "second")
+	}
+}
+
+// TestSetBuiltinReplacesWithoutReordering checks re-registering a tool updates
+// it in place rather than moving it to the end.
+func TestSetBuiltinReplacesWithoutReordering(t *testing.T) {
+	var b adapter.Base
+	b.SetBuiltin(adapter.Builtin{Tool: frames.Tool{Name: "first"}})
+	b.SetBuiltin(adapter.Builtin{Tool: frames.Tool{Name: "second"}})
+	b.SetBuiltin(adapter.Builtin{Tool: frames.Tool{Name: "first", Description: "updated"}})
+
+	tools := b.WithBuiltins(nil)
+	wantNames(t, tools, "first", "second")
+	if tools[0].Description != "updated" {
+		t.Errorf("description = %q, want the re-registered tool's", tools[0].Description)
+	}
+}
+
+// TestRemoveBuiltin checks a withdrawn tool stops being sent, and that
+// withdrawing one that was never registered says so.
+func TestRemoveBuiltin(t *testing.T) {
+	var b adapter.Base
+	b.SetBuiltin(adapter.Builtin{Tool: frames.Tool{Name: "cancel"}})
+
+	if !b.RemoveBuiltin("cancel") {
+		t.Error("RemoveBuiltin said there was no such tool, want it removed")
+	}
+	wantNames(t, b.WithBuiltins([]frames.Tool{{Name: "watch"}}), "watch")
+
+	if b.RemoveBuiltin("cancel") {
+		t.Error("RemoveBuiltin said it removed a tool that was not registered")
+	}
+}
+
+// TestWithBuiltinsLeavesTheConversationAlone checks the merge does not write
+// into the slice it was given, which the conversation still holds.
+func TestWithBuiltinsLeavesTheConversationAlone(t *testing.T) {
+	var b adapter.Base
+	b.SetBuiltin(adapter.Builtin{Tool: frames.Tool{Name: "cancel"}})
+
+	tools := []frames.Tool{{Name: "watch"}}
+	b.WithBuiltins(tools)
+	wantNames(t, tools, "watch")
+}
+
+// TestSystemWithBuiltins checks the instructions of an offered tool are appended
+// to the prompt, so the model is told how to use what it is being sent.
+func TestSystemWithBuiltins(t *testing.T) {
+	var b adapter.Base
+	if got := b.SystemWithBuiltins("be brief"); got != "be brief" {
+		t.Errorf("system = %q, want it unchanged with no built-in tools", got)
+	}
+
+	b.SetBuiltin(adapter.Builtin{
+		Tool:         frames.Tool{Name: "cancel"},
+		Instructions: "how to cancel",
+	})
+	if got := b.SystemWithBuiltins("be brief"); got != "be brief\n\nhow to cancel" {
+		t.Errorf("system = %q, want the instructions appended", got)
+	}
+	if got := b.SystemWithBuiltins(""); got != "how to cancel" {
+		t.Errorf("system = %q, want the instructions to stand alone", got)
+	}
+}
+
+// TestSystemWithBuiltinsSkipsToolsThatSayNothing checks a built-in tool needing
+// no explanation adds no blank run to the prompt.
+func TestSystemWithBuiltinsSkipsToolsThatSayNothing(t *testing.T) {
+	var b adapter.Base
+	b.SetBuiltin(adapter.Builtin{Tool: frames.Tool{Name: "cancel"}})
+
+	if got := b.SystemWithBuiltins("be brief"); got != "be brief" {
+		t.Errorf("system = %q, want it unchanged", got)
+	}
+}
+
+// TestConversionErrorCarriesItsCause checks the failure a conversion wrapped is
+// still reachable, so what actually went wrong can be read off it.
+func TestConversionErrorCarriesItsCause(t *testing.T) {
+	cause := testError{}
+	err := &adapter.ConversionError{Cause: cause}
+	if !errors.Is(err.Unwrap(), cause) {
+		t.Errorf("Unwrap = %v, want the cause", err.Unwrap())
+	}
+	if got := err.Error(); got == "" {
+		t.Error("Error() is empty, want it to name the failure")
+	}
+}
+
+// testError is a stand-in cause for the wrapping test.
+type testError struct{}
+
+func (testError) Error() string { return "boom" }

--- a/adapter/anthropic/anthropic.go
+++ b/adapter/anthropic/anthropic.go
@@ -4,6 +4,7 @@ package anthropic
 
 import (
 	"encoding/json"
+	"errors"
 
 	sdk "github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/packages/param"
@@ -53,7 +54,8 @@ func (a *Adapter) LLMInvocationParams(
 	convo *frames.LLMContext, opts adapter.Options,
 ) (Params, error) {
 	fromContext, msgs := a.ExtractInitialSystem(
-		a.SystemWithBuiltins(convo.System()), opts.SystemInstruction, convo.Messages(),
+		a.SystemWithBuiltins(convo.System()), opts.SystemInstruction,
+		convo.MessagesFor(a.IDForLLMSpecificMessages()),
 	)
 
 	converted, err := ToMessages(msgs)
@@ -125,34 +127,81 @@ func (a *Adapter) systemBlocks(
 func ToMessages(msgs []frames.Message) ([]sdk.MessageParam, error) {
 	out := make([]sdk.MessageParam, 0, len(msgs))
 	for _, m := range msgs {
-		converted, err := toMessage(m)
+		converted, send, err := toMessage(m)
 		if err != nil {
+			var convErr *adapter.ConversionError
+			if errors.As(err, &convErr) {
+				return nil, err
+			}
 			return nil, &adapter.ConversionError{Cause: err}
+		}
+		if !send {
+			continue
 		}
 		out = append(out, converted)
 	}
 	return mergeSameRole(out), nil
 }
 
-// toMessage converts one message.
-func toMessage(m frames.Message) (sdk.MessageParam, error) {
+// toMessage converts one message, reporting whether there is one to send: a
+// thought Anthropic cannot read is left out rather than sent as something else.
+func toMessage(m frames.Message) (sdk.MessageParam, bool, error) {
 	switch {
+	case m.IsLLMSpecific():
+		return nativeMessage(m)
 	case len(m.ToolResults) > 0:
 		blocks := make([]sdk.ContentBlockParamUnion, 0, len(m.ToolResults))
 		for _, r := range m.ToolResults {
 			blocks = append(blocks, sdk.NewToolResultBlock(r.ID, r.Content, false))
 		}
-		return sdk.NewUserMessage(blocks...), nil
+		return sdk.NewUserMessage(blocks...), true, nil
 	case len(m.ToolCalls) > 0:
-		return toolCallMessage(m)
+		msg, err := toolCallMessage(m)
+		return msg, err == nil, err
 	case m.Role == frames.RoleAssistant:
-		return sdk.NewAssistantMessage(sdk.NewTextBlock(text(m.Text))), nil
+		return sdk.NewAssistantMessage(sdk.NewTextBlock(text(m.Text))), true, nil
 	default:
 		// A user message, and a system or developer message too: Anthropic has
 		// neither a system nor a developer input role, so all three enter as the
 		// user rather than being dropped.
-		return sdk.NewUserMessage(sdk.NewTextBlock(text(m.Text))), nil
+		return sdk.NewUserMessage(sdk.NewTextBlock(text(m.Text))), true, nil
 	}
+}
+
+// Thought is a reasoning block the model produced, kept in the conversation so
+// it can be handed back on the next turn.
+//
+// Signature is the encrypted reasoning Anthropic decrypts when the block is
+// passed back. A thinking block is only valid with one, so a thought without a
+// signature cannot be sent and is left out of the conversation entirely. The
+// text may legitimately be empty: a model set to omit its reasoning returns
+// thinking blocks with none.
+type Thought struct {
+	Text      string
+	Signature string
+}
+
+// NewThought builds a conversation message carrying a reasoning block, written
+// for Anthropic and sent to no other provider.
+func NewThought(t Thought) frames.Message {
+	return adapter.CreateLLMSpecificMessage(&Adapter{}, t)
+}
+
+// nativeMessage reads a message written for Anthropic. It is either a thought,
+// which becomes a thinking block, or a message already in Anthropic's format.
+func nativeMessage(m frames.Message) (sdk.MessageParam, bool, error) {
+	if t, ok := m.Native.(Thought); ok {
+		if t.Signature == "" {
+			// Nothing to send: the block cannot be round-tripped without the
+			// signature the API decrypts it by.
+			return sdk.MessageParam{}, false, nil
+		}
+		return sdk.NewAssistantMessage(
+			sdk.NewThinkingBlock(t.Signature, t.Text),
+		), true, nil
+	}
+	native, err := adapter.NativeMessage[sdk.MessageParam](m)
+	return native, err == nil, err
 }
 
 // toolCallMessage renders an assistant turn that requested tool calls.

--- a/adapter/anthropic/anthropic.go
+++ b/adapter/anthropic/anthropic.go
@@ -53,7 +53,7 @@ func (a *Adapter) LLMInvocationParams(
 	convo *frames.LLMContext, opts adapter.Options,
 ) (Params, error) {
 	fromContext, msgs := a.ExtractInitialSystem(
-		convo.System(), opts.SystemInstruction, convo.Messages(),
+		a.SystemWithBuiltins(convo.System()), opts.SystemInstruction, convo.Messages(),
 	)
 
 	converted, err := ToMessages(msgs)
@@ -71,7 +71,7 @@ func (a *Adapter) LLMInvocationParams(
 		Messages: converted,
 		System:   a.systemBlocks(convo, fromContext, opts),
 	}
-	if tools := convo.Tools(); len(tools) > 0 {
+	if tools := a.WithBuiltins(convo.Tools()); len(tools) > 0 {
 		params.Tools = a.ToProviderToolsFormat(tools)
 	}
 	return params, nil

--- a/adapter/anthropic/anthropic.go
+++ b/adapter/anthropic/anthropic.go
@@ -1,0 +1,331 @@
+// Package anthropic converts a universal conversation into the request
+// Anthropic takes, and with it Bedrock, which serves the same models.
+package anthropic
+
+import (
+	"encoding/json"
+
+	sdk "github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/packages/param"
+	"github.com/gojargo/jargo/adapter"
+	"github.com/gojargo/jargo/frames"
+)
+
+// emptyText stands in for a message whose content came out empty. Anthropic
+// rejects a message with no content, and a turn that produced none is still
+// part of the conversation.
+const emptyText = "(empty)"
+
+// noOpUserTurn is the minimal user message appended to a conversation ending on
+// an assistant message. A full stop says nothing in any language, which is the
+// point: it is there to satisfy the shape, not to be read.
+const noOpUserTurn = "."
+
+// Params is what one Anthropic call takes from the conversation: the system
+// prompt it carries beside the messages, the messages themselves, and the tools
+// to advertise.
+type Params struct {
+	System   []sdk.TextBlockParam
+	Messages []sdk.MessageParam
+	Tools    []sdk.ToolUnionParam
+}
+
+// Adapter converts a universal conversation into an Anthropic request. The zero
+// value is ready to use.
+type Adapter struct {
+	adapter.Base
+}
+
+// Compile-time check that the adapter satisfies the contract.
+var _ adapter.LLMAdapter[Params, sdk.ToolUnionParam] = (*Adapter)(nil)
+
+// IDForLLMSpecificMessages implements adapter.LLMAdapter.
+func (*Adapter) IDForLLMSpecificMessages() string { return "anthropic" }
+
+// LLMInvocationParams converts the conversation into an Anthropic request.
+//
+// Anthropic carries the system prompt beside the conversation rather than in
+// it, so it has one field to put it in: an instruction given for this call
+// replaces the conversation's own prompt rather than supplementing it. It has
+// neither a system nor a developer input role either, so a message in one of
+// those roles enters as the user.
+func (a *Adapter) LLMInvocationParams(
+	convo *frames.LLMContext, opts adapter.Options,
+) (Params, error) {
+	fromContext, msgs := a.ExtractInitialSystem(
+		convo.System(), opts.SystemInstruction, convo.Messages(),
+	)
+
+	converted, err := ToMessages(msgs)
+	if err != nil {
+		return Params{}, err
+	}
+	if opts.EnsureLastMessageIsUser {
+		converted = EnsureLastMessageIsUser(converted)
+	}
+	if opts.EnablePromptCaching {
+		converted = WithCacheControlMarkers(converted)
+	}
+
+	params := Params{
+		Messages: converted,
+		System:   a.systemBlocks(convo, fromContext, opts),
+	}
+	if tools := convo.Tools(); len(tools) > 0 {
+		params.Tools = a.ToProviderToolsFormat(tools)
+	}
+	return params, nil
+}
+
+// systemBlocks renders the system prompt Anthropic is sent beside the
+// conversation.
+//
+// When the prompt comes from the conversation and caching is on, the cache
+// breakpoint goes on the part of it that survives between turns. A cached
+// prefix is only reused while it stays byte-identical, and everything after the
+// breakpoint is free to vary without disturbing it. The recalled context a
+// memory service refreshes every turn is exactly that: putting it inside the
+// breakpoint would rewrite the cache on every request and never read one back,
+// which costs more than not caching at all.
+func (a *Adapter) systemBlocks(
+	convo *frames.LLMContext, fromContext string, opts adapter.Options,
+) []sdk.TextBlockParam {
+	resolved := a.ResolveSystemInstruction(fromContext, opts.SystemInstruction, true)
+	if resolved == "" {
+		return nil
+	}
+	// An instruction given for one call is not the conversation's prompt and has
+	// no part that survives between turns, so there is nothing to cache.
+	if !opts.EnablePromptCaching || resolved != fromContext {
+		return []sdk.TextBlockParam{{Text: resolved}}
+	}
+
+	stable, volatile := convo.SystemParts()
+	blocks := make([]sdk.TextBlockParam, 0, 2)
+	if stable != "" {
+		blocks = append(blocks, sdk.TextBlockParam{
+			Text:         stable,
+			CacheControl: sdk.NewCacheControlEphemeralParam(),
+		})
+	}
+	if volatile != "" {
+		blocks = append(blocks, sdk.TextBlockParam{Text: volatile})
+	}
+	if len(blocks) == 0 {
+		return nil
+	}
+	return blocks
+}
+
+// ToMessages converts the conversation's messages into Anthropic messages.
+//
+// A system or developer message enters as the user, which is the only input
+// role Anthropic offers besides the assistant. Consecutive messages of one role
+// are merged, because Anthropic requires the roles to alternate.
+func ToMessages(msgs []frames.Message) ([]sdk.MessageParam, error) {
+	out := make([]sdk.MessageParam, 0, len(msgs))
+	for _, m := range msgs {
+		converted, err := toMessage(m)
+		if err != nil {
+			return nil, &adapter.ConversionError{Cause: err}
+		}
+		out = append(out, converted)
+	}
+	return mergeSameRole(out), nil
+}
+
+// toMessage converts one message.
+func toMessage(m frames.Message) (sdk.MessageParam, error) {
+	switch {
+	case len(m.ToolResults) > 0:
+		blocks := make([]sdk.ContentBlockParamUnion, 0, len(m.ToolResults))
+		for _, r := range m.ToolResults {
+			blocks = append(blocks, sdk.NewToolResultBlock(r.ID, r.Content, false))
+		}
+		return sdk.NewUserMessage(blocks...), nil
+	case len(m.ToolCalls) > 0:
+		return toolCallMessage(m)
+	case m.Role == frames.RoleAssistant:
+		return sdk.NewAssistantMessage(sdk.NewTextBlock(text(m.Text))), nil
+	default:
+		// A user message, and a system or developer message too: Anthropic has
+		// neither a system nor a developer input role, so all three enter as the
+		// user rather than being dropped.
+		return sdk.NewUserMessage(sdk.NewTextBlock(text(m.Text))), nil
+	}
+}
+
+// toolCallMessage renders an assistant turn that requested tool calls.
+//
+// Any text the model spoke alongside the calls is dropped. It was already
+// pushed downstream to be spoken and is committed as an assistant message of
+// its own when the turn ends, so keeping it here too would say it twice.
+func toolCallMessage(m frames.Message) (sdk.MessageParam, error) {
+	blocks := make([]sdk.ContentBlockParamUnion, 0, len(m.ToolCalls))
+	for _, c := range m.ToolCalls {
+		input := any(c.Args)
+		if len(c.Args) == 0 {
+			input = json.RawMessage("{}")
+		} else if !json.Valid(c.Args) {
+			return sdk.MessageParam{}, &argumentsError{name: c.Name, id: c.ID}
+		}
+		blocks = append(blocks, sdk.NewToolUseBlock(c.ID, input, c.Name))
+	}
+	return sdk.NewAssistantMessage(blocks...), nil
+}
+
+// argumentsError reports a tool call whose arguments are not JSON, which
+// Anthropic has no representation for: the input of a tool-use block is an
+// object, not a string.
+type argumentsError struct {
+	name string
+	id   string
+}
+
+// Error implements error.
+func (e *argumentsError) Error() string {
+	return "tool call " + e.id + " to " + e.name + " has arguments that are not valid JSON"
+}
+
+// text substitutes a placeholder for content that came out empty.
+func text(s string) string {
+	if s == "" {
+		return emptyText
+	}
+	return s
+}
+
+// mergeSameRole folds each run of same-role messages into one carrying every
+// content block in turn, because Anthropic requires the roles to alternate.
+func mergeSameRole(msgs []sdk.MessageParam) []sdk.MessageParam {
+	out := make([]sdk.MessageParam, 0, len(msgs))
+	for _, m := range msgs {
+		if n := len(out); n > 0 && out[n-1].Role == m.Role {
+			out[n-1].Content = append(out[n-1].Content, m.Content...)
+			continue
+		}
+		out = append(out, m)
+	}
+	for i := range out {
+		if len(out[i].Content) == 0 {
+			out[i].Content = []sdk.ContentBlockParamUnion{sdk.NewTextBlock(emptyText)}
+		}
+	}
+	return out
+}
+
+// EnsureLastMessageIsUser appends a minimal user message when the conversation
+// ends on an assistant message, which a model without assistant-prefill support
+// rejects.
+func EnsureLastMessageIsUser(msgs []sdk.MessageParam) []sdk.MessageParam {
+	if n := len(msgs); n > 0 && msgs[n-1].Role == sdk.MessageParamRoleAssistant {
+		return append(msgs, sdk.NewUserMessage(sdk.NewTextBlock(noOpUserTurn)))
+	}
+	return msgs
+}
+
+// WithCacheControlMarkers marks the two most recent user messages so the prompt
+// up to each is cached.
+//
+// The marker on the most recent user message tells Anthropic to cache the
+// prompt up to that point. The one on the message before it tells Anthropic to
+// look up the cache written on the previous turn, which ended there. Marking
+// only the last would write a cache on every turn and never read one back.
+//
+// User messages are the ones marked because a turn is generated as soon as the
+// user finishes speaking, and Anthropic's roles strictly alternate, so the last
+// user message is where the reusable prefix ends.
+func WithCacheControlMarkers(msgs []sdk.MessageParam) []sdk.MessageParam {
+	out := make([]sdk.MessageParam, len(msgs))
+	copy(out, msgs)
+	marked := 0
+	for i := len(out) - 1; i >= 0 && marked < 2; i-- {
+		if out[i].Role != sdk.MessageParamRoleUser || len(out[i].Content) == 0 {
+			continue
+		}
+		// The blocks are shared with the caller's messages, so the run is copied
+		// before its last block is given a marker.
+		blocks := make([]sdk.ContentBlockParamUnion, len(out[i].Content))
+		copy(blocks, out[i].Content)
+		last := &blocks[len(blocks)-1]
+		if !markCacheControl(last) {
+			continue
+		}
+		out[i].Content = blocks
+		marked++
+	}
+	return out
+}
+
+// markCacheControl puts an ephemeral cache breakpoint on a content block,
+// reporting whether the block is one that carries it.
+//
+// A block union holds its block by pointer, so the marked block is replaced by
+// a copy rather than written through: the original is shared with the
+// conversation this request was converted from.
+func markCacheControl(b *sdk.ContentBlockParamUnion) bool {
+	switch {
+	case b.OfText != nil:
+		blk := *b.OfText
+		blk.CacheControl = sdk.NewCacheControlEphemeralParam()
+		b.OfText = &blk
+	case b.OfToolResult != nil:
+		blk := *b.OfToolResult
+		blk.CacheControl = sdk.NewCacheControlEphemeralParam()
+		b.OfToolResult = &blk
+	case b.OfImage != nil:
+		blk := *b.OfImage
+		blk.CacheControl = sdk.NewCacheControlEphemeralParam()
+		b.OfImage = &blk
+	default:
+		return false
+	}
+	return true
+}
+
+// ToProviderToolsFormat implements adapter.LLMAdapter.
+func (*Adapter) ToProviderToolsFormat(tools []frames.Tool) []sdk.ToolUnionParam {
+	out := make([]sdk.ToolUnionParam, 0, len(tools))
+	for _, t := range tools {
+		var schema struct {
+			Properties json.RawMessage `json:"properties"`
+			Required   []string        `json:"required"`
+		}
+		if len(t.Parameters) > 0 {
+			_ = json.Unmarshal(t.Parameters, &schema)
+		}
+		tool := &sdk.ToolParam{
+			Name:        t.Name,
+			InputSchema: sdk.ToolInputSchemaParam{Required: schema.Required},
+		}
+		if t.Description != "" {
+			tool.Description = param.NewOpt(t.Description)
+		}
+		if len(schema.Properties) > 0 {
+			tool.InputSchema.Properties = schema.Properties
+		}
+		out = append(out, sdk.ToolUnionParam{OfTool: tool})
+	}
+	return out
+}
+
+// MessagesForLogging implements adapter.LLMAdapter.
+func (a *Adapter) MessagesForLogging(convo *frames.LLMContext) []map[string]any {
+	params, err := a.LLMInvocationParams(convo, adapter.Options{})
+	if err != nil {
+		return nil
+	}
+	out := make([]map[string]any, 0, len(params.Messages))
+	for _, m := range params.Messages {
+		raw, err := json.Marshal(m)
+		if err != nil {
+			continue
+		}
+		var got map[string]any
+		if err := json.Unmarshal(raw, &got); err != nil {
+			continue
+		}
+		out = append(out, got)
+	}
+	return out
+}

--- a/adapter/anthropic/anthropic.go
+++ b/adapter/anthropic/anthropic.go
@@ -73,7 +73,8 @@ func (a *Adapter) LLMInvocationParams(
 		Messages: converted,
 		System:   a.systemBlocks(convo, fromContext, opts),
 	}
-	if tools := a.WithBuiltins(convo.Tools()); len(tools) > 0 {
+	if tools := a.WithBuiltins(convo.ToolsSchema()); len(tools.Standard) > 0 ||
+		len(tools.Custom) > 0 {
 		params.Tools = a.ToProviderToolsFormat(tools)
 	}
 	return params, nil
@@ -333,9 +334,12 @@ func markCacheControl(b *sdk.ContentBlockParamUnion) bool {
 }
 
 // ToProviderToolsFormat implements adapter.LLMAdapter.
-func (*Adapter) ToProviderToolsFormat(tools []frames.Tool) []sdk.ToolUnionParam {
-	out := make([]sdk.ToolUnionParam, 0, len(tools))
-	for _, t := range tools {
+//
+// Anthropic takes no custom tools: it has no tool this schema cannot describe,
+// so anything under a custom key is not for it and is left out.
+func (*Adapter) ToProviderToolsFormat(schema frames.ToolsSchema) []sdk.ToolUnionParam {
+	out := make([]sdk.ToolUnionParam, 0, len(schema.Standard))
+	for _, t := range schema.Standard {
 		var schema struct {
 			Properties json.RawMessage `json:"properties"`
 			Required   []string        `json:"required"`

--- a/adapter/anthropic/anthropic_test.go
+++ b/adapter/anthropic/anthropic_test.go
@@ -1,0 +1,425 @@
+package anthropic
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	sdk "github.com/anthropics/anthropic-sdk-go"
+	"github.com/gojargo/jargo/adapter"
+	"github.com/gojargo/jargo/frames"
+)
+
+// capturedWarnings swaps the default logger for one writing into a buffer and
+// returns a reader for what was logged, restoring the logger when the test ends.
+func capturedWarnings(t *testing.T) func() string {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return buf.String
+}
+
+// paramsOf converts a conversation and fails the test if the conversion did.
+func paramsOf(t *testing.T, convo *frames.LLMContext, opts adapter.Options) Params {
+	t.Helper()
+	p, err := (&Adapter{}).LLMInvocationParams(convo, opts)
+	if err != nil {
+		t.Fatalf("LLMInvocationParams: %v", err)
+	}
+	return p
+}
+
+// wantRoles fails unless the messages carry exactly the given roles in order.
+func wantRoles(t *testing.T, msgs []sdk.MessageParam, want ...sdk.MessageParamRole) {
+	t.Helper()
+	if len(msgs) != len(want) {
+		got := make([]sdk.MessageParamRole, 0, len(msgs))
+		for _, m := range msgs {
+			got = append(got, m.Role)
+		}
+		t.Fatalf("roles = %v, want %v", got, want)
+	}
+	for i := range want {
+		if msgs[i].Role != want[i] {
+			t.Errorf("message %d role = %q, want %q", i, msgs[i].Role, want[i])
+		}
+	}
+}
+
+// textOf returns the text blocks of a message, joined, which is what most of
+// these tests compare.
+func textOf(m sdk.MessageParam) string {
+	var b strings.Builder
+	for _, blk := range m.Content {
+		if blk.OfText != nil {
+			b.WriteString(blk.OfText.Text)
+		}
+	}
+	return b.String()
+}
+
+func TestIDForLLMSpecificMessages(t *testing.T) {
+	if got := (&Adapter{}).IDForLLMSpecificMessages(); got != "anthropic" {
+		t.Errorf("id = %q, want %q", got, "anthropic")
+	}
+}
+
+// TestStandardMessagesConverted checks the conversation reaches the request with
+// the system prompt carried beside it rather than in it.
+func TestStandardMessagesConverted(t *testing.T) {
+	convo := frames.NewLLMContext("You are helpful.")
+	convo.AddUserMessage("Hello")
+	convo.AddAssistantMessage("Hi there")
+
+	p := paramsOf(t, convo, adapter.Options{})
+	wantRoles(t, p.Messages, sdk.MessageParamRoleUser, sdk.MessageParamRoleAssistant)
+	if len(p.System) != 1 || p.System[0].Text != "You are helpful." {
+		t.Errorf("system = %+v, want the conversation's prompt beside the messages", p.System)
+	}
+	if got := textOf(p.Messages[0]); got != "Hello" {
+		t.Errorf("message 0 = %q, want %q", got, "Hello")
+	}
+}
+
+// TestSystemMessagesInTheListBecomeUser checks a system message said partway
+// through the conversation enters as the user. Anthropic has no system input
+// role, and dropping the message would lose what it said.
+func TestSystemMessagesInTheListBecomeUser(t *testing.T) {
+	convo := frames.NewLLMContext("You are helpful.")
+	convo.AddUserMessage("Hello")
+	convo.AddAssistantMessage("Hi")
+	convo.AddMessage(frames.Message{Role: frames.RoleSystem, Text: "Be concise."})
+
+	p := paramsOf(t, convo, adapter.Options{})
+	wantRoles(t, p.Messages,
+		sdk.MessageParamRoleUser, sdk.MessageParamRoleAssistant, sdk.MessageParamRoleUser)
+	if got := textOf(p.Messages[2]); got != "Be concise." {
+		t.Errorf("message 2 = %q, want what the system message said", got)
+	}
+}
+
+// TestDeveloperMessagesBecomeUser checks a developer message enters as the user,
+// which is what carries an asynchronous tool's late results to a provider with
+// no developer role.
+func TestDeveloperMessagesBecomeUser(t *testing.T) {
+	convo := frames.NewLLMContext("")
+	convo.AddUserMessage("Hello")
+	convo.AddAssistantMessage("Hi")
+	convo.AddMessage(frames.Message{Role: frames.RoleDeveloper, Text: "a tool reported late"})
+
+	p := paramsOf(t, convo, adapter.Options{})
+	wantRoles(t, p.Messages,
+		sdk.MessageParamRoleUser, sdk.MessageParamRoleAssistant, sdk.MessageParamRoleUser)
+	if got := textOf(p.Messages[2]); got != "a tool reported late" {
+		t.Errorf("message 2 = %q, want what the developer message carried", got)
+	}
+}
+
+// TestConsecutiveSameRoleMerged checks two messages of one role become one
+// carrying both contents, because Anthropic requires the roles to alternate.
+func TestConsecutiveSameRoleMerged(t *testing.T) {
+	convo := frames.NewLLMContext("")
+	convo.AddUserMessage("Hello")
+	convo.AddUserMessage("Are you there?")
+	convo.AddAssistantMessage("Hi")
+
+	p := paramsOf(t, convo, adapter.Options{})
+	wantRoles(t, p.Messages, sdk.MessageParamRoleUser, sdk.MessageParamRoleAssistant)
+	if len(p.Messages[0].Content) != 2 {
+		t.Fatalf("content = %+v, want both messages kept as blocks", p.Messages[0].Content)
+	}
+	if got := textOf(p.Messages[0]); got != "HelloAre you there?" {
+		t.Errorf("merged text = %q, want both contents in turn", got)
+	}
+}
+
+// TestEmptyTextGetsAPlaceholder checks a turn that produced no text is still
+// sent: Anthropic rejects a message with no content.
+func TestEmptyTextGetsAPlaceholder(t *testing.T) {
+	convo := frames.NewLLMContext("")
+	convo.AddUserMessage("")
+
+	p := paramsOf(t, convo, adapter.Options{})
+	if got := textOf(p.Messages[0]); got != emptyText {
+		t.Errorf("text = %q, want %q", got, emptyText)
+	}
+}
+
+// TestSystemOnlyConversationBecomesAUserMessage checks a conversation carrying
+// nothing but a system prompt is sent as a user message. Sending the prompt
+// beside an empty message list is a request Anthropic rejects.
+func TestSystemOnlyConversationBecomesAUserMessage(t *testing.T) {
+	convo := frames.NewLLMContext("You are helpful.")
+
+	p := paramsOf(t, convo, adapter.Options{})
+	if len(p.System) != 0 {
+		t.Errorf("system = %+v, want none: it went into the messages", p.System)
+	}
+	wantRoles(t, p.Messages, sdk.MessageParamRoleUser)
+	if got := textOf(p.Messages[0]); got != "You are helpful." {
+		t.Errorf("message = %q, want the prompt sent as a user message", got)
+	}
+}
+
+// TestSystemOnlyConversationDoesNotMutateTheContext checks the conversation is
+// left as it was: the prompt is still its prompt, not a message.
+func TestSystemOnlyConversationDoesNotMutateTheContext(t *testing.T) {
+	convo := frames.NewLLMContext("You are helpful.")
+	paramsOf(t, convo, adapter.Options{})
+
+	if got := convo.System(); got != "You are helpful." {
+		t.Errorf("system = %q, want the conversation's prompt untouched", got)
+	}
+	if got := convo.Messages(); len(got) != 0 {
+		t.Errorf("messages = %+v, want the conversation still empty", got)
+	}
+}
+
+// TestSystemInstructionReplacesTheContextPrompt checks that an instruction given
+// for one call stands in place of the conversation's own. Anthropic has one
+// field for it, so the two cannot both be sent.
+func TestSystemInstructionReplacesTheContextPrompt(t *testing.T) {
+	convo := frames.NewLLMContext("You are helpful.")
+	convo.AddUserMessage("Hello")
+	warnings := capturedWarnings(t)
+
+	p := paramsOf(t, convo, adapter.Options{SystemInstruction: "Be concise."})
+
+	if len(p.System) != 1 || p.System[0].Text != "Be concise." {
+		t.Errorf("system = %+v, want the call's instruction", p.System)
+	}
+	if got := warnings(); !strings.Contains(got, "using the instruction") {
+		t.Errorf("warnings = %q, want the conflict reported", got)
+	}
+}
+
+// TestSystemInstructionOnly checks an instruction given for a call, with no
+// prompt on the conversation, is sent on its own and reported as no conflict.
+func TestSystemInstructionOnly(t *testing.T) {
+	convo := frames.NewLLMContext("")
+	convo.AddUserMessage("Hello")
+	warnings := capturedWarnings(t)
+
+	p := paramsOf(t, convo, adapter.Options{SystemInstruction: "Be helpful."})
+
+	if len(p.System) != 1 || p.System[0].Text != "Be helpful." {
+		t.Errorf("system = %+v, want the instruction", p.System)
+	}
+	if got := warnings(); got != "" {
+		t.Errorf("warnings = %q, want none", got)
+	}
+}
+
+// TestDeveloperMessageWithInstructionDoesNotWarn checks the conflict is about
+// the system prompt alone: a developer message carries no instruction to clash
+// with.
+func TestDeveloperMessageWithInstructionDoesNotWarn(t *testing.T) {
+	convo := frames.NewLLMContext("")
+	convo.AddMessage(frames.Message{Role: frames.RoleDeveloper, Text: "Extra context."})
+	convo.AddUserMessage("Hello")
+	warnings := capturedWarnings(t)
+
+	paramsOf(t, convo, adapter.Options{SystemInstruction: "Be concise."})
+
+	if got := warnings(); got != "" {
+		t.Errorf("warnings = %q, want none", got)
+	}
+}
+
+// TestEnsureLastMessageIsUser checks the trailing user turn a model without
+// assistant-prefill support needs, and that nothing is added when the
+// conversation already ends the right way.
+func TestEnsureLastMessageIsUser(t *testing.T) {
+	user := sdk.NewUserMessage(sdk.NewTextBlock("hi"))
+	assistant := sdk.NewAssistantMessage(sdk.NewTextBlock("hello"))
+
+	got := EnsureLastMessageIsUser([]sdk.MessageParam{user, assistant})
+	if len(got) != 3 || got[2].Role != sdk.MessageParamRoleUser {
+		t.Fatalf("ending on assistant should append a user message; got %d messages", len(got))
+	}
+
+	got = EnsureLastMessageIsUser([]sdk.MessageParam{assistant, user})
+	if len(got) != 2 {
+		t.Fatalf("ending on user should be unchanged; got %d messages", len(got))
+	}
+
+	if got := EnsureLastMessageIsUser(nil); len(got) != 0 {
+		t.Fatalf("empty list should stay empty; got %d messages", len(got))
+	}
+}
+
+// TestEnsureLastMessageIsUserLeavesAToolResult checks a conversation ending on
+// a tool result is left alone: a tool result is a user message already.
+func TestEnsureLastMessageIsUserLeavesAToolResult(t *testing.T) {
+	convo := frames.NewLLMContext("")
+	convo.AddUserMessage("weather?")
+	convo.AddAssistantToolCall(frames.ToolCall{ID: "c1", Name: "get_weather"})
+	convo.AddToolResult(frames.ToolResult{ID: "c1", Name: "get_weather", Content: "sunny"})
+
+	p := paramsOf(t, convo, adapter.Options{EnsureLastMessageIsUser: true})
+	wantRoles(t, p.Messages,
+		sdk.MessageParamRoleUser, sdk.MessageParamRoleAssistant, sdk.MessageParamRoleUser)
+}
+
+// TestMalformedToolCallIsAConversionError checks a tool call whose arguments are
+// not JSON is reported as a conversion failure rather than sent: Anthropic takes
+// a tool-use input as an object, so there is nothing to send.
+func TestMalformedToolCallIsAConversionError(t *testing.T) {
+	convo := frames.NewLLMContext("")
+	convo.AddAssistantToolCall(frames.ToolCall{ID: "c1", Name: "f", Args: []byte("not json")})
+
+	_, err := (&Adapter{}).LLMInvocationParams(convo, adapter.Options{})
+	if err == nil {
+		t.Fatal("LLMInvocationParams succeeded, want a conversion error")
+	}
+	var convErr *adapter.ConversionError
+	if !errors.As(err, &convErr) {
+		t.Fatalf("err = %v, want an adapter.ConversionError", err)
+	}
+}
+
+// TestToMessagesBuildsToolTurns checks a tool turn reaches the request as a
+// tool-use block and the tool-result block answering it.
+func TestToMessagesBuildsToolTurns(t *testing.T) {
+	msgs := []frames.Message{
+		{Role: frames.RoleUser, Text: "weather?"},
+		{Role: frames.RoleAssistant, ToolCalls: []frames.ToolCall{
+			{ID: "c1", Name: "get_weather", Args: json.RawMessage(`{"location":"Paris"}`)},
+		}},
+		{Role: frames.RoleUser, ToolResults: []frames.ToolResult{
+			{ID: "c1", Name: "get_weather", Content: "sunny"},
+		}},
+		{Role: frames.RoleAssistant, Text: "It is sunny."},
+	}
+	out, err := ToMessages(msgs)
+	if err != nil {
+		t.Fatalf("ToMessages: %v", err)
+	}
+	if len(out) != 4 {
+		t.Fatalf("len = %d, want 4", len(out))
+	}
+	b, err := json.Marshal(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	for _, want := range []string{
+		`"tool_use"`, `"c1"`, `"get_weather"`, `"tool_result"`, `"tool_use_id":"c1"`, `sunny`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Fatalf("messages JSON missing %q:\n%s", want, s)
+		}
+	}
+}
+
+// TestToProviderToolsFormatMapsSchema checks an advertised tool reaches the
+// request with its JSON-Schema properties and required list.
+func TestToProviderToolsFormatMapsSchema(t *testing.T) {
+	tools := []frames.Tool{{
+		Name:        "get_weather",
+		Description: "Get the weather",
+		Parameters: json.RawMessage(
+			`{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}`,
+		),
+	}}
+	out := (&Adapter{}).ToProviderToolsFormat(tools)
+	if len(out) != 1 {
+		t.Fatalf("len = %d, want 1", len(out))
+	}
+	b, err := json.Marshal(out[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	for _, want := range []string{
+		`"name":"get_weather"`, `"Get the weather"`, `"location"`, `"required":["location"]`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Fatalf("tool JSON %s missing %q", s, want)
+		}
+	}
+}
+
+// TestCacheControlMarksTheLastTwoUserMessages checks the prompt is cached up to
+// the most recent user message and looked up from the one before it. Marking
+// only the last would write a cache every turn and never read one back.
+func TestCacheControlMarksTheLastTwoUserMessages(t *testing.T) {
+	convo := frames.NewLLMContext("be helpful")
+	convo.AddUserMessage("one")
+	convo.AddAssistantMessage("a")
+	convo.AddUserMessage("two")
+	convo.AddAssistantMessage("b")
+	convo.AddUserMessage("three")
+
+	p := paramsOf(t, convo, adapter.Options{EnablePromptCaching: true})
+	marked := make([]int, 0, 2)
+	for i, m := range p.Messages {
+		for _, blk := range m.Content {
+			if blk.OfText != nil && blk.OfText.CacheControl.Type != "" {
+				marked = append(marked, i)
+			}
+		}
+	}
+	// Messages 0, 2 and 4 are the user turns; the last two are 2 and 4.
+	if len(marked) != 2 || marked[0] != 2 || marked[1] != 4 {
+		t.Errorf("marked messages %v, want the last two user turns (2 and 4)", marked)
+	}
+}
+
+// TestCacheControlIsOffByRequest checks nothing is marked when caching is not
+// asked for.
+func TestCacheControlIsOffByRequest(t *testing.T) {
+	convo := frames.NewLLMContext("be helpful")
+	convo.AddUserMessage("one")
+
+	p := paramsOf(t, convo, adapter.Options{})
+	for _, m := range p.Messages {
+		for _, blk := range m.Content {
+			if blk.OfText != nil && blk.OfText.CacheControl.Type != "" {
+				t.Errorf("message %+v is marked, want no cache control", m)
+			}
+		}
+	}
+	if len(p.System) != 1 || p.System[0].CacheControl.Type != "" {
+		t.Errorf("system = %+v, want it unmarked", p.System)
+	}
+}
+
+// TestCacheControlDoesNotMutateTheSource checks the marking leaves the caller's
+// messages alone: the blocks are shared with whoever converted the conversation.
+func TestCacheControlDoesNotMutateTheSource(t *testing.T) {
+	msgs, err := ToMessages([]frames.Message{{Role: frames.RoleUser, Text: "hello"}})
+	if err != nil {
+		t.Fatalf("ToMessages: %v", err)
+	}
+	WithCacheControlMarkers(msgs)
+	if msgs[0].Content[0].OfText.CacheControl.Type != "" {
+		t.Error("the source message was marked, want it left as it was")
+	}
+}
+
+// TestSystemPromptKeepsTheCachedPrefixStable checks the cache breakpoint falls
+// on the part of the prompt that survives between turns. The recalled context a
+// memory service refreshes every turn sits outside it, so the cached prefix
+// stays byte-identical and is read back rather than rewritten.
+func TestSystemPromptKeepsTheCachedPrefixStable(t *testing.T) {
+	convo := frames.NewLLMContext("be helpful")
+	convo.AddUserMessage("hi")
+	convo.SetRecall("the user likes tea")
+
+	p := paramsOf(t, convo, adapter.Options{EnablePromptCaching: true})
+	if len(p.System) != 2 {
+		t.Fatalf("system = %+v, want the prompt split at its first volatile point", p.System)
+	}
+	if p.System[0].Text != "be helpful" || p.System[0].CacheControl.Type == "" {
+		t.Errorf("block 0 = %+v, want the stable prompt marked", p.System[0])
+	}
+	if p.System[1].Text != "the user likes tea" || p.System[1].CacheControl.Type != "" {
+		t.Errorf("block 1 = %+v, want the recalled context outside the breakpoint", p.System[1])
+	}
+}

--- a/adapter/anthropic/anthropic_test.go
+++ b/adapter/anthropic/anthropic_test.go
@@ -327,7 +327,7 @@ func TestToProviderToolsFormatMapsSchema(t *testing.T) {
 			`{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}`,
 		),
 	}}
-	out := (&Adapter{}).ToProviderToolsFormat(tools)
+	out := (&Adapter{}).ToProviderToolsFormat(frames.ToolsSchema{Standard: tools})
 	if len(out) != 1 {
 		t.Fatalf("len = %d, want 1", len(out))
 	}

--- a/adapter/anthropic/anthropic_test.go
+++ b/adapter/anthropic/anthropic_test.go
@@ -423,3 +423,71 @@ func TestSystemPromptKeepsTheCachedPrefixStable(t *testing.T) {
 		t.Errorf("block 1 = %+v, want the recalled context outside the breakpoint", p.System[1])
 	}
 }
+
+// TestThoughtBecomesAThinkingBlock checks a reasoning block kept in the
+// conversation is handed back as a thinking block, which is what lets the model
+// carry its reasoning across a turn.
+func TestThoughtBecomesAThinkingBlock(t *testing.T) {
+	convo := frames.NewLLMContext("")
+	convo.AddUserMessage("hello")
+	convo.AddMessage(NewThought(Thought{Text: "let me think", Signature: "sig"}))
+
+	p := paramsOf(t, convo, adapter.Options{})
+	wantRoles(t, p.Messages, sdk.MessageParamRoleUser, sdk.MessageParamRoleAssistant)
+	blk := p.Messages[1].Content[0]
+	if blk.OfThinking == nil {
+		t.Fatalf("block = %+v, want a thinking block", blk)
+	}
+	if blk.OfThinking.Thinking != "let me think" || blk.OfThinking.Signature != "sig" {
+		t.Errorf("thinking block = %+v, want the thought it was written with", blk.OfThinking)
+	}
+}
+
+// TestThoughtWithEmptyTextIsKept checks a model set to omit its reasoning still
+// round-trips: the block carries no text but the signature is what matters.
+func TestThoughtWithEmptyTextIsKept(t *testing.T) {
+	convo := frames.NewLLMContext("")
+	convo.AddMessage(NewThought(Thought{Signature: "sig"}))
+
+	p := paramsOf(t, convo, adapter.Options{})
+	if len(p.Messages) != 1 || p.Messages[0].Content[0].OfThinking == nil {
+		t.Fatalf("messages = %+v, want the thinking block kept", p.Messages)
+	}
+}
+
+// TestThoughtWithoutSignatureIsDropped checks a thought that cannot be
+// round-tripped is left out rather than sent: Anthropic decrypts a thinking
+// block by its signature, and refuses one without.
+func TestThoughtWithoutSignatureIsDropped(t *testing.T) {
+	convo := frames.NewLLMContext("")
+	convo.AddUserMessage("hello")
+	convo.AddMessage(NewThought(Thought{Text: "unsigned"}))
+
+	p := paramsOf(t, convo, adapter.Options{})
+	wantRoles(t, p.Messages, sdk.MessageParamRoleUser)
+}
+
+// TestNativeAnthropicMessagePassedThrough checks a message already written in
+// Anthropic's own format is sent as it stands.
+func TestNativeAnthropicMessagePassedThrough(t *testing.T) {
+	convo := frames.NewLLMContext("")
+	convo.AddMessage(adapter.CreateLLMSpecificMessage(
+		&Adapter{}, sdk.NewAssistantMessage(sdk.NewTextBlock("written for anthropic")),
+	))
+
+	p := paramsOf(t, convo, adapter.Options{})
+	if len(p.Messages) != 1 || textOf(p.Messages[0]) != "written for anthropic" {
+		t.Errorf("messages = %+v, want the provider's own message", p.Messages)
+	}
+}
+
+// TestAnotherProvidersMessageIsLeftOut checks a message written for a different
+// provider never reaches this one.
+func TestAnotherProvidersMessageIsLeftOut(t *testing.T) {
+	convo := frames.NewLLMContext("")
+	convo.AddUserMessage("hello")
+	convo.AddMessage(frames.NewLLMSpecificMessage("openai", "not for anthropic"))
+
+	p := paramsOf(t, convo, adapter.Options{})
+	wantRoles(t, p.Messages, sdk.MessageParamRoleUser)
+}

--- a/adapter/customtools_test.go
+++ b/adapter/customtools_test.go
@@ -1,0 +1,112 @@
+package adapter_test
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/gojargo/jargo/adapter"
+	"github.com/gojargo/jargo/adapter/gemini"
+	openaiadapter "github.com/gojargo/jargo/adapter/openai"
+	"github.com/gojargo/jargo/frames"
+)
+
+// TestCustomToolsReachTheirOwnAdapter checks a tool written for one format is
+// advertised by that provider and by no other.
+func TestCustomToolsReachTheirOwnAdapter(t *testing.T) {
+	schema := frames.ToolsSchema{
+		Standard: []frames.Tool{{Name: "get_weather"}},
+		Custom: map[frames.AdapterType][]any{
+			frames.AdapterTypeOpenAI: {openaiadapter.Tool{
+				Raw: map[string]any{"type": "web_search_preview"},
+			}},
+			frames.AdapterTypeGemini: {map[string]any{"google_search": map[string]any{}}},
+		},
+	}
+
+	openaiTools := (&openaiadapter.Adapter{}).ToProviderToolsFormat(schema)
+	if len(openaiTools) != 2 {
+		t.Fatalf("openai tools = %+v, want the standard one and openai's custom", openaiTools)
+	}
+	if openaiTools[1].Raw["type"] != "web_search_preview" {
+		t.Errorf("custom tool = %+v, want openai's own", openaiTools[1])
+	}
+
+	geminiTools := (&gemini.Adapter{}).ToProviderToolsFormat(schema)
+	if len(geminiTools) != 2 {
+		t.Fatalf("gemini tools = %+v, want the declarations and gemini's custom", geminiTools)
+	}
+	if _, ok := geminiTools[1]["google_search"]; !ok {
+		t.Errorf("custom tool = %+v, want gemini's own", geminiTools[1])
+	}
+}
+
+// TestCustomToolGoesOutWhole checks a provider-native tool reaches the wire
+// exactly as it was written, rather than being forced into the function shape
+// the modeled fields describe.
+func TestCustomToolGoesOutWhole(t *testing.T) {
+	raw, err := json.Marshal(openaiadapter.Tool{
+		Raw: map[string]any{"type": "web_search_preview"},
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if string(raw) != `{"type":"web_search_preview"}` {
+		t.Errorf("encoded = %s, want the tool exactly as it was written", raw)
+	}
+}
+
+// TestStandardToolStillEncodesAsAFunction checks the escape hatch changes
+// nothing for a tool that fits the schema.
+func TestStandardToolStillEncodesAsAFunction(t *testing.T) {
+	raw, err := json.Marshal(openaiadapter.Tool{
+		Type:     "function",
+		Function: openaiadapter.Function{Name: "get_weather"},
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got["type"] != "function" {
+		t.Errorf("encoded = %s, want a function tool", raw)
+	}
+}
+
+// TestCustomToolsForRejectsAnotherType checks a custom tool holding something
+// its adapter cannot read is reported rather than sent as whatever it is.
+func TestCustomToolsForRejectsAnotherType(t *testing.T) {
+	schema := frames.ToolsSchema{
+		Custom: map[frames.AdapterType][]any{
+			frames.AdapterTypeGemini: {"a bare string"},
+		},
+	}
+	_, err := adapter.CustomToolsFor[map[string]any](schema, frames.AdapterTypeGemini)
+	if err == nil {
+		t.Fatal("CustomToolsFor succeeded, want a conversion error")
+	}
+	var convErr *adapter.ConversionError
+	if !errors.As(err, &convErr) {
+		t.Fatalf("err = %v, want an adapter.ConversionError", err)
+	}
+}
+
+// TestGeminiOmitsDeclarationsWithoutStandardTools checks a conversation
+// advertising only a custom tool sends that alone, with no empty declarations
+// block beside it.
+func TestGeminiOmitsDeclarationsWithoutStandardTools(t *testing.T) {
+	schema := frames.ToolsSchema{
+		Custom: map[frames.AdapterType][]any{
+			frames.AdapterTypeGemini: {map[string]any{"google_search": map[string]any{}}},
+		},
+	}
+	tools := (&gemini.Adapter{}).ToProviderToolsFormat(schema)
+	if len(tools) != 1 {
+		t.Fatalf("tools = %+v, want only the custom one", tools)
+	}
+	if _, ok := tools[0]["functionDeclarations"]; ok {
+		t.Errorf("tools = %+v, want no empty declarations block", tools)
+	}
+}

--- a/adapter/gemini/gemini.go
+++ b/adapter/gemini/gemini.go
@@ -4,6 +4,7 @@ package gemini
 
 import (
 	"encoding/json"
+	"log/slog"
 
 	"github.com/gojargo/jargo/adapter"
 	"github.com/gojargo/jargo/frames"
@@ -78,7 +79,8 @@ func (a *Adapter) LLMInvocationParams(
 	contents = dropEmpty(contents)
 
 	params := Params{SystemInstruction: system, Contents: contents}
-	if tools := a.WithBuiltins(convo.Tools()); len(tools) > 0 {
+	if tools := a.WithBuiltins(convo.ToolsSchema()); len(tools.Standard) > 0 ||
+		len(tools.Custom) > 0 {
 		params.Tools = a.ToProviderToolsFormat(tools)
 	}
 	return params, nil
@@ -222,21 +224,34 @@ func FunctionResponseDict(content string) any {
 	return map[string]any{"value": content}
 }
 
-// ToProviderToolsFormat implements adapter.LLMAdapter, rendering the tools as
-// Gemini functionDeclarations.
-func (*Adapter) ToProviderToolsFormat(tools []frames.Tool) []map[string]any {
-	decls := make([]map[string]any, 0, len(tools))
-	for _, t := range tools {
-		d := map[string]any{keyName: t.Name}
-		if t.Description != "" {
-			d["description"] = t.Description
+// ToProviderToolsFormat implements adapter.LLMAdapter, rendering the standard
+// tools as Gemini functionDeclarations and appending the custom tools written
+// for Gemini beside them.
+func (*Adapter) ToProviderToolsFormat(schema frames.ToolsSchema) []map[string]any {
+	var out []map[string]any
+	if len(schema.Standard) > 0 {
+		decls := make([]map[string]any, 0, len(schema.Standard))
+		for _, t := range schema.Standard {
+			d := map[string]any{keyName: t.Name}
+			if t.Description != "" {
+				d["description"] = t.Description
+			}
+			if params := geminiParameters(t.Parameters); params != nil {
+				d["parameters"] = params
+			}
+			decls = append(decls, d)
 		}
-		if params := geminiParameters(t.Parameters); params != nil {
-			d["parameters"] = params
-		}
-		decls = append(decls, d)
+		out = append(out, map[string]any{"functionDeclarations": decls})
 	}
-	return []map[string]any{{"functionDeclarations": decls}}
+	// A custom tool that cannot be read is left out rather than failing the whole
+	// conversion: the tools are advertised alongside a conversation that is
+	// otherwise sendable.
+	custom, err := adapter.CustomToolsFor[map[string]any](schema, frames.AdapterTypeGemini)
+	if err != nil {
+		slog.Error("leaving out a custom tool the adapter cannot read", "err", err)
+		return out
+	}
+	return append(out, custom...)
 }
 
 // geminiParameters returns the tool's JSON-Schema parameters with

--- a/adapter/gemini/gemini.go
+++ b/adapter/gemini/gemini.go
@@ -60,11 +60,15 @@ func (a *Adapter) LLMInvocationParams(
 	convo *frames.LLMContext, opts adapter.Options,
 ) (Params, error) {
 	fromContext, msgs := a.ExtractInitialSystem(
-		a.SystemWithBuiltins(convo.System()), opts.SystemInstruction, convo.Messages(),
+		a.SystemWithBuiltins(convo.System()), opts.SystemInstruction,
+		convo.MessagesFor(a.IDForLLMSpecificMessages()),
 	)
 	system := a.ResolveSystemInstruction(fromContext, opts.SystemInstruction, true)
 
-	contents := ToContents(msgs)
+	contents, err := ToContents(msgs)
+	if err != nil {
+		return Params{}, err
+	}
 	// A conversation of nothing but tool turns gives the model no prose to answer,
 	// and Gemini reads the system instruction as framing rather than as something
 	// to act on. Saying it again as a user message is what prompts a reply.
@@ -85,11 +89,17 @@ func (a *Adapter) LLMInvocationParams(
 // the user, Gemini having neither input role. Tool turns become functionCall
 // parts (model) and functionResponse parts (user), paired by the call id
 // carried on both.
-func ToContents(msgs []frames.Message) []map[string]any {
+func ToContents(msgs []frames.Message) ([]map[string]any, error) {
 	names := toolCallNames(msgs)
 	out := make([]map[string]any, 0, len(msgs))
 	for _, m := range msgs {
 		switch {
+		case m.IsLLMSpecific():
+			native, err := adapter.NativeMessage[map[string]any](m)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, native)
 		case len(m.ToolResults) > 0:
 			out = append(out, map[string]any{
 				keyRole: roleUser, keyParts: toolResultParts(m.ToolResults, names),
@@ -106,7 +116,7 @@ func ToContents(msgs []frames.Message) []map[string]any {
 			out = append(out, textContent(role, m.Text))
 		}
 	}
-	return out
+	return out, nil
 }
 
 // textContent builds a content carrying one text part.

--- a/adapter/gemini/gemini.go
+++ b/adapter/gemini/gemini.go
@@ -1,0 +1,269 @@
+// Package gemini converts a universal conversation into the request Gemini
+// takes, and with it Vertex AI, which serves the same models.
+package gemini
+
+import (
+	"encoding/json"
+
+	"github.com/gojargo/jargo/adapter"
+	"github.com/gojargo/jargo/frames"
+)
+
+// The keys Gemini's generateContent body is built from.
+const (
+	keyRole  = "role"
+	keyParts = "parts"
+	keyName  = "name"
+	keyText  = "text"
+	keyID    = "id"
+)
+
+// The roles Gemini's contents take. It calls the assistant the model, and has
+// no system or developer input role: a message in either enters as the user.
+const (
+	roleUser  = "user"
+	roleModel = "model"
+)
+
+// unnamedToolResult names a tool result whose call cannot be found. Gemini
+// requires a name on every functionResponse, and a result can outlive the call
+// it answers: an asynchronous tool's messages carry only the call's id.
+const unnamedToolResult = "tool_call_result"
+
+// Params is what one generateContent call takes from the conversation: the
+// system instruction Gemini carries beside the conversation, the contents
+// themselves, and the tools to advertise.
+type Params struct {
+	SystemInstruction string
+	Contents          []map[string]any
+	Tools             []map[string]any
+}
+
+// Adapter converts a universal conversation into a Gemini request. The zero
+// value is ready to use.
+type Adapter struct {
+	adapter.Base
+}
+
+// Compile-time check that the adapter satisfies the contract.
+var _ adapter.LLMAdapter[Params, map[string]any] = (*Adapter)(nil)
+
+// IDForLLMSpecificMessages implements adapter.LLMAdapter.
+func (*Adapter) IDForLLMSpecificMessages() string { return "google" }
+
+// LLMInvocationParams converts the conversation into a generateContent request.
+//
+// Gemini carries the system instruction beside the conversation rather than in
+// it, so it has one field to put it in: an instruction given for this call
+// replaces the conversation's own prompt rather than supplementing it.
+func (a *Adapter) LLMInvocationParams(
+	convo *frames.LLMContext, opts adapter.Options,
+) (Params, error) {
+	fromContext, msgs := a.ExtractInitialSystem(
+		convo.System(), opts.SystemInstruction, convo.Messages(),
+	)
+	system := a.ResolveSystemInstruction(fromContext, opts.SystemInstruction, true)
+
+	contents := ToContents(msgs)
+	// A conversation of nothing but tool turns gives the model no prose to answer,
+	// and Gemini reads the system instruction as framing rather than as something
+	// to act on. Saying it again as a user message is what prompts a reply.
+	if system != "" && !hasProse(contents) {
+		contents = append(contents, textContent(roleUser, system))
+	}
+	contents = dropEmpty(contents)
+
+	params := Params{SystemInstruction: system, Contents: contents}
+	if tools := convo.Tools(); len(tools) > 0 {
+		params.Tools = a.ToProviderToolsFormat(tools)
+	}
+	return params, nil
+}
+
+// ToContents converts the conversation's messages into Gemini contents. The
+// assistant role maps to "model", and a system or developer message enters as
+// the user, Gemini having neither input role. Tool turns become functionCall
+// parts (model) and functionResponse parts (user), paired by the call id
+// carried on both.
+func ToContents(msgs []frames.Message) []map[string]any {
+	names := toolCallNames(msgs)
+	out := make([]map[string]any, 0, len(msgs))
+	for _, m := range msgs {
+		switch {
+		case len(m.ToolResults) > 0:
+			out = append(out, map[string]any{
+				keyRole: roleUser, keyParts: toolResultParts(m.ToolResults, names),
+			})
+		case len(m.ToolCalls) > 0:
+			out = append(out, map[string]any{
+				keyRole: roleModel, keyParts: toolCallParts(m.Text, m.ToolCalls),
+			})
+		default:
+			role := roleUser
+			if m.Role == frames.RoleAssistant {
+				role = roleModel
+			}
+			out = append(out, textContent(role, m.Text))
+		}
+	}
+	return out
+}
+
+// textContent builds a content carrying one text part.
+func textContent(role, text string) map[string]any {
+	return map[string]any{keyRole: role, keyParts: []map[string]any{{keyText: text}}}
+}
+
+// hasProse reports whether any content is something the model said or was told
+// in words, as opposed to a tool call or its result.
+func hasProse(contents []map[string]any) bool {
+	for _, c := range contents {
+		parts, ok := c[keyParts].([]map[string]any)
+		if !ok || len(parts) != 1 {
+			continue
+		}
+		if text, ok := parts[0][keyText].(string); ok && text != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// dropEmpty removes contents carrying no parts, which Gemini rejects.
+func dropEmpty(contents []map[string]any) []map[string]any {
+	out := make([]map[string]any, 0, len(contents))
+	for _, c := range contents {
+		if parts, ok := c[keyParts].([]map[string]any); ok && len(parts) > 0 {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// toolCallNames maps each tool call in the conversation to the name it was made
+// with, so a result can be named after the call it answers rather than after
+// whatever it happens to carry itself.
+func toolCallNames(msgs []frames.Message) map[string]string {
+	names := make(map[string]string)
+	for _, m := range msgs {
+		for _, c := range m.ToolCalls {
+			names[c.ID] = c.Name
+		}
+	}
+	return names
+}
+
+// toolCallParts renders an assistant turn's optional preamble and tool calls as
+// Gemini parts.
+func toolCallParts(text string, calls []frames.ToolCall) []map[string]any {
+	parts := make([]map[string]any, 0, len(calls)+1)
+	if text != "" {
+		parts = append(parts, map[string]any{keyText: text})
+	}
+	for _, c := range calls {
+		args := c.Args
+		if len(args) == 0 {
+			args = json.RawMessage("{}")
+		}
+		parts = append(parts, map[string]any{
+			"functionCall": map[string]any{keyID: c.ID, keyName: c.Name, "args": args},
+		})
+	}
+	return parts
+}
+
+// toolResultParts renders tool outputs as Gemini functionResponse parts. Each
+// carries the id of the call it answers, which is what tells apart the results
+// of a batch of parallel calls to the same tool.
+func toolResultParts(results []frames.ToolResult, names map[string]string) []map[string]any {
+	parts := make([]map[string]any, 0, len(results))
+	for _, r := range results {
+		parts = append(parts, map[string]any{
+			"functionResponse": map[string]any{
+				keyID:      r.ID,
+				keyName:    toolResultName(r, names),
+				"response": FunctionResponseDict(r.Content),
+			},
+		})
+	}
+	return parts
+}
+
+// toolResultName names a result after the call it answers, falling back to the
+// name recorded on the result itself and then to a placeholder.
+func toolResultName(r frames.ToolResult, names map[string]string) string {
+	if name, ok := names[r.ID]; ok && name != "" {
+		return name
+	}
+	if r.Name != "" {
+		return r.Name
+	}
+	return unnamedToolResult
+}
+
+// FunctionResponseDict shapes a tool result for Gemini's functionResponse,
+// which requires an object: a JSON object passes through, anything else is
+// wrapped as {"value": content}.
+func FunctionResponseDict(content string) any {
+	var obj map[string]any
+	if json.Unmarshal([]byte(content), &obj) == nil {
+		return json.RawMessage(content)
+	}
+	return map[string]any{"value": content}
+}
+
+// ToProviderToolsFormat implements adapter.LLMAdapter, rendering the tools as
+// Gemini functionDeclarations.
+func (*Adapter) ToProviderToolsFormat(tools []frames.Tool) []map[string]any {
+	decls := make([]map[string]any, 0, len(tools))
+	for _, t := range tools {
+		d := map[string]any{keyName: t.Name}
+		if t.Description != "" {
+			d["description"] = t.Description
+		}
+		if params := geminiParameters(t.Parameters); params != nil {
+			d["parameters"] = params
+		}
+		decls = append(decls, d)
+	}
+	return []map[string]any{{"functionDeclarations": decls}}
+}
+
+// geminiParameters returns the tool's JSON-Schema parameters with
+// "additionalProperties" stripped (Gemini rejects it). On a parse error the raw
+// schema passes through unchanged.
+func geminiParameters(raw json.RawMessage) any {
+	if len(raw) == 0 {
+		return nil
+	}
+	var schema map[string]any
+	if json.Unmarshal(raw, &schema) != nil {
+		return raw
+	}
+	stripAdditionalProperties(schema)
+	return schema
+}
+
+// stripAdditionalProperties recursively removes "additionalProperties" keys.
+func stripAdditionalProperties(v any) {
+	switch t := v.(type) {
+	case map[string]any:
+		delete(t, "additionalProperties")
+		for _, val := range t {
+			stripAdditionalProperties(val)
+		}
+	case []any:
+		for _, val := range t {
+			stripAdditionalProperties(val)
+		}
+	}
+}
+
+// MessagesForLogging implements adapter.LLMAdapter.
+func (a *Adapter) MessagesForLogging(convo *frames.LLMContext) []map[string]any {
+	params, err := a.LLMInvocationParams(convo, adapter.Options{})
+	if err != nil {
+		return nil
+	}
+	return params.Contents
+}

--- a/adapter/gemini/gemini.go
+++ b/adapter/gemini/gemini.go
@@ -60,7 +60,7 @@ func (a *Adapter) LLMInvocationParams(
 	convo *frames.LLMContext, opts adapter.Options,
 ) (Params, error) {
 	fromContext, msgs := a.ExtractInitialSystem(
-		convo.System(), opts.SystemInstruction, convo.Messages(),
+		a.SystemWithBuiltins(convo.System()), opts.SystemInstruction, convo.Messages(),
 	)
 	system := a.ResolveSystemInstruction(fromContext, opts.SystemInstruction, true)
 
@@ -74,7 +74,7 @@ func (a *Adapter) LLMInvocationParams(
 	contents = dropEmpty(contents)
 
 	params := Params{SystemInstruction: system, Contents: contents}
-	if tools := convo.Tools(); len(tools) > 0 {
+	if tools := a.WithBuiltins(convo.Tools()); len(tools) > 0 {
 		params.Tools = a.ToProviderToolsFormat(tools)
 	}
 	return params, nil

--- a/adapter/gemini/gemini_test.go
+++ b/adapter/gemini/gemini_test.go
@@ -56,6 +56,16 @@ func textAt(t *testing.T, c map[string]any) string {
 	return text
 }
 
+// mustContents converts messages and fails the test if the conversion did.
+func mustContents(t *testing.T, msgs []frames.Message) []map[string]any {
+	t.Helper()
+	got, err := ToContents(msgs)
+	if err != nil {
+		t.Fatalf("ToContents: %v", err)
+	}
+	return got
+}
+
 func TestIDForLLMSpecificMessages(t *testing.T) {
 	if got := (&Adapter{}).IDForLLMSpecificMessages(); got != "google" {
 		t.Errorf("id = %q, want %q", got, "google")
@@ -184,7 +194,7 @@ func TestToolResultNamedAfterItsCall(t *testing.T) {
 		{Role: frames.RoleAssistant, ToolCalls: []frames.ToolCall{{ID: "c1", Name: "get_weather"}}},
 		{Role: frames.RoleUser, ToolResults: []frames.ToolResult{{ID: "c1", Content: "sunny"}}},
 	}
-	b, err := json.Marshal(ToContents(msgs))
+	b, err := json.Marshal(mustContents(t, msgs))
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
@@ -199,7 +209,7 @@ func TestUnnamedToolResultGetsAPlaceholder(t *testing.T) {
 	msgs := []frames.Message{
 		{Role: frames.RoleUser, ToolResults: []frames.ToolResult{{ID: "gone", Content: "sunny"}}},
 	}
-	b, err := json.Marshal(ToContents(msgs))
+	b, err := json.Marshal(mustContents(t, msgs))
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
@@ -216,7 +226,7 @@ func TestToContentsToolTurn(t *testing.T) {
 	})
 	convo.AddToolResult(frames.ToolResult{ID: "call_0", Name: "get_weather", Content: "sunny"})
 
-	b, err := json.Marshal(ToContents(convo.Messages()))
+	b, err := json.Marshal(mustContents(t, convo.Messages()))
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}

--- a/adapter/gemini/gemini_test.go
+++ b/adapter/gemini/gemini_test.go
@@ -260,11 +260,11 @@ func TestFunctionResponseDict(t *testing.T) {
 }
 
 func TestToProviderToolsFormatStripsAdditionalProperties(t *testing.T) {
-	out := (&Adapter{}).ToProviderToolsFormat([]frames.Tool{{
+	out := (&Adapter{}).ToProviderToolsFormat(frames.ToolsSchema{Standard: []frames.Tool{{
 		Name:        "get_weather",
 		Description: "Look up the weather",
 		Parameters:  json.RawMessage(`{"type":"object","additionalProperties":false,"properties":{"loc":{"type":"string"}}}`),
-	}})
+	}}})
 	b, err := json.Marshal(out)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)

--- a/adapter/gemini/gemini_test.go
+++ b/adapter/gemini/gemini_test.go
@@ -1,0 +1,269 @@
+package gemini
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/gojargo/jargo/adapter"
+	"github.com/gojargo/jargo/frames"
+)
+
+// capturedWarnings swaps the default logger for one writing into a buffer and
+// returns a reader for what was logged, restoring the logger when the test ends.
+func capturedWarnings(t *testing.T) func() string {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return buf.String
+}
+
+// paramsOf converts a conversation and fails the test if the conversion did.
+func paramsOf(t *testing.T, convo *frames.LLMContext, opts adapter.Options) Params {
+	t.Helper()
+	p, err := (&Adapter{}).LLMInvocationParams(convo, opts)
+	if err != nil {
+		t.Fatalf("LLMInvocationParams: %v", err)
+	}
+	return p
+}
+
+// wantRoles fails unless the contents carry exactly the given roles in order.
+func wantRoles(t *testing.T, contents []map[string]any, want ...string) {
+	t.Helper()
+	if len(contents) != len(want) {
+		t.Fatalf("contents = %v, want %d of them with roles %v", contents, len(want), want)
+	}
+	for i := range want {
+		if got := contents[i][keyRole]; got != want[i] {
+			t.Errorf("content %d role = %v, want %q", i, got, want[i])
+		}
+	}
+}
+
+// textAt returns the text of a content's single text part.
+func textAt(t *testing.T, c map[string]any) string {
+	t.Helper()
+	parts, ok := c[keyParts].([]map[string]any)
+	if !ok || len(parts) == 0 {
+		t.Fatalf("content %v carries no parts", c)
+	}
+	text, _ := parts[0][keyText].(string)
+	return text
+}
+
+func TestIDForLLMSpecificMessages(t *testing.T) {
+	if got := (&Adapter{}).IDForLLMSpecificMessages(); got != "google" {
+		t.Errorf("id = %q, want %q", got, "google")
+	}
+}
+
+// TestStandardMessagesConverted checks the conversation reaches the request with
+// the assistant as the model and the instruction carried beside the contents.
+func TestStandardMessagesConverted(t *testing.T) {
+	convo := frames.NewLLMContext("You are helpful.")
+	convo.AddUserMessage("Hello")
+	convo.AddAssistantMessage("Hi there")
+
+	p := paramsOf(t, convo, adapter.Options{})
+	wantRoles(t, p.Contents, roleUser, roleModel)
+	if p.SystemInstruction != "You are helpful." {
+		t.Errorf("instruction = %q, want the conversation's prompt", p.SystemInstruction)
+	}
+}
+
+// TestSystemAndDeveloperMessagesBecomeUser checks that a system or developer
+// message said partway through the conversation enters as the user, Gemini
+// having neither input role.
+func TestSystemAndDeveloperMessagesBecomeUser(t *testing.T) {
+	convo := frames.NewLLMContext("You are helpful.")
+	convo.AddUserMessage("Hello")
+	convo.AddMessage(frames.Message{Role: frames.RoleSystem, Text: "Be concise."})
+	convo.AddMessage(frames.Message{Role: frames.RoleDeveloper, Text: "a tool reported late"})
+
+	p := paramsOf(t, convo, adapter.Options{})
+	wantRoles(t, p.Contents, roleUser, roleUser, roleUser)
+	if got := textAt(t, p.Contents[1]); got != "Be concise." {
+		t.Errorf("content 1 = %q, want what the system message said", got)
+	}
+	if got := textAt(t, p.Contents[2]); got != "a tool reported late" {
+		t.Errorf("content 2 = %q, want what the developer message carried", got)
+	}
+}
+
+// TestSystemOnlyConversationBecomesAUserMessage checks a conversation carrying
+// nothing but a system prompt is sent as a user message rather than beside an
+// empty content list, which Gemini rejects.
+func TestSystemOnlyConversationBecomesAUserMessage(t *testing.T) {
+	convo := frames.NewLLMContext("You are helpful.")
+
+	p := paramsOf(t, convo, adapter.Options{})
+	if p.SystemInstruction != "" {
+		t.Errorf("instruction = %q, want none: it went into the contents", p.SystemInstruction)
+	}
+	wantRoles(t, p.Contents, roleUser)
+	if got := textAt(t, p.Contents[0]); got != "You are helpful." {
+		t.Errorf("content = %q, want the prompt sent as a user message", got)
+	}
+}
+
+// TestSystemInstructionReplacesTheContextPrompt checks that an instruction given
+// for one call stands in place of the conversation's own: Gemini has one field
+// for it, so the two cannot both be sent.
+func TestSystemInstructionReplacesTheContextPrompt(t *testing.T) {
+	convo := frames.NewLLMContext("You are helpful.")
+	convo.AddUserMessage("Hello")
+	warnings := capturedWarnings(t)
+
+	p := paramsOf(t, convo, adapter.Options{SystemInstruction: "Be concise."})
+
+	if p.SystemInstruction != "Be concise." {
+		t.Errorf("instruction = %q, want the call's own", p.SystemInstruction)
+	}
+	if got := warnings(); !strings.Contains(got, "using the instruction") {
+		t.Errorf("warnings = %q, want the conflict reported", got)
+	}
+}
+
+// TestSystemRepeatedWhenOnlyToolTurns checks a conversation of nothing but tool
+// turns is given the instruction again as a user message. Gemini reads the
+// instruction as framing rather than as something to answer, so without it the
+// model has no prose to reply to.
+func TestSystemRepeatedWhenOnlyToolTurns(t *testing.T) {
+	convo := frames.NewLLMContext("You are helpful.")
+	convo.AddAssistantToolCall(frames.ToolCall{ID: "c1", Name: "get_weather"})
+	convo.AddToolResult(frames.ToolResult{ID: "c1", Name: "get_weather", Content: "sunny"})
+
+	p := paramsOf(t, convo, adapter.Options{})
+	wantRoles(t, p.Contents, roleModel, roleUser, roleUser)
+	if got := textAt(t, p.Contents[2]); got != "You are helpful." {
+		t.Errorf("trailing content = %q, want the instruction said again", got)
+	}
+	if p.SystemInstruction != "You are helpful." {
+		t.Errorf("instruction = %q, want it still carried beside the contents", p.SystemInstruction)
+	}
+}
+
+// TestSystemNotRepeatedWhenProseIsPresent checks the repeat above is only for a
+// conversation with nothing to answer.
+func TestSystemNotRepeatedWhenProseIsPresent(t *testing.T) {
+	convo := frames.NewLLMContext("You are helpful.")
+	convo.AddUserMessage("weather?")
+	convo.AddAssistantToolCall(frames.ToolCall{ID: "c1", Name: "get_weather"})
+	convo.AddToolResult(frames.ToolResult{ID: "c1", Name: "get_weather", Content: "sunny"})
+
+	p := paramsOf(t, convo, adapter.Options{})
+	wantRoles(t, p.Contents, roleUser, roleModel, roleUser)
+}
+
+// TestEmptyContentsDropped checks a turn that carries nothing is left out:
+// Gemini rejects a content with no parts.
+func TestEmptyContentsDropped(t *testing.T) {
+	convo := frames.NewLLMContext("")
+	convo.AddUserMessage("hello")
+	convo.AddMessage(frames.Message{Role: frames.RoleAssistant, ToolCalls: nil, Text: ""})
+
+	p := paramsOf(t, convo, adapter.Options{})
+	for _, c := range p.Contents {
+		parts, ok := c[keyParts].([]map[string]any)
+		if !ok || len(parts) == 0 {
+			t.Errorf("content %v carries no parts, want it dropped", c)
+		}
+	}
+}
+
+// TestToolResultNamedAfterItsCall checks a result is named after the call it
+// answers, which is what an asynchronous tool's late result carries only an id
+// for.
+func TestToolResultNamedAfterItsCall(t *testing.T) {
+	msgs := []frames.Message{
+		{Role: frames.RoleAssistant, ToolCalls: []frames.ToolCall{{ID: "c1", Name: "get_weather"}}},
+		{Role: frames.RoleUser, ToolResults: []frames.ToolResult{{ID: "c1", Content: "sunny"}}},
+	}
+	b, err := json.Marshal(ToContents(msgs))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(b), `"name":"get_weather"`) {
+		t.Errorf("contents = %s, want the result named after its call", b)
+	}
+}
+
+// TestUnnamedToolResultGetsAPlaceholder checks a result whose call is nowhere in
+// the conversation still carries a name, which Gemini requires.
+func TestUnnamedToolResultGetsAPlaceholder(t *testing.T) {
+	msgs := []frames.Message{
+		{Role: frames.RoleUser, ToolResults: []frames.ToolResult{{ID: "gone", Content: "sunny"}}},
+	}
+	b, err := json.Marshal(ToContents(msgs))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(b), `"name":"`+unnamedToolResult+`"`) {
+		t.Errorf("contents = %s, want the placeholder name", b)
+	}
+}
+
+func TestToContentsToolTurn(t *testing.T) {
+	convo := frames.NewLLMContext("be helpful")
+	convo.AddUserMessage("weather in Paris?")
+	convo.AddAssistantToolCall(frames.ToolCall{
+		ID: "call_0", Name: "get_weather", Args: json.RawMessage(`{"location":"Paris"}`),
+	})
+	convo.AddToolResult(frames.ToolResult{ID: "call_0", Name: "get_weather", Content: "sunny"})
+
+	b, err := json.Marshal(ToContents(convo.Messages()))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(b)
+	// user turn + tool-result turn use role "user"; the assistant tool-call turn
+	// uses role "model". Map keys marshal in alphabetical order.
+	wants := []string{
+		`"role":"user"`,
+		`"role":"model"`,
+		`"functionCall":{"args":{"location":"Paris"},"id":"call_0","name":"get_weather"}`,
+		`"functionResponse":{"id":"call_0","name":"get_weather","response":{"value":"sunny"}}`,
+	}
+	for _, want := range wants {
+		if !strings.Contains(got, want) {
+			t.Errorf("contents missing %s\nin: %s", want, got)
+		}
+	}
+}
+
+func TestFunctionResponseDict(t *testing.T) {
+	// A JSON object passes through unchanged.
+	raw, ok := FunctionResponseDict(`{"temp":20}`).(json.RawMessage)
+	if !ok || string(raw) != `{"temp":20}` {
+		t.Errorf("object should pass through, got %v", FunctionResponseDict(`{"temp":20}`))
+	}
+	// A plain string is wrapped under "value".
+	m, ok := FunctionResponseDict("sunny").(map[string]any)
+	if !ok || m["value"] != "sunny" {
+		t.Errorf("non-object should wrap as {value}, got %v", FunctionResponseDict("sunny"))
+	}
+}
+
+func TestToProviderToolsFormatStripsAdditionalProperties(t *testing.T) {
+	out := (&Adapter{}).ToProviderToolsFormat([]frames.Tool{{
+		Name:        "get_weather",
+		Description: "Look up the weather",
+		Parameters:  json.RawMessage(`{"type":"object","additionalProperties":false,"properties":{"loc":{"type":"string"}}}`),
+	}})
+	b, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(b)
+	if strings.Contains(got, "additionalProperties") {
+		t.Errorf("additionalProperties should be stripped: %s", got)
+	}
+	if !strings.Contains(got, `"functionDeclarations"`) || !strings.Contains(got, `"name":"get_weather"`) {
+		t.Errorf("declaration shape wrong: %s", got)
+	}
+}

--- a/adapter/llmspecific_test.go
+++ b/adapter/llmspecific_test.go
@@ -1,0 +1,72 @@
+package adapter_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gojargo/jargo/adapter"
+	"github.com/gojargo/jargo/frames"
+)
+
+// namedAdapter stands in for a provider adapter, which is all
+// CreateLLMSpecificMessage needs of one.
+type namedAdapter struct{ id string }
+
+func (a namedAdapter) IDForLLMSpecificMessages() string { return a.id }
+
+// nativeMessage is a stand-in for a provider's own message type.
+type nativeMessage struct{ Text string }
+
+// TestCreateLLMSpecificMessage checks a message is written for the provider the
+// adapter converts for, carrying that provider's own type.
+func TestCreateLLMSpecificMessage(t *testing.T) {
+	m := adapter.CreateLLMSpecificMessage(namedAdapter{id: "anthropic"}, nativeMessage{Text: "hi"})
+
+	if !m.IsLLMSpecific() {
+		t.Error("message is not provider-specific, want it written for one provider")
+	}
+	if m.LLM != "anthropic" {
+		t.Errorf("llm = %q, want the adapter's own identifier", m.LLM)
+	}
+	if got, ok := m.Native.(nativeMessage); !ok || got.Text != "hi" {
+		t.Errorf("native = %v, want the message it was given", m.Native)
+	}
+}
+
+// TestNativeMessageReadsItsOwnType checks a native message is handed back as
+// the type the adapter defines.
+func TestNativeMessageReadsItsOwnType(t *testing.T) {
+	m := frames.NewLLMSpecificMessage("anthropic", nativeMessage{Text: "hi"})
+
+	got, err := adapter.NativeMessage[nativeMessage](m)
+	if err != nil {
+		t.Fatalf("NativeMessage: %v", err)
+	}
+	if got.Text != "hi" {
+		t.Errorf("native = %+v, want the message it was written with", got)
+	}
+}
+
+// TestNativeMessageRejectsAnotherType checks a message holding something its own
+// adapter cannot read is a conversion failure rather than being sent as
+// whatever it happens to be.
+func TestNativeMessageRejectsAnotherType(t *testing.T) {
+	m := frames.NewLLMSpecificMessage("anthropic", "just a string")
+
+	_, err := adapter.NativeMessage[nativeMessage](m)
+	if err == nil {
+		t.Fatal("NativeMessage succeeded, want a conversion error")
+	}
+	var convErr *adapter.ConversionError
+	if !errors.As(err, &convErr) {
+		t.Fatalf("err = %v, want an adapter.ConversionError", err)
+	}
+}
+
+// TestPlainMessageIsNotLLMSpecific checks an ordinary turn is not mistaken for
+// one written in a provider's own format.
+func TestPlainMessageIsNotLLMSpecific(t *testing.T) {
+	if (frames.Message{Role: frames.RoleUser, Text: "hi"}).IsLLMSpecific() {
+		t.Error("a plain message reads as provider-specific, want it universal")
+	}
+}

--- a/adapter/mistral/mistral.go
+++ b/adapter/mistral/mistral.go
@@ -67,7 +67,7 @@ func TransformMessages(msgs []openai.Message) []openai.Message {
 		}
 	}
 
-	demoteLateSystem(out)
+	openai.DemoteLateSystem(out)
 
 	if last := &out[len(out)-1]; last.Role == openai.RoleAssistant {
 		if _, ok := last.Extra["prefix"]; !ok {
@@ -80,20 +80,4 @@ func TransformMessages(msgs []openai.Message) []openai.Message {
 		}
 	}
 	return out
-}
-
-// demoteLateSystem sends every system message past the leading run as a user
-// message, which is the only place Mistral accepts one.
-func demoteLateSystem(msgs []openai.Message) {
-	for i := range msgs {
-		if msgs[i].Role == openai.RoleSystem {
-			continue
-		}
-		for j := i; j < len(msgs); j++ {
-			if msgs[j].Role == openai.RoleSystem {
-				msgs[j].Role = openai.RoleUser
-			}
-		}
-		return
-	}
 }

--- a/adapter/mistral/mistral.go
+++ b/adapter/mistral/mistral.go
@@ -1,0 +1,99 @@
+// Package mistral converts a universal conversation into the request Mistral
+// takes.
+//
+// Mistral speaks the OpenAI chat-completions schema but constrains the shape of
+// a conversation beyond what that schema says, so this adapter embeds the
+// OpenAI one and rewrites what it produced rather than converting the
+// conversation a second time.
+package mistral
+
+import (
+	"maps"
+
+	"github.com/gojargo/jargo/adapter"
+	"github.com/gojargo/jargo/adapter/openai"
+	"github.com/gojargo/jargo/frames"
+)
+
+// Adapter converts a universal conversation into a Mistral chat-completions
+// request. The zero value is ready to use.
+//
+// Messages travel under the OpenAI identifier, which the embedded adapter
+// supplies: Mistral reads the same message format, so a message written for one
+// is readable by the other.
+type Adapter struct {
+	openai.Adapter
+}
+
+// Compile-time check that the adapter satisfies the contract.
+var _ adapter.LLMAdapter[openai.Params, openai.Tool] = (*Adapter)(nil)
+
+// LLMInvocationParams converts the conversation and then rewrites it to satisfy
+// the constraints Mistral puts on a message history.
+func (a *Adapter) LLMInvocationParams(
+	convo *frames.LLMContext, opts adapter.Options,
+) (openai.Params, error) {
+	p, err := a.Adapter.LLMInvocationParams(convo, opts)
+	if err != nil {
+		return openai.Params{}, err
+	}
+	p.Messages = TransformMessages(p.Messages)
+	return p, nil
+}
+
+// TransformMessages rewrites the conversation to satisfy the three constraints
+// Mistral puts on a message history that the OpenAI schema does not:
+//
+//  1. A tool result must be followed by an assistant message. One that is not
+//     is rejected, so a minimal assistant message is inserted after it.
+//  2. Only the leading run of system messages is accepted. A system message
+//     after any other message is sent as a user message instead.
+//  3. A conversation ending on an assistant message is a partial reply Mistral
+//     is being asked to continue, which it only does when the message is marked
+//     as a prefix.
+func TransformMessages(msgs []openai.Message) []openai.Message {
+	if len(msgs) == 0 {
+		return msgs
+	}
+
+	out := make([]openai.Message, 0, len(msgs)+1)
+	for i, m := range msgs {
+		out = append(out, m)
+		if m.Role != openai.RoleTool {
+			continue
+		}
+		if i == len(msgs)-1 || msgs[i+1].Role != openai.RoleAssistant {
+			out = append(out, openai.Message{Role: openai.RoleAssistant, Content: " "})
+		}
+	}
+
+	demoteLateSystem(out)
+
+	if last := &out[len(out)-1]; last.Role == openai.RoleAssistant {
+		if _, ok := last.Extra["prefix"]; !ok {
+			extra := maps.Clone(last.Extra)
+			if extra == nil {
+				extra = map[string]any{}
+			}
+			extra["prefix"] = true
+			last.Extra = extra
+		}
+	}
+	return out
+}
+
+// demoteLateSystem sends every system message past the leading run as a user
+// message, which is the only place Mistral accepts one.
+func demoteLateSystem(msgs []openai.Message) {
+	for i := range msgs {
+		if msgs[i].Role == openai.RoleSystem {
+			continue
+		}
+		for j := i; j < len(msgs); j++ {
+			if msgs[j].Role == openai.RoleSystem {
+				msgs[j].Role = openai.RoleUser
+			}
+		}
+		return
+	}
+}

--- a/adapter/mistral/mistral_test.go
+++ b/adapter/mistral/mistral_test.go
@@ -1,0 +1,87 @@
+package mistral
+
+import (
+	"testing"
+
+	"github.com/gojargo/jargo/adapter/openai"
+)
+
+// TestTransformMessagesFollowsATooResultWithAnAssistantMessage checks the first of
+// Mistral's constraints: a tool result that ends the conversation, which is
+// exactly what the completion answering a tool call sees.
+func TestTransformMessagesFollowsATooResultWithAnAssistantMessage(t *testing.T) {
+	out := TransformMessages([]openai.Message{
+		{Role: openai.RoleUser, Content: "weather?"},
+		{Role: openai.RoleAssistant, ToolCalls: []openai.ToolCall{{ID: "call_a"}}},
+		{Role: openai.RoleTool, ToolCallID: "call_a", Content: "sunny"},
+	})
+
+	if len(out) != 4 {
+		t.Fatalf("messages = %+v, want an assistant message inserted after the tool result", out)
+	}
+	if out[3].Role != openai.RoleAssistant || out[3].Content != " " {
+		t.Errorf("inserted message = %+v, want a minimal assistant message", out[3])
+	}
+	// It now trails the conversation, so it is a partial reply to continue.
+	if out[3].Extra["prefix"] != true {
+		t.Errorf("trailing assistant message = %+v, want it marked as a prefix", out[3])
+	}
+
+	// A tool result already followed by an assistant message needs no insertion.
+	out = TransformMessages([]openai.Message{
+		{Role: openai.RoleTool, ToolCallID: "call_a", Content: "sunny"},
+		{Role: openai.RoleAssistant, Content: "it is sunny"},
+		{Role: openai.RoleUser, Content: "thanks"},
+	})
+	if len(out) != 3 {
+		t.Errorf("messages = %+v, want no insertion", out)
+	}
+}
+
+// TestTransformMessagesDemotesLateSystemMessages checks the second constraint: only
+// the leading run of system messages is accepted.
+func TestTransformMessagesDemotesLateSystemMessages(t *testing.T) {
+	out := TransformMessages([]openai.Message{
+		{Role: openai.RoleSystem, Content: "be brief"},
+		{Role: openai.RoleSystem, Content: "and polite"},
+		{Role: openai.RoleUser, Content: "hello"},
+		{Role: openai.RoleSystem, Content: "the user is in a hurry"},
+	})
+
+	if out[0].Role != openai.RoleSystem || out[1].Role != openai.RoleSystem {
+		t.Errorf("leading messages = %+v, want the opening system block kept", out[:2])
+	}
+	if out[3].Role != openai.RoleUser {
+		t.Errorf("late system message = %+v, want it sent as a user message", out[3])
+	}
+	if out[3].Content != "the user is in a hurry" {
+		t.Errorf("content = %q, want what the system message carried", out[3].Content)
+	}
+}
+
+// TestTransformMessagesMarksATrailingAssistantMessage checks the third constraint,
+// and that a conversation ending any other way is left as it is.
+func TestTransformMessagesMarksATrailingAssistantMessage(t *testing.T) {
+	out := TransformMessages([]openai.Message{
+		{Role: openai.RoleUser, Content: "hello"},
+		{Role: openai.RoleAssistant, Content: "hi, I was saying"},
+	})
+	if out[1].Extra["prefix"] != true {
+		t.Errorf("trailing assistant message = %+v, want it marked as a prefix", out[1])
+	}
+
+	out = TransformMessages([]openai.Message{
+		{Role: openai.RoleAssistant, Content: "hi"},
+		{Role: openai.RoleUser, Content: "hello"},
+	})
+	if _, ok := out[1].Extra["prefix"]; ok {
+		t.Errorf("trailing user message = %+v, want nothing added to it", out[1])
+	}
+	if _, ok := out[0].Extra["prefix"]; ok {
+		t.Errorf("assistant message mid-conversation = %+v, want nothing added to it", out[0])
+	}
+
+	if got := TransformMessages(nil); got != nil {
+		t.Errorf("TransformMessages(nil) = %+v, want nil", got)
+	}
+}

--- a/adapter/openai/openai.go
+++ b/adapter/openai/openai.go
@@ -8,6 +8,7 @@ package openai
 
 import (
 	"encoding/json"
+	"log/slog"
 	"maps"
 
 	"github.com/gojargo/jargo/adapter"
@@ -118,10 +119,28 @@ type ToolCallFunction struct {
 	Arguments string `json:"arguments"`
 }
 
-// Tool is a function tool advertised on the request.
+// Tool is a tool advertised on the request. A function tool is described by
+// Type and Function; a tool the provider implements itself, which this schema
+// has no place for, is carried whole in Raw.
 type Tool struct {
 	Type     string   `json:"type"`
 	Function Function `json:"function"`
+	// Raw is the tool exactly as the provider takes it, and replaces the modeled
+	// fields entirely when set. It is how a provider-native tool (a hosted search
+	// tool, say, which the model runs itself rather than calling back for) is
+	// advertised without being forced into the function shape.
+	Raw map[string]any `json:"-"`
+}
+
+// MarshalJSON encodes the tool, sending Raw in place of the modeled fields when
+// it is set.
+func (t Tool) MarshalJSON() ([]byte, error) {
+	if len(t.Raw) > 0 {
+		return json.Marshal(t.Raw)
+	}
+	// plain drops the method set, so marshaling it does not recurse.
+	type plain Tool
+	return json.Marshal(plain(t))
 }
 
 // Function describes the tool a model may call.
@@ -199,7 +218,8 @@ func (a *Adapter) LLMInvocationParams(
 	out = append(out, converted...)
 
 	params := Params{Messages: out}
-	if tools := a.WithBuiltins(convo.Tools()); len(tools) > 0 {
+	if tools := a.WithBuiltins(convo.ToolsSchema()); len(tools.Standard) > 0 ||
+		len(tools.Custom) > 0 {
 		params.Tools = a.ToProviderToolsFormat(tools)
 		params.ToolChoice = string(convo.ToolChoice())
 	}
@@ -262,9 +282,9 @@ func assistantToolCalls(m frames.Message) Message {
 }
 
 // ToProviderToolsFormat implements adapter.LLMAdapter.
-func (*Adapter) ToProviderToolsFormat(tools []frames.Tool) []Tool {
-	out := make([]Tool, 0, len(tools))
-	for _, t := range tools {
+func (*Adapter) ToProviderToolsFormat(schema frames.ToolsSchema) []Tool {
+	out := make([]Tool, 0, len(schema.Standard))
+	for _, t := range schema.Standard {
 		out = append(out, Tool{
 			Type: toolTypeFunction,
 			Function: Function{
@@ -274,7 +294,15 @@ func (*Adapter) ToProviderToolsFormat(tools []frames.Tool) []Tool {
 			},
 		})
 	}
-	return out
+	// A custom tool that cannot be read is left out rather than failing the whole
+	// conversion: the tools are advertised alongside a conversation that is
+	// otherwise sendable, and the mismatch is reported when the schema is built.
+	custom, err := adapter.CustomToolsFor[Tool](schema, frames.AdapterTypeOpenAI)
+	if err != nil {
+		slog.Error("leaving out a custom tool the adapter cannot read", "err", err)
+		return out
+	}
+	return append(out, custom...)
 }
 
 // MessagesForLogging implements adapter.LLMAdapter. It renders the conversation

--- a/adapter/openai/openai.go
+++ b/adapter/openai/openai.go
@@ -179,7 +179,7 @@ func (*Adapter) IDForLLMSpecificMessages() string { return "openai" }
 func (a *Adapter) LLMInvocationParams(
 	convo *frames.LLMContext, opts adapter.Options,
 ) (Params, error) {
-	system := convo.System()
+	system := a.SystemWithBuiltins(convo.System())
 	// Only the conflict is resolved here, not the prompt's position: OpenAI
 	// carries the conversation's prompt in the messages either way.
 	instruction := a.ResolveSystemInstruction(system, opts.SystemInstruction, false)
@@ -195,7 +195,7 @@ func (a *Adapter) LLMInvocationParams(
 	out = append(out, ToMessages(msgs, opts.ConvertDeveloperToUser)...)
 
 	params := Params{Messages: out}
-	if tools := convo.Tools(); len(tools) > 0 {
+	if tools := a.WithBuiltins(convo.Tools()); len(tools) > 0 {
 		params.Tools = a.ToProviderToolsFormat(tools)
 		params.ToolChoice = string(convo.ToolChoice())
 	}

--- a/adapter/openai/openai.go
+++ b/adapter/openai/openai.go
@@ -1,0 +1,242 @@
+// Package openai converts a universal conversation into the chat-completions
+// request OpenAI takes, and with it every endpoint that speaks OpenAI's API.
+//
+// The types here are the wire format itself, so a provider that departs from
+// OpenAI in some detail can embed this adapter and rewrite what it produces
+// rather than convert the conversation a second time.
+package openai
+
+import (
+	"encoding/json"
+	"maps"
+
+	"github.com/gojargo/jargo/adapter"
+	"github.com/gojargo/jargo/frames"
+)
+
+// The message roles the chat-completions API defines.
+const (
+	RoleSystem    = "system"
+	RoleUser      = "user"
+	RoleAssistant = "assistant"
+	RoleTool      = "tool"
+	RoleDeveloper = "developer"
+)
+
+// toolTypeFunction is the only tool type OpenAI's chat API defines.
+const toolTypeFunction = "function"
+
+// Message is one message of the conversation as the chat-completions API takes
+// it.
+type Message struct {
+	Role       string     `json:"role"`
+	Content    string     `json:"content"`
+	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`
+	ToolCallID string     `json:"tool_call_id,omitempty"`
+	// Extra sets fields on this message that OpenAI's schema has no place for,
+	// merged over the modeled ones when the message is encoded. It is how an
+	// endpoint that reads a field of its own is served without that field
+	// reaching the endpoints that would reject it.
+	Extra map[string]any `json:"-"`
+}
+
+// MarshalJSON encodes the message, merging Extra over the modeled fields.
+func (m Message) MarshalJSON() ([]byte, error) {
+	// plain drops the method set, so marshaling it does not recurse.
+	type plain Message
+	if len(m.Extra) == 0 {
+		return json.Marshal(plain(m))
+	}
+	return MergeExtra(plain(m), m.Extra)
+}
+
+// ToolCall is an assistant tool-call entry on a message.
+type ToolCall struct {
+	ID       string           `json:"id"`
+	Type     string           `json:"type"`
+	Function ToolCallFunction `json:"function"`
+}
+
+// ToolCallFunction is the function a tool call invokes, with its arguments as
+// the raw JSON string the model produced.
+type ToolCallFunction struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+// Tool is a function tool advertised on the request.
+type Tool struct {
+	Type     string   `json:"type"`
+	Function Function `json:"function"`
+}
+
+// Function describes the tool a model may call.
+type Function struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Parameters  json.RawMessage `json:"parameters,omitempty"`
+}
+
+// Params is what one chat-completions call takes from the conversation: the
+// messages to send, the tools to advertise, and whether the model may or must
+// call one. Everything else on the request is the service's own configuration.
+type Params struct {
+	Messages   []Message
+	Tools      []Tool
+	ToolChoice string
+}
+
+// MergeExtra encodes v and merges extra over the fields it produced, so a
+// caller-supplied field wins over the modeled one of the same name. It is how
+// both a message and a whole request carry fields OpenAI's schema has no place
+// for.
+func MergeExtra(v any, extra map[string]any) ([]byte, error) {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil, err
+	}
+	maps.Copy(m, extra)
+	return json.Marshal(m)
+}
+
+// Adapter converts a universal conversation into an OpenAI chat-completions
+// request. The zero value is ready to use.
+type Adapter struct {
+	adapter.Base
+}
+
+// Compile-time check that the adapter satisfies the contract.
+var _ adapter.LLMAdapter[Params, Tool] = (*Adapter)(nil)
+
+// IDForLLMSpecificMessages implements adapter.LLMAdapter.
+func (*Adapter) IDForLLMSpecificMessages() string { return "openai" }
+
+// LLMInvocationParams converts the conversation into a chat-completions
+// request.
+//
+// OpenAI takes the system prompt as a leading message rather than beside the
+// conversation, so an instruction given for this call and the conversation's own
+// prompt can both be sent, and both are: an instruction supplements the
+// conversation's prompt rather than silently replacing it.
+func (a *Adapter) LLMInvocationParams(
+	convo *frames.LLMContext, opts adapter.Options,
+) (Params, error) {
+	system := convo.System()
+	// Only the conflict is resolved here, not the prompt's position: OpenAI
+	// carries the conversation's prompt in the messages either way.
+	instruction := a.ResolveSystemInstruction(system, opts.SystemInstruction, false)
+
+	msgs := convo.Messages()
+	out := make([]Message, 0, len(msgs)+2)
+	if instruction != "" {
+		out = append(out, Message{Role: RoleSystem, Content: instruction})
+	}
+	if system != "" {
+		out = append(out, Message{Role: RoleSystem, Content: system})
+	}
+	out = append(out, ToMessages(msgs, opts.ConvertDeveloperToUser)...)
+
+	params := Params{Messages: out}
+	if tools := convo.Tools(); len(tools) > 0 {
+		params.Tools = a.ToProviderToolsFormat(tools)
+		params.ToolChoice = string(convo.ToolChoice())
+	}
+	return params, nil
+}
+
+// ToMessages converts the conversation's messages into chat-completions
+// messages. A tool turn becomes an assistant message carrying tool_calls and one
+// "tool" message per result.
+//
+// convertDeveloperToUser sends a developer message as a user message, for an
+// endpoint that has no developer role.
+//
+// It is exported so an adapter that embeds this one can convert the conversation
+// once and then rewrite what came out.
+func ToMessages(msgs []frames.Message, convertDeveloperToUser bool) []Message {
+	out := make([]Message, 0, len(msgs))
+	for _, m := range msgs {
+		switch {
+		case len(m.ToolResults) > 0:
+			for _, r := range m.ToolResults {
+				out = append(out, Message{Role: RoleTool, ToolCallID: r.ID, Content: r.Content})
+			}
+		case len(m.ToolCalls) > 0:
+			out = append(out, assistantToolCalls(m))
+		default:
+			role := string(m.Role)
+			if convertDeveloperToUser && m.Role == frames.RoleDeveloper {
+				role = RoleUser
+			}
+			out = append(out, Message{Role: role, Content: m.Text})
+		}
+	}
+	return out
+}
+
+// assistantToolCalls renders an assistant turn that requested tool calls.
+func assistantToolCalls(m frames.Message) Message {
+	msg := Message{Role: RoleAssistant, Content: m.Text}
+	for _, c := range m.ToolCalls {
+		args := string(c.Args)
+		if args == "" {
+			args = "{}"
+		}
+		msg.ToolCalls = append(msg.ToolCalls, ToolCall{
+			ID:       c.ID,
+			Type:     toolTypeFunction,
+			Function: ToolCallFunction{Name: c.Name, Arguments: args},
+		})
+	}
+	return msg
+}
+
+// ToProviderToolsFormat implements adapter.LLMAdapter.
+func (*Adapter) ToProviderToolsFormat(tools []frames.Tool) []Tool {
+	out := make([]Tool, 0, len(tools))
+	for _, t := range tools {
+		out = append(out, Tool{
+			Type: toolTypeFunction,
+			Function: Function{
+				Name:        t.Name,
+				Description: t.Description,
+				Parameters:  t.Parameters,
+			},
+		})
+	}
+	return out
+}
+
+// MessagesForLogging implements adapter.LLMAdapter. It renders the conversation
+// as the endpoint will see it, so a trace carries the prompt that was actually
+// sent rather than the universal form it was converted from.
+func (a *Adapter) MessagesForLogging(convo *frames.LLMContext) []map[string]any {
+	params, err := a.LLMInvocationParams(convo, adapter.Options{})
+	if err != nil {
+		return nil
+	}
+	return asMaps(params.Messages)
+}
+
+// asMaps renders messages through their own encoding, so what is logged is the
+// shape that goes on the wire rather than a second rendering that could drift
+// from it.
+func asMaps(msgs []Message) []map[string]any {
+	out := make([]map[string]any, 0, len(msgs))
+	for _, m := range msgs {
+		raw, err := json.Marshal(m)
+		if err != nil {
+			continue
+		}
+		var got map[string]any
+		if err := json.Unmarshal(raw, &got); err != nil {
+			continue
+		}
+		out = append(out, got)
+	}
+	return out
+}

--- a/adapter/openai/openai.go
+++ b/adapter/openai/openai.go
@@ -184,7 +184,7 @@ func (a *Adapter) LLMInvocationParams(
 	// carries the conversation's prompt in the messages either way.
 	instruction := a.ResolveSystemInstruction(system, opts.SystemInstruction, false)
 
-	msgs := convo.Messages()
+	msgs := convo.MessagesFor(a.IDForLLMSpecificMessages())
 	out := make([]Message, 0, len(msgs)+2)
 	if instruction != "" {
 		out = append(out, Message{Role: RoleSystem, Content: instruction})
@@ -192,7 +192,11 @@ func (a *Adapter) LLMInvocationParams(
 	if system != "" {
 		out = append(out, Message{Role: RoleSystem, Content: system})
 	}
-	out = append(out, ToMessages(msgs, opts.ConvertDeveloperToUser)...)
+	converted, err := ToMessages(msgs, opts.ConvertDeveloperToUser)
+	if err != nil {
+		return Params{}, err
+	}
+	out = append(out, converted...)
 
 	params := Params{Messages: out}
 	if tools := a.WithBuiltins(convo.Tools()); len(tools) > 0 {
@@ -209,12 +213,20 @@ func (a *Adapter) LLMInvocationParams(
 // convertDeveloperToUser sends a developer message as a user message, for an
 // endpoint that has no developer role.
 //
+// A message already written in this format is passed through as it stands.
+//
 // It is exported so an adapter that embeds this one can convert the conversation
 // once and then rewrite what came out.
-func ToMessages(msgs []frames.Message, convertDeveloperToUser bool) []Message {
+func ToMessages(msgs []frames.Message, convertDeveloperToUser bool) ([]Message, error) {
 	out := make([]Message, 0, len(msgs))
 	for _, m := range msgs {
 		switch {
+		case m.IsLLMSpecific():
+			native, err := adapter.NativeMessage[Message](m)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, native)
 		case len(m.ToolResults) > 0:
 			for _, r := range m.ToolResults {
 				out = append(out, Message{Role: RoleTool, ToolCallID: r.ID, Content: r.Content})
@@ -229,7 +241,7 @@ func ToMessages(msgs []frames.Message, convertDeveloperToUser bool) []Message {
 			out = append(out, Message{Role: role, Content: m.Text})
 		}
 	}
-	return out
+	return out, nil
 }
 
 // assistantToolCalls renders an assistant turn that requested tool calls.

--- a/adapter/openai/openai.go
+++ b/adapter/openai/openai.go
@@ -26,6 +26,21 @@ const (
 // toolTypeFunction is the only tool type OpenAI's chat API defines.
 const toolTypeFunction = "function"
 
+// ContentPartText is the only content part type this format needs today.
+const ContentPartText = "text"
+
+// ContentPart is one part of a message's content. The API takes content either
+// as a plain string or as a list of parts.
+type ContentPart struct {
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
+}
+
+// TextPart builds a text content part.
+func TextPart(text string) ContentPart {
+	return ContentPart{Type: ContentPartText, Text: text}
+}
+
 // Message is one message of the conversation as the chat-completions API takes
 // it.
 type Message struct {
@@ -33,6 +48,11 @@ type Message struct {
 	Content    string     `json:"content"`
 	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`
 	ToolCallID string     `json:"tool_call_id,omitempty"`
+	// ContentParts carries the content as a list of parts instead of a plain
+	// string, and replaces Content when it is set. It is what lets an endpoint
+	// that takes two same-role messages as one keep what each said distinct,
+	// rather than running their text together.
+	ContentParts []ContentPart `json:"-"`
 	// Extra sets fields on this message that OpenAI's schema has no place for,
 	// merged over the modeled ones when the message is encoded. It is how an
 	// endpoint that reads a field of its own is served without that field
@@ -40,14 +60,48 @@ type Message struct {
 	Extra map[string]any `json:"-"`
 }
 
-// MarshalJSON encodes the message, merging Extra over the modeled fields.
+// MarshalJSON encodes the message, sending the content as parts when it has
+// them and merging Extra over the modeled fields.
 func (m Message) MarshalJSON() ([]byte, error) {
 	// plain drops the method set, so marshaling it does not recurse.
 	type plain Message
-	if len(m.Extra) == 0 {
+	if len(m.Extra) == 0 && len(m.ContentParts) == 0 {
 		return json.Marshal(plain(m))
 	}
-	return MergeExtra(plain(m), m.Extra)
+	over := map[string]any{}
+	if len(m.ContentParts) > 0 {
+		over["content"] = m.ContentParts
+	}
+	// Extra is the explicit override, so it wins over the parts.
+	maps.Copy(over, m.Extra)
+	return MergeExtra(plain(m), over)
+}
+
+// Parts returns the message's content as parts, whichever way it carries it. A
+// plain string becomes the single text part it stands for.
+func (m Message) Parts() []ContentPart {
+	if len(m.ContentParts) > 0 {
+		return m.ContentParts
+	}
+	return []ContentPart{TextPart(m.Content)}
+}
+
+// DemoteLateSystem sends every system message past the leading run as a user
+// message. Several endpoints that otherwise speak this API accept a system
+// message only at the start of a conversation and reject one that follows any
+// other message.
+func DemoteLateSystem(msgs []Message) {
+	for i := range msgs {
+		if msgs[i].Role == RoleSystem {
+			continue
+		}
+		for j := i; j < len(msgs); j++ {
+			if msgs[j].Role == RoleSystem {
+				msgs[j].Role = RoleUser
+			}
+		}
+		return
+	}
 }
 
 // ToolCall is an assistant tool-call entry on a message.

--- a/adapter/openai/openai_test.go
+++ b/adapter/openai/openai_test.go
@@ -3,6 +3,7 @@ package openai
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"strings"
 	"testing"
@@ -368,5 +369,50 @@ func TestMessageExtraMergedOverModeledFields(t *testing.T) {
 	}
 	if got["role"] != RoleAssistant {
 		t.Errorf("role = %v, want the modeled field kept", got["role"])
+	}
+}
+
+// TestLLMSpecificMessagePassedThrough checks a message already written in this
+// format is sent as it stands, which is what an application uses to say
+// something the universal conversation has no representation for.
+func TestLLMSpecificMessagePassedThrough(t *testing.T) {
+	convo := frames.NewLLMContext("")
+	convo.AddUserMessage("hello")
+	convo.AddMessage(adapter.CreateLLMSpecificMessage(
+		&Adapter{}, Message{Role: RoleAssistant, Content: "written for openai"},
+	))
+
+	p := paramsOf(t, convo, adapter.Options{})
+	wantRoles(t, p.Messages, RoleUser, RoleAssistant)
+	if p.Messages[1].Content != "written for openai" {
+		t.Errorf("message 1 = %+v, want the provider's own message", p.Messages[1])
+	}
+}
+
+// TestAnotherProvidersMessageIsLeftOut checks a message written for a different
+// provider never reaches this one, so a conversation carrying one can still be
+// sent here.
+func TestAnotherProvidersMessageIsLeftOut(t *testing.T) {
+	convo := frames.NewLLMContext("")
+	convo.AddUserMessage("hello")
+	convo.AddMessage(frames.NewLLMSpecificMessage("anthropic", "not for openai"))
+
+	p := paramsOf(t, convo, adapter.Options{})
+	wantRoles(t, p.Messages, RoleUser)
+}
+
+// TestLLMSpecificMessageOfTheWrongTypeFails checks a message written for this
+// provider but holding something it cannot read is reported rather than sent.
+func TestLLMSpecificMessageOfTheWrongTypeFails(t *testing.T) {
+	convo := frames.NewLLMContext("")
+	convo.AddMessage(frames.NewLLMSpecificMessage("openai", "a bare string"))
+
+	_, err := (&Adapter{}).LLMInvocationParams(convo, adapter.Options{})
+	if err == nil {
+		t.Fatal("LLMInvocationParams succeeded, want a conversion error")
+	}
+	var convErr *adapter.ConversionError
+	if !errors.As(err, &convErr) {
+		t.Fatalf("err = %v, want an adapter.ConversionError", err)
 	}
 }

--- a/adapter/openai/openai_test.go
+++ b/adapter/openai/openai_test.go
@@ -1,0 +1,372 @@
+package openai
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/gojargo/jargo/adapter"
+	"github.com/gojargo/jargo/frames"
+)
+
+// capturedWarnings swaps the default logger for one writing into a buffer and
+// returns a reader for what was logged, restoring the logger when the test ends.
+// The conflict between an instruction and a conversation's own prompt is
+// reported rather than returned, so reading the log is how a test sees it.
+func capturedWarnings(t *testing.T) func() string {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return buf.String
+}
+
+// roles returns the role of each message, which is what most of these tests
+// compare.
+func roles(msgs []Message) []string {
+	out := make([]string, 0, len(msgs))
+	for _, m := range msgs {
+		out = append(out, m.Role)
+	}
+	return out
+}
+
+// wantRoles fails unless the messages carry exactly the given roles in order.
+func wantRoles(t *testing.T, msgs []Message, want ...string) {
+	t.Helper()
+	got := roles(msgs)
+	if len(got) != len(want) {
+		t.Fatalf("roles = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("message %d role = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// paramsOf converts a conversation and fails the test if the conversion did.
+func paramsOf(t *testing.T, convo *frames.LLMContext, opts adapter.Options) Params {
+	t.Helper()
+	p, err := (&Adapter{}).LLMInvocationParams(convo, opts)
+	if err != nil {
+		t.Fatalf("LLMInvocationParams: %v", err)
+	}
+	return p
+}
+
+func TestIDForLLMSpecificMessages(t *testing.T) {
+	if got := (&Adapter{}).IDForLLMSpecificMessages(); got != "openai" {
+		t.Errorf("id = %q, want %q", got, "openai")
+	}
+}
+
+// TestStandardMessagesConverted checks the conversation reaches the request in
+// the order it was said, with each role as it was.
+func TestStandardMessagesConverted(t *testing.T) {
+	convo := frames.NewLLMContext("You are a helpful assistant.")
+	convo.AddUserMessage("Hello, how are you?")
+	convo.AddAssistantMessage("I'm doing well, thank you for asking!")
+
+	p := paramsOf(t, convo, adapter.Options{})
+	wantRoles(t, p.Messages, RoleSystem, RoleUser, RoleAssistant)
+
+	want := []string{
+		"You are a helpful assistant.",
+		"Hello, how are you?",
+		"I'm doing well, thank you for asking!",
+	}
+	for i, content := range want {
+		if p.Messages[i].Content != content {
+			t.Errorf("message %d content = %q, want %q", i, p.Messages[i].Content, content)
+		}
+	}
+}
+
+// TestSystemMessagesPreservedThroughout checks a system message said partway
+// through the conversation stays where it was said. OpenAI takes the system
+// prompt as a message like any other, so there is nothing to hoist out.
+func TestSystemMessagesPreservedThroughout(t *testing.T) {
+	convo := frames.NewLLMContext("You are a helpful assistant.")
+	convo.AddUserMessage("Hello!")
+	convo.AddAssistantMessage("Hi there!")
+	convo.AddMessage(frames.Message{Role: frames.RoleSystem, Text: "Remember to be concise."})
+	convo.AddUserMessage("Tell me about Go.")
+	convo.AddMessage(frames.Message{Role: frames.RoleSystem, Text: "Use simple language."})
+	convo.AddAssistantMessage("Go is a programming language.")
+
+	p := paramsOf(t, convo, adapter.Options{})
+	wantRoles(t, p.Messages,
+		RoleSystem, RoleUser, RoleAssistant, RoleSystem, RoleUser, RoleSystem, RoleAssistant)
+
+	if p.Messages[3].Content != "Remember to be concise." {
+		t.Errorf("message 3 = %q, want the system message said midway", p.Messages[3].Content)
+	}
+	if p.Messages[5].Content != "Use simple language." {
+		t.Errorf("message 5 = %q, want the later system message", p.Messages[5].Content)
+	}
+}
+
+// TestSystemInstructionOnly checks an instruction given for one call, with no
+// prompt on the conversation, leads the messages.
+func TestSystemInstructionOnly(t *testing.T) {
+	convo := frames.NewLLMContext("")
+	convo.AddUserMessage("Hello")
+
+	p := paramsOf(t, convo, adapter.Options{SystemInstruction: "Be helpful."})
+	wantRoles(t, p.Messages, RoleSystem, RoleUser)
+	if p.Messages[0].Content != "Be helpful." {
+		t.Errorf("leading message = %q, want the instruction", p.Messages[0].Content)
+	}
+}
+
+// TestContextSystemOnly checks the conversation's own prompt leads the messages
+// when no instruction was given for the call.
+func TestContextSystemOnly(t *testing.T) {
+	convo := frames.NewLLMContext("You are helpful.")
+	convo.AddUserMessage("Hello")
+
+	p := paramsOf(t, convo, adapter.Options{})
+	wantRoles(t, p.Messages, RoleSystem, RoleUser)
+	if p.Messages[0].Content != "You are helpful." {
+		t.Errorf("leading message = %q, want the conversation's prompt", p.Messages[0].Content)
+	}
+}
+
+// TestBothSystemInstructionAndContextSystemWarns checks that an instruction
+// given for a call alongside a prompt on the conversation is reported and that
+// both are sent: OpenAI takes the prompt as a message, so an instruction can
+// supplement it rather than having to replace it.
+func TestBothSystemInstructionAndContextSystemWarns(t *testing.T) {
+	convo := frames.NewLLMContext("You are helpful.")
+	convo.AddUserMessage("Hello")
+	warnings := capturedWarnings(t)
+
+	p := paramsOf(t, convo, adapter.Options{SystemInstruction: "Be concise."})
+
+	if got := warnings(); !strings.Contains(got, "may be unintended") {
+		t.Errorf("warnings = %q, want the conflict reported as possibly unintended", got)
+	}
+	wantRoles(t, p.Messages, RoleSystem, RoleSystem, RoleUser)
+	if p.Messages[0].Content != "Be concise." {
+		t.Errorf("message 0 = %q, want the call's instruction first", p.Messages[0].Content)
+	}
+	if p.Messages[1].Content != "You are helpful." {
+		t.Errorf("message 1 = %q, want the conversation's prompt kept", p.Messages[1].Content)
+	}
+}
+
+// TestDeveloperMessageWithInstructionDoesNotWarn checks the conflict is about
+// the system prompt alone: a developer message is not one, and carries no
+// instruction to clash with.
+func TestDeveloperMessageWithInstructionDoesNotWarn(t *testing.T) {
+	convo := frames.NewLLMContext("")
+	convo.AddMessage(frames.Message{Role: frames.RoleDeveloper, Text: "Extra context."})
+	convo.AddUserMessage("Hello")
+	warnings := capturedWarnings(t)
+
+	p := paramsOf(t, convo, adapter.Options{SystemInstruction: "Be concise."})
+
+	if got := warnings(); got != "" {
+		t.Errorf("warnings = %q, want none", got)
+	}
+	wantRoles(t, p.Messages, RoleSystem, RoleDeveloper, RoleUser)
+}
+
+// TestConflictWarningFiresOnlyOnce checks the report is made once for the
+// adapter rather than on every generation of a session.
+func TestConflictWarningFiresOnlyOnce(t *testing.T) {
+	convo := frames.NewLLMContext("You are helpful.")
+	convo.AddUserMessage("Hello")
+	warnings := capturedWarnings(t)
+
+	a := &Adapter{}
+	for range 2 {
+		if _, err := a.LLMInvocationParams(
+			convo, adapter.Options{SystemInstruction: "Be concise."},
+		); err != nil {
+			t.Fatalf("LLMInvocationParams: %v", err)
+		}
+	}
+
+	if got := strings.Count(warnings(), "may be unintended"); got != 1 {
+		t.Errorf("reported %d times, want once", got)
+	}
+}
+
+// TestDeveloperMessagesConvertedToUser checks the role an asynchronous tool's
+// late results travel under: kept as it is for an endpoint that has the
+// developer role, and sent as a user message for one that does not, which is
+// what stops such an endpoint rejecting the turn. The conversation itself is
+// left as it was either way: the conversion is how this endpoint is addressed,
+// not a change to what was said.
+func TestDeveloperMessagesConvertedToUser(t *testing.T) {
+	convo := frames.NewLLMContext("")
+	convo.AddMessage(frames.Message{Role: frames.RoleDeveloper, Text: "Extra context."})
+	convo.AddUserMessage("Hello")
+
+	kept := paramsOf(t, convo, adapter.Options{})
+	if kept.Messages[0].Role != RoleDeveloper {
+		t.Errorf("role = %q, want it left as the developer role", kept.Messages[0].Role)
+	}
+
+	converted := paramsOf(t, convo, adapter.Options{ConvertDeveloperToUser: true})
+	if converted.Messages[0].Role != RoleUser {
+		t.Errorf("role = %q, want the developer message sent as a user message",
+			converted.Messages[0].Role)
+	}
+	if converted.Messages[0].Content != "Extra context." {
+		t.Errorf("content = %q, want what the developer message carried",
+			converted.Messages[0].Content)
+	}
+	if got := convo.Messages()[0].Role; got != frames.RoleDeveloper {
+		t.Errorf("the conversation now reads %q, want the developer message untouched", got)
+	}
+}
+
+// TestDeveloperConversionDoesNotAffectOtherRoles checks the conversion reaches
+// the developer role and nothing else.
+func TestDeveloperConversionDoesNotAffectOtherRoles(t *testing.T) {
+	convo := frames.NewLLMContext("System prompt.")
+	convo.AddMessage(frames.Message{Role: frames.RoleDeveloper, Text: "Dev guidance."})
+	convo.AddUserMessage("Hello")
+	convo.AddAssistantMessage("Hi")
+
+	p := paramsOf(t, convo, adapter.Options{ConvertDeveloperToUser: true})
+	wantRoles(t, p.Messages, RoleSystem, RoleUser, RoleUser, RoleAssistant)
+	if p.Messages[1].Content != "Dev guidance." {
+		t.Errorf("content = %q, want what the developer message carried", p.Messages[1].Content)
+	}
+}
+
+// TestToolTurn checks a tool turn reaches the request as an assistant message
+// carrying the call and a "tool" message carrying its result.
+func TestToolTurn(t *testing.T) {
+	convo := frames.NewLLMContext("be helpful")
+	convo.AddUserMessage("weather in Paris?")
+	convo.AddAssistantToolCall(frames.ToolCall{
+		ID: "call_a", Name: "get_weather", Args: json.RawMessage(`{"location":"Paris"}`),
+	})
+	convo.AddToolResult(frames.ToolResult{ID: "call_a", Name: "get_weather", Content: "sunny, 20C"})
+
+	p := paramsOf(t, convo, adapter.Options{})
+	wantRoles(t, p.Messages, RoleSystem, RoleUser, RoleAssistant, RoleTool)
+
+	asst := p.Messages[2]
+	if len(asst.ToolCalls) != 1 {
+		t.Fatalf("assistant tool message malformed: %+v", asst)
+	}
+	tc := asst.ToolCalls[0]
+	if tc.ID != "call_a" || tc.Type != toolTypeFunction || tc.Function.Name != "get_weather" {
+		t.Errorf("tool_call fields wrong: %+v", tc)
+	}
+	if tc.Function.Arguments != `{"location":"Paris"}` {
+		t.Errorf("tool_call arguments = %q", tc.Function.Arguments)
+	}
+
+	res := p.Messages[3]
+	if res.ToolCallID != "call_a" || res.Content != "sunny, 20C" {
+		t.Errorf("tool result message wrong: %+v", res)
+	}
+}
+
+// TestToolCallEmptyArgsDefaults checks a call the model made with no arguments
+// goes out as an empty object rather than an empty string, which is not JSON.
+func TestToolCallEmptyArgsDefaults(t *testing.T) {
+	convo := frames.NewLLMContext("")
+	convo.AddAssistantToolCall(frames.ToolCall{ID: "c1", Name: "now"})
+
+	p := paramsOf(t, convo, adapter.Options{})
+	if got := p.Messages[0].ToolCalls[0].Function.Arguments; got != "{}" {
+		t.Errorf("empty args should default to {}, got %q", got)
+	}
+}
+
+// TestToProviderToolsFormat checks an advertised tool reaches the request as an
+// OpenAI function tool with its schema passed through untouched.
+func TestToProviderToolsFormat(t *testing.T) {
+	out := (&Adapter{}).ToProviderToolsFormat([]frames.Tool{{
+		Name:        "get_weather",
+		Description: "Look up the weather",
+		Parameters:  json.RawMessage(`{"type":"object"}`),
+	}})
+	if len(out) != 1 {
+		t.Fatalf("want 1 tool, got %d", len(out))
+	}
+	if out[0].Type != toolTypeFunction || out[0].Function.Name != "get_weather" {
+		t.Errorf("tool shape wrong: %+v", out[0])
+	}
+	if string(out[0].Function.Parameters) != `{"type":"object"}` {
+		t.Errorf("parameters not passed through: %s", out[0].Function.Parameters)
+	}
+}
+
+// TestToolsAdvertisedOnParams checks the toolset and the choice travel together:
+// a conversation with no tools states no choice either, which would otherwise
+// pin a model to a toolset it was not given.
+func TestToolsAdvertisedOnParams(t *testing.T) {
+	convo := frames.NewLLMContext("")
+	convo.AddUserMessage("hello")
+
+	if p := paramsOf(t, convo, adapter.Options{}); p.Tools != nil || p.ToolChoice != "" {
+		t.Errorf("tools = %+v, choice = %q, want neither sent", p.Tools, p.ToolChoice)
+	}
+
+	convo.SetTools([]frames.Tool{{Name: "now"}})
+	convo.SetToolChoice(frames.ToolChoiceRequired)
+	p := paramsOf(t, convo, adapter.Options{})
+	if len(p.Tools) != 1 || p.Tools[0].Function.Name != "now" {
+		t.Errorf("tools = %+v, want the advertised one", p.Tools)
+	}
+	if p.ToolChoice != string(frames.ToolChoiceRequired) {
+		t.Errorf("choice = %q, want %q", p.ToolChoice, frames.ToolChoiceRequired)
+	}
+}
+
+// TestMessagesForLogging checks a trace is given the conversation in the shape
+// that goes on the wire.
+func TestMessagesForLogging(t *testing.T) {
+	convo := frames.NewLLMContext("be helpful")
+	convo.AddUserMessage("hello")
+
+	got := (&Adapter{}).MessagesForLogging(convo)
+	if len(got) != 2 {
+		t.Fatalf("logged %d messages, want 2", len(got))
+	}
+	if got[0]["role"] != RoleSystem || got[0]["content"] != "be helpful" {
+		t.Errorf("logged message 0 = %v, want the system prompt", got[0])
+	}
+	if got[1]["role"] != RoleUser || got[1]["content"] != "hello" {
+		t.Errorf("logged message 1 = %v, want the user message", got[1])
+	}
+}
+
+// TestMessageExtraMergedOverModeledFields checks a field an endpoint reads that
+// OpenAI's schema has no place for is carried, and that it wins over a modeled
+// field of the same name.
+func TestMessageExtraMergedOverModeledFields(t *testing.T) {
+	raw, err := json.Marshal(Message{
+		Role:    RoleAssistant,
+		Content: "partial",
+		Extra:   map[string]any{"prefix": true, "content": "overridden"},
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got["prefix"] != true {
+		t.Errorf("prefix = %v, want the extra field carried", got["prefix"])
+	}
+	if got["content"] != "overridden" {
+		t.Errorf("content = %v, want the extra field to win", got["content"])
+	}
+	if got["role"] != RoleAssistant {
+		t.Errorf("role = %v, want the modeled field kept", got["role"])
+	}
+}

--- a/adapter/openai/openai_test.go
+++ b/adapter/openai/openai_test.go
@@ -289,11 +289,11 @@ func TestToolCallEmptyArgsDefaults(t *testing.T) {
 // TestToProviderToolsFormat checks an advertised tool reaches the request as an
 // OpenAI function tool with its schema passed through untouched.
 func TestToProviderToolsFormat(t *testing.T) {
-	out := (&Adapter{}).ToProviderToolsFormat([]frames.Tool{{
+	out := (&Adapter{}).ToProviderToolsFormat(frames.ToolsSchema{Standard: []frames.Tool{{
 		Name:        "get_weather",
 		Description: "Look up the weather",
 		Parameters:  json.RawMessage(`{"type":"object"}`),
-	}})
+	}}})
 	if len(out) != 1 {
 		t.Fatalf("want 1 tool, got %d", len(out))
 	}

--- a/adapter/perplexity/perplexity.go
+++ b/adapter/perplexity/perplexity.go
@@ -1,0 +1,106 @@
+// Package perplexity converts a universal conversation into the request
+// Perplexity takes.
+//
+// Perplexity speaks the OpenAI chat-completions schema but is stricter than
+// OpenAI about the shape of a conversation, so this adapter embeds the OpenAI
+// one and rewrites what it produced rather than converting the conversation a
+// second time.
+package perplexity
+
+import (
+	"slices"
+
+	"github.com/gojargo/jargo/adapter"
+	"github.com/gojargo/jargo/adapter/openai"
+	"github.com/gojargo/jargo/frames"
+)
+
+// Adapter converts a universal conversation into a Perplexity chat-completions
+// request. The zero value is ready to use.
+//
+// Messages travel under the OpenAI identifier, which the embedded adapter
+// supplies: Perplexity reads the same message format, so a message written for
+// one is readable by the other.
+type Adapter struct {
+	openai.Adapter
+}
+
+// Compile-time check that the adapter satisfies the contract.
+var _ adapter.LLMAdapter[openai.Params, openai.Tool] = (*Adapter)(nil)
+
+// LLMInvocationParams converts the conversation and then rewrites it to satisfy
+// the constraints Perplexity puts on a message history.
+func (a *Adapter) LLMInvocationParams(
+	convo *frames.LLMContext, opts adapter.Options,
+) (openai.Params, error) {
+	p, err := a.Adapter.LLMInvocationParams(convo, opts)
+	if err != nil {
+		return openai.Params{}, err
+	}
+	p.Messages = TransformMessages(p.Messages)
+	return p, nil
+}
+
+// TransformMessages rewrites the conversation to satisfy the three constraints
+// Perplexity puts on a message history that the OpenAI schema does not:
+//
+//  1. Only the leading run of system messages is accepted. A system message
+//     after any other message is sent as a user message instead.
+//  2. Roles must strictly alternate. Adjacent messages of the same role are
+//     merged into one carrying both their contents, which is also what the
+//     demotion above tends to produce: a system message sent as a user message
+//     next to a user message.
+//  3. The conversation must end on a user or tool message. A trailing assistant
+//     message is dropped, which is what OpenAI does with one server-side, so the
+//     turn reads the same either way.
+//
+// A trailing system message is deliberately left as it is. Demoting it would
+// make the rewrite depend on how much of the conversation has happened so far,
+// and Perplexity keeps state within a conversation: a message sent as a user
+// message on one turn and as a system message on the next, once more messages
+// follow it, is rejected. A conversation of nothing but system messages is
+// refused by the API, which reports the mistake straight away.
+func TransformMessages(msgs []openai.Message) []openai.Message {
+	if len(msgs) == 0 {
+		return msgs
+	}
+	// The demotion writes to the messages, which the caller still holds.
+	out := slices.Clone(msgs)
+	openai.DemoteLateSystem(out)
+	out = mergeSameRole(out)
+	return dropTrailingAssistant(out)
+}
+
+// mergeSameRole folds each run of same-role messages into one carrying every
+// content in turn, so the roles strictly alternate.
+//
+// Two system messages are never merged. Perplexity accepts several at the
+// start, and by this point the demotion above has left system messages nowhere
+// else, so a run of them is the opening block and merging it would rewrite a
+// conversation the endpoint already reads correctly.
+func mergeSameRole(msgs []openai.Message) []openai.Message {
+	out := make([]openai.Message, 0, len(msgs))
+	for _, m := range msgs {
+		if len(out) == 0 {
+			out = append(out, m)
+			continue
+		}
+		last := &out[len(out)-1]
+		if last.Role != m.Role || m.Role == openai.RoleSystem {
+			out = append(out, m)
+			continue
+		}
+		last.ContentParts = append(last.Parts(), m.Parts()...)
+		last.Content = ""
+	}
+	return out
+}
+
+// dropTrailingAssistant removes the assistant messages the conversation ends on,
+// which Perplexity refuses as a final message.
+func dropTrailingAssistant(msgs []openai.Message) []openai.Message {
+	for len(msgs) > 0 && msgs[len(msgs)-1].Role == openai.RoleAssistant {
+		msgs = msgs[:len(msgs)-1]
+	}
+	return msgs
+}

--- a/adapter/perplexity/perplexity_test.go
+++ b/adapter/perplexity/perplexity_test.go
@@ -1,0 +1,269 @@
+package perplexity
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/gojargo/jargo/adapter"
+	"github.com/gojargo/jargo/adapter/openai"
+	"github.com/gojargo/jargo/frames"
+)
+
+// msg builds a message with plain text content.
+func msg(role, content string) openai.Message {
+	return openai.Message{Role: role, Content: content}
+}
+
+// roles returns the role of each message, which is what most of these tests
+// compare.
+func roles(msgs []openai.Message) []string {
+	out := make([]string, 0, len(msgs))
+	for _, m := range msgs {
+		out = append(out, m.Role)
+	}
+	return out
+}
+
+// wantRoles fails unless the messages carry exactly the given roles in order.
+func wantRoles(t *testing.T, msgs []openai.Message, want ...string) {
+	t.Helper()
+	got := roles(msgs)
+	if len(got) != len(want) {
+		t.Fatalf("roles = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("message %d role = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// texts returns the text a message carries, whichever way it carries it.
+func texts(m openai.Message) []string {
+	out := make([]string, 0, len(m.Parts()))
+	for _, p := range m.Parts() {
+		out = append(out, p.Text)
+	}
+	return out
+}
+
+// wantTexts fails unless the message carries exactly the given texts in order.
+func wantTexts(t *testing.T, m openai.Message, want ...string) {
+	t.Helper()
+	got := texts(m)
+	if len(got) != len(want) {
+		t.Fatalf("texts = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("text %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestStandardMessagesPassThrough checks a conversation that already alternates
+// is left as it is.
+func TestStandardMessagesPassThrough(t *testing.T) {
+	out := TransformMessages([]openai.Message{
+		msg(openai.RoleSystem, "You are helpful."),
+		msg(openai.RoleUser, "Hello"),
+		msg(openai.RoleAssistant, "Hi"),
+		msg(openai.RoleUser, "How are you?"),
+	})
+	wantRoles(t, out, openai.RoleSystem, openai.RoleUser, openai.RoleAssistant, openai.RoleUser)
+	if out[1].Content != "Hello" {
+		t.Errorf("content = %q, want it untouched", out[1].Content)
+	}
+}
+
+// TestInitialSystemMessagePreserved checks the leading system message stays the
+// system message it was.
+func TestInitialSystemMessagePreserved(t *testing.T) {
+	out := TransformMessages([]openai.Message{
+		msg(openai.RoleSystem, "You are helpful."),
+		msg(openai.RoleUser, "Hello"),
+	})
+	wantRoles(t, out, openai.RoleSystem, openai.RoleUser)
+}
+
+// TestMultipleInitialSystemMessagesPreserved checks the leading run of system
+// messages is neither demoted nor merged: Perplexity accepts several, and
+// merging them would rewrite a conversation it already reads.
+func TestMultipleInitialSystemMessagesPreserved(t *testing.T) {
+	out := TransformMessages([]openai.Message{
+		msg(openai.RoleSystem, "Be brief."),
+		msg(openai.RoleSystem, "Be polite."),
+		msg(openai.RoleUser, "Hello"),
+	})
+	wantRoles(t, out, openai.RoleSystem, openai.RoleSystem, openai.RoleUser)
+	if out[0].Content != "Be brief." || out[1].Content != "Be polite." {
+		t.Errorf("messages = %+v, want the opening system block kept apart", out[:2])
+	}
+}
+
+// TestNonInitialSystemConvertedToUser checks a system message after any other
+// message is sent as a user message, which is the only way Perplexity takes one.
+func TestNonInitialSystemConvertedToUser(t *testing.T) {
+	out := TransformMessages([]openai.Message{
+		msg(openai.RoleSystem, "You are helpful."),
+		msg(openai.RoleUser, "Hello"),
+		msg(openai.RoleAssistant, "Hi"),
+		msg(openai.RoleSystem, "Be concise."),
+		msg(openai.RoleUser, "Tell me more"),
+	})
+	wantRoles(t, out, openai.RoleSystem, openai.RoleUser, openai.RoleAssistant, openai.RoleUser)
+	// The demoted system message merges with the user message following it.
+	wantTexts(t, out[3], "Be concise.", "Tell me more")
+}
+
+// TestConsecutiveSameRoleMerged checks two messages of one role become one
+// carrying both contents, which is what strict alternation requires.
+func TestConsecutiveSameRoleMerged(t *testing.T) {
+	out := TransformMessages([]openai.Message{
+		msg(openai.RoleSystem, "You are helpful."),
+		msg(openai.RoleUser, "Hello"),
+		msg(openai.RoleUser, "Are you there?"),
+		msg(openai.RoleAssistant, "Hi"),
+		msg(openai.RoleUser, "Good"),
+	})
+	wantRoles(t, out, openai.RoleSystem, openai.RoleUser, openai.RoleAssistant, openai.RoleUser)
+	wantTexts(t, out[1], "Hello", "Are you there?")
+}
+
+// TestConsecutiveAssistantsMergedThenTrailingRemoved checks the two rewrites
+// compose: the run is merged first, and the merged message is then dropped for
+// ending the conversation.
+func TestConsecutiveAssistantsMergedThenTrailingRemoved(t *testing.T) {
+	out := TransformMessages([]openai.Message{
+		msg(openai.RoleUser, "Hello"),
+		msg(openai.RoleAssistant, "Hi"),
+		msg(openai.RoleAssistant, "How can I help?"),
+	})
+	wantRoles(t, out, openai.RoleUser)
+}
+
+// TestTrailingAssistantRemoved checks a conversation ending on an assistant
+// message has it dropped, which is what OpenAI does with one server-side.
+func TestTrailingAssistantRemoved(t *testing.T) {
+	out := TransformMessages([]openai.Message{
+		msg(openai.RoleUser, "Hello"),
+		msg(openai.RoleAssistant, "Hi"),
+	})
+	wantRoles(t, out, openai.RoleUser)
+}
+
+// TestSystemExposedAfterTrailingAssistantRemoved checks the system message a
+// dropped assistant message was hiding is left as a system message, not demoted.
+// Demoting it would depend on how much of the conversation had happened, and
+// Perplexity rejects a message whose role changes between turns.
+func TestSystemExposedAfterTrailingAssistantRemoved(t *testing.T) {
+	out := TransformMessages([]openai.Message{
+		msg(openai.RoleSystem, "You are helpful."),
+		msg(openai.RoleAssistant, "Hi"),
+	})
+	wantRoles(t, out, openai.RoleSystem)
+}
+
+// TestOnlySystemMessagesPreserved checks a conversation of nothing but system
+// messages is left alone. The API refuses it, which reports the mistake straight
+// away rather than the rewrite hiding it.
+func TestOnlySystemMessagesPreserved(t *testing.T) {
+	out := TransformMessages([]openai.Message{
+		msg(openai.RoleSystem, "Be brief."),
+		msg(openai.RoleSystem, "Be polite."),
+	})
+	wantRoles(t, out, openai.RoleSystem, openai.RoleSystem)
+}
+
+// TestToolMessagesPreserved checks a tool turn survives: a tool message may end
+// the conversation, and it does not merge with the assistant message that asked
+// for it.
+func TestToolMessagesPreserved(t *testing.T) {
+	out := TransformMessages([]openai.Message{
+		msg(openai.RoleUser, "weather?"),
+		{Role: openai.RoleAssistant, ToolCalls: []openai.ToolCall{{ID: "call_a"}}},
+		{Role: openai.RoleTool, ToolCallID: "call_a", Content: "sunny"},
+	})
+	wantRoles(t, out, openai.RoleUser, openai.RoleAssistant, openai.RoleTool)
+	if out[2].ToolCallID != "call_a" || out[2].Content != "sunny" {
+		t.Errorf("tool message = %+v, want it untouched", out[2])
+	}
+}
+
+// TestEmptyMessages checks an empty conversation is returned as it came.
+func TestEmptyMessages(t *testing.T) {
+	if got := TransformMessages(nil); got != nil {
+		t.Errorf("TransformMessages(nil) = %+v, want nil", got)
+	}
+	if got := TransformMessages([]openai.Message{}); len(got) != 0 {
+		t.Errorf("TransformMessages(empty) = %+v, want empty", got)
+	}
+}
+
+// TestSourceMessagesNotMutated checks the rewrite leaves the caller's messages
+// as they were: the demotion writes roles, and the slice is shared with whoever
+// converted the conversation.
+func TestSourceMessagesNotMutated(t *testing.T) {
+	in := []openai.Message{
+		msg(openai.RoleSystem, "You are helpful."),
+		msg(openai.RoleUser, "Hello"),
+		msg(openai.RoleSystem, "Be concise."),
+	}
+	TransformMessages(in)
+	if in[2].Role != openai.RoleSystem {
+		t.Errorf("source message role = %q, want it left as the system role", in[2].Role)
+	}
+}
+
+// TestDeveloperMessageConvertedToUser checks the developer role is settled by
+// the embedded adapter, which the service tells that this endpoint has none.
+func TestDeveloperMessageConvertedToUser(t *testing.T) {
+	convo := frames.NewLLMContext("")
+	convo.AddMessage(frames.Message{Role: frames.RoleDeveloper, Text: "Extra context."})
+	convo.AddUserMessage("Hello")
+
+	p, err := (&Adapter{}).LLMInvocationParams(
+		convo, adapter.Options{ConvertDeveloperToUser: true},
+	)
+	if err != nil {
+		t.Fatalf("LLMInvocationParams: %v", err)
+	}
+	// Both became user messages, so they merge into one.
+	wantRoles(t, p.Messages, openai.RoleUser)
+	wantTexts(t, p.Messages[0], "Extra context.", "Hello")
+}
+
+// TestMergedContentGoesOutAsParts checks a merged message reaches the wire as a
+// list of parts, so what each of the two messages said stays distinct rather
+// than their text running together.
+func TestMergedContentGoesOutAsParts(t *testing.T) {
+	out := TransformMessages([]openai.Message{
+		msg(openai.RoleUser, "Hello"),
+		msg(openai.RoleUser, "Are you there?"),
+	})
+	raw, err := json.Marshal(out[0])
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	want := `{"content":[{"type":"text","text":"Hello"},` +
+		`{"type":"text","text":"Are you there?"}],"role":"user"}`
+	if string(raw) != want {
+		t.Errorf("encoded = %s, want %s", raw, want)
+	}
+}
+
+// TestConversionThroughAdapter checks the whole path: a conversation the
+// endpoint would reject is converted and rewritten into one it takes.
+func TestConversionThroughAdapter(t *testing.T) {
+	convo := frames.NewLLMContext("You are helpful.")
+	convo.AddUserMessage("Hello")
+	convo.AddUserMessage("Are you there?")
+	convo.AddAssistantMessage("Hi")
+
+	p, err := (&Adapter{}).LLMInvocationParams(convo, adapter.Options{})
+	if err != nil {
+		t.Fatalf("LLMInvocationParams: %v", err)
+	}
+	wantRoles(t, p.Messages, openai.RoleSystem, openai.RoleUser)
+	wantTexts(t, p.Messages[1], "Hello", "Are you there?")
+}

--- a/adapter/realtime/realtime.go
+++ b/adapter/realtime/realtime.go
@@ -68,7 +68,7 @@ func (a *Adapter) SessionParams(tools []frames.Tool, choice frames.ToolChoice) P
 	if choice == "" {
 		choice = frames.ToolChoiceAuto
 	}
-	return Params{Tools: a.ToProviderToolsFormat(tools), ToolChoice: string(choice)}
+	return Params{Tools: a.ToProviderToolsFormat(a.WithBuiltins(tools)), ToolChoice: string(choice)}
 }
 
 // ToProviderToolsFormat implements adapter.LLMAdapter. The Realtime API

--- a/adapter/realtime/realtime.go
+++ b/adapter/realtime/realtime.go
@@ -8,6 +8,8 @@
 package realtime
 
 import (
+	"log/slog"
+
 	"github.com/gojargo/jargo/adapter"
 	"github.com/gojargo/jargo/frames"
 )
@@ -58,27 +60,28 @@ func (*Adapter) IDForLLMSpecificMessages() string { return "openai_realtime" }
 func (a *Adapter) LLMInvocationParams(
 	convo *frames.LLMContext, _ adapter.Options,
 ) (Params, error) {
-	return a.SessionParams(convo.Tools(), convo.ToolChoice()), nil
+	return a.SessionParams(convo.ToolsSchema(), convo.ToolChoice()), nil
 }
 
 // SessionParams renders a toolset and choice for a session. It is what the
 // service calls when the toolset changes mid-conversation, which reaches a
 // realtime model as a session update rather than on the next request.
-func (a *Adapter) SessionParams(tools []frames.Tool, choice frames.ToolChoice) Params {
+func (a *Adapter) SessionParams(schema frames.ToolsSchema, choice frames.ToolChoice) Params {
 	if choice == "" {
 		choice = frames.ToolChoiceAuto
 	}
-	return Params{Tools: a.ToProviderToolsFormat(a.WithBuiltins(tools)), ToolChoice: string(choice)}
+	return Params{
+		Tools:      a.ToProviderToolsFormat(a.WithBuiltins(schema)),
+		ToolChoice: string(choice),
+	}
 }
 
 // ToProviderToolsFormat implements adapter.LLMAdapter. The Realtime API
-// flattens the function fields onto the tool rather than nesting them.
-func (*Adapter) ToProviderToolsFormat(tools []frames.Tool) []map[string]any {
-	if len(tools) == 0 {
-		return nil
-	}
-	out := make([]map[string]any, 0, len(tools))
-	for _, t := range tools {
+// flattens the function fields onto the tool rather than nesting them, and
+// reads the custom tools written for OpenAI like the other OpenAI APIs.
+func (*Adapter) ToProviderToolsFormat(schema frames.ToolsSchema) []map[string]any {
+	var out []map[string]any
+	for _, t := range schema.Standard {
 		spec := map[string]any{keyType: toolTypeFunction, keyName: t.Name}
 		if t.Description != "" {
 			spec[keyDescription] = t.Description
@@ -88,7 +91,12 @@ func (*Adapter) ToProviderToolsFormat(tools []frames.Tool) []map[string]any {
 		}
 		out = append(out, spec)
 	}
-	return out
+	custom, err := adapter.CustomToolsFor[map[string]any](schema, frames.AdapterTypeOpenAI)
+	if err != nil {
+		slog.Error("leaving out a custom tool the adapter cannot read", "err", err)
+		return out
+	}
+	return append(out, custom...)
 }
 
 // MessagesForLogging implements adapter.LLMAdapter. A realtime session carries

--- a/adapter/realtime/realtime.go
+++ b/adapter/realtime/realtime.go
@@ -1,0 +1,97 @@
+// Package realtime converts a universal conversation into what OpenAI's
+// Realtime API takes on a session.
+//
+// A realtime session is not a request carrying the conversation: the model
+// listens to the audio and keeps the history itself, so what is converted here
+// is the part of a session the conversation decides, which is the toolset and
+// whether the model may or must call one.
+package realtime
+
+import (
+	"github.com/gojargo/jargo/adapter"
+	"github.com/gojargo/jargo/frames"
+)
+
+// The keys a session payload's function-calling block is built from.
+const (
+	keyType        = "type"
+	keyName        = "name"
+	keyDescription = "description"
+	keyParameters  = "parameters"
+	keyTools       = "tools"
+	keyToolChoice  = "tool_choice"
+)
+
+// toolTypeFunction is the only tool type the Realtime API defines.
+const toolTypeFunction = "function"
+
+// Params is the part of a Realtime session the conversation decides: the tools
+// to advertise and whether the model may or must call one.
+type Params struct {
+	Tools      []map[string]any
+	ToolChoice string
+}
+
+// Session renders the params as the session payload block the API takes, or nil
+// when there are no tools to advertise.
+func (p Params) Session() map[string]any {
+	if len(p.Tools) == 0 {
+		return nil
+	}
+	return map[string]any{keyTools: p.Tools, keyToolChoice: p.ToolChoice}
+}
+
+// Adapter converts a universal conversation into Realtime session parameters.
+// The zero value is ready to use.
+type Adapter struct {
+	adapter.Base
+}
+
+// Compile-time check that the adapter satisfies the contract.
+var _ adapter.LLMAdapter[Params, map[string]any] = (*Adapter)(nil)
+
+// IDForLLMSpecificMessages implements adapter.LLMAdapter.
+func (*Adapter) IDForLLMSpecificMessages() string { return "openai_realtime" }
+
+// LLMInvocationParams converts the conversation into what a session takes from
+// it.
+func (a *Adapter) LLMInvocationParams(
+	convo *frames.LLMContext, _ adapter.Options,
+) (Params, error) {
+	return a.SessionParams(convo.Tools(), convo.ToolChoice()), nil
+}
+
+// SessionParams renders a toolset and choice for a session. It is what the
+// service calls when the toolset changes mid-conversation, which reaches a
+// realtime model as a session update rather than on the next request.
+func (a *Adapter) SessionParams(tools []frames.Tool, choice frames.ToolChoice) Params {
+	if choice == "" {
+		choice = frames.ToolChoiceAuto
+	}
+	return Params{Tools: a.ToProviderToolsFormat(tools), ToolChoice: string(choice)}
+}
+
+// ToProviderToolsFormat implements adapter.LLMAdapter. The Realtime API
+// flattens the function fields onto the tool rather than nesting them.
+func (*Adapter) ToProviderToolsFormat(tools []frames.Tool) []map[string]any {
+	if len(tools) == 0 {
+		return nil
+	}
+	out := make([]map[string]any, 0, len(tools))
+	for _, t := range tools {
+		spec := map[string]any{keyType: toolTypeFunction, keyName: t.Name}
+		if t.Description != "" {
+			spec[keyDescription] = t.Description
+		}
+		if len(t.Parameters) > 0 {
+			spec[keyParameters] = t.Parameters
+		}
+		out = append(out, spec)
+	}
+	return out
+}
+
+// MessagesForLogging implements adapter.LLMAdapter. A realtime session carries
+// no message list: the model hears the conversation rather than being sent it,
+// so there is nothing to render.
+func (*Adapter) MessagesForLogging(*frames.LLMContext) []map[string]any { return nil }

--- a/adapter/realtime/realtime_test.go
+++ b/adapter/realtime/realtime_test.go
@@ -17,11 +17,11 @@ func TestIDForLLMSpecificMessages(t *testing.T) {
 // TestToProviderToolsFormat checks the Realtime API's flattened tool shape: the
 // function fields sit on the tool rather than nested under a "function" key.
 func TestToProviderToolsFormat(t *testing.T) {
-	out := (&Adapter{}).ToProviderToolsFormat([]frames.Tool{{
+	out := (&Adapter{}).ToProviderToolsFormat(frames.ToolsSchema{Standard: []frames.Tool{{
 		Name:        "get_weather",
 		Description: "Look it up",
 		Parameters:  json.RawMessage(`{"type":"object"}`),
-	}})
+	}}})
 	if len(out) != 1 {
 		t.Fatalf("tools = %+v, want one", out)
 	}
@@ -36,7 +36,7 @@ func TestToProviderToolsFormat(t *testing.T) {
 // TestToProviderToolsFormatOmitsEmptyFields checks a tool with no description or
 // schema states neither, rather than sending them empty.
 func TestToProviderToolsFormatOmitsEmptyFields(t *testing.T) {
-	out := (&Adapter{}).ToProviderToolsFormat([]frames.Tool{{Name: "now"}})
+	out := (&Adapter{}).ToProviderToolsFormat(frames.ToolsSchema{Standard: []frames.Tool{{Name: "now"}}})
 	if _, ok := out[0][keyDescription]; ok {
 		t.Errorf("tool = %+v, want no description key", out[0])
 	}
@@ -49,7 +49,7 @@ func TestToProviderToolsFormatOmitsEmptyFields(t *testing.T) {
 // is sent the default rather than an empty one, which would leave the model
 // without an answer to whether it may call a tool.
 func TestSessionParamsDefaultsTheChoice(t *testing.T) {
-	p := (&Adapter{}).SessionParams([]frames.Tool{{Name: "now"}}, "")
+	p := (&Adapter{}).SessionParams(frames.ToolsSchema{Standard: []frames.Tool{{Name: "now"}}}, "")
 	if p.ToolChoice != string(frames.ToolChoiceAuto) {
 		t.Errorf("choice = %q, want %q", p.ToolChoice, frames.ToolChoiceAuto)
 	}
@@ -58,7 +58,7 @@ func TestSessionParamsDefaultsTheChoice(t *testing.T) {
 // TestSessionIsNilWithoutTools checks a conversation advertising no tools
 // renders no function-calling block at all.
 func TestSessionIsNilWithoutTools(t *testing.T) {
-	if got := (&Adapter{}).SessionParams(nil, frames.ToolChoiceAuto).Session(); got != nil {
+	if got := (&Adapter{}).SessionParams(frames.ToolsSchema{}, frames.ToolChoiceAuto).Session(); got != nil {
 		t.Errorf("session = %+v, want nil", got)
 	}
 }
@@ -66,7 +66,9 @@ func TestSessionIsNilWithoutTools(t *testing.T) {
 // TestSessionCarriesToolsAndChoice checks both halves reach the session payload.
 func TestSessionCarriesToolsAndChoice(t *testing.T) {
 	got := (&Adapter{}).
-		SessionParams([]frames.Tool{{Name: "now"}}, frames.ToolChoiceRequired).
+		SessionParams(
+			frames.ToolsSchema{Standard: []frames.Tool{{Name: "now"}}}, frames.ToolChoiceRequired,
+		).
 		Session()
 	tools, ok := got[keyTools].([]map[string]any)
 	if !ok || len(tools) != 1 {

--- a/adapter/realtime/realtime_test.go
+++ b/adapter/realtime/realtime_test.go
@@ -1,0 +1,107 @@
+package realtime
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/gojargo/jargo/adapter"
+	"github.com/gojargo/jargo/frames"
+)
+
+func TestIDForLLMSpecificMessages(t *testing.T) {
+	if got := (&Adapter{}).IDForLLMSpecificMessages(); got != "openai_realtime" {
+		t.Errorf("id = %q, want %q", got, "openai_realtime")
+	}
+}
+
+// TestToProviderToolsFormat checks the Realtime API's flattened tool shape: the
+// function fields sit on the tool rather than nested under a "function" key.
+func TestToProviderToolsFormat(t *testing.T) {
+	out := (&Adapter{}).ToProviderToolsFormat([]frames.Tool{{
+		Name:        "get_weather",
+		Description: "Look it up",
+		Parameters:  json.RawMessage(`{"type":"object"}`),
+	}})
+	if len(out) != 1 {
+		t.Fatalf("tools = %+v, want one", out)
+	}
+	if out[0][keyType] != toolTypeFunction || out[0][keyName] != "get_weather" {
+		t.Errorf("tool = %+v, want a flattened function tool", out[0])
+	}
+	if out[0][keyDescription] != "Look it up" {
+		t.Errorf("description = %v, want the tool's own", out[0][keyDescription])
+	}
+}
+
+// TestToProviderToolsFormatOmitsEmptyFields checks a tool with no description or
+// schema states neither, rather than sending them empty.
+func TestToProviderToolsFormatOmitsEmptyFields(t *testing.T) {
+	out := (&Adapter{}).ToProviderToolsFormat([]frames.Tool{{Name: "now"}})
+	if _, ok := out[0][keyDescription]; ok {
+		t.Errorf("tool = %+v, want no description key", out[0])
+	}
+	if _, ok := out[0][keyParameters]; ok {
+		t.Errorf("tool = %+v, want no parameters key", out[0])
+	}
+}
+
+// TestSessionParamsDefaultsTheChoice checks a conversation that states no choice
+// is sent the default rather than an empty one, which would leave the model
+// without an answer to whether it may call a tool.
+func TestSessionParamsDefaultsTheChoice(t *testing.T) {
+	p := (&Adapter{}).SessionParams([]frames.Tool{{Name: "now"}}, "")
+	if p.ToolChoice != string(frames.ToolChoiceAuto) {
+		t.Errorf("choice = %q, want %q", p.ToolChoice, frames.ToolChoiceAuto)
+	}
+}
+
+// TestSessionIsNilWithoutTools checks a conversation advertising no tools
+// renders no function-calling block at all.
+func TestSessionIsNilWithoutTools(t *testing.T) {
+	if got := (&Adapter{}).SessionParams(nil, frames.ToolChoiceAuto).Session(); got != nil {
+		t.Errorf("session = %+v, want nil", got)
+	}
+}
+
+// TestSessionCarriesToolsAndChoice checks both halves reach the session payload.
+func TestSessionCarriesToolsAndChoice(t *testing.T) {
+	got := (&Adapter{}).
+		SessionParams([]frames.Tool{{Name: "now"}}, frames.ToolChoiceRequired).
+		Session()
+	tools, ok := got[keyTools].([]map[string]any)
+	if !ok || len(tools) != 1 {
+		t.Fatalf("session = %+v, want the toolset on it", got)
+	}
+	if got[keyToolChoice] != string(frames.ToolChoiceRequired) {
+		t.Errorf("choice = %v, want %q", got[keyToolChoice], frames.ToolChoiceRequired)
+	}
+}
+
+// TestLLMInvocationParamsReadsTheConversation checks the conversation's own
+// toolset and choice are what a session is built from.
+func TestLLMInvocationParamsReadsTheConversation(t *testing.T) {
+	convo := frames.NewLLMContext("be helpful")
+	convo.SetTools([]frames.Tool{{Name: "now"}})
+	convo.SetToolChoice(frames.ToolChoiceRequired)
+
+	p, err := (&Adapter{}).LLMInvocationParams(convo, adapter.Options{})
+	if err != nil {
+		t.Fatalf("LLMInvocationParams: %v", err)
+	}
+	if len(p.Tools) != 1 || p.Tools[0][keyName] != "now" {
+		t.Errorf("tools = %+v, want the conversation's own", p.Tools)
+	}
+	if p.ToolChoice != string(frames.ToolChoiceRequired) {
+		t.Errorf("choice = %q, want the conversation's own", p.ToolChoice)
+	}
+}
+
+// TestMessagesForLoggingIsEmpty checks a realtime session renders no message
+// list: the model hears the conversation rather than being sent it.
+func TestMessagesForLoggingIsEmpty(t *testing.T) {
+	convo := frames.NewLLMContext("be helpful")
+	convo.AddUserMessage("hello")
+	if got := (&Adapter{}).MessagesForLogging(convo); got != nil {
+		t.Errorf("logged = %+v, want nothing", got)
+	}
+}

--- a/adapter/responses/responses.go
+++ b/adapter/responses/responses.go
@@ -81,7 +81,9 @@ func (*Adapter) IDForLLMSpecificMessages() string { return "openai" }
 func (a *Adapter) LLMInvocationParams(
 	convo *frames.LLMContext, opts adapter.Options,
 ) (Params, error) {
-	instructions := a.ResolveSystemInstruction(convo.System(), opts.SystemInstruction, true)
+	instructions := a.ResolveSystemInstruction(
+		a.SystemWithBuiltins(convo.System()), opts.SystemInstruction, true,
+	)
 	params := Params{
 		Input:        ToInput(convo.Messages()),
 		Instructions: instructions,
@@ -95,7 +97,7 @@ func (a *Adapter) LLMInvocationParams(
 		}
 		params.Instructions = ""
 	}
-	if tools := convo.Tools(); len(tools) > 0 {
+	if tools := a.WithBuiltins(convo.Tools()); len(tools) > 0 {
 		params.Tools = a.ToProviderToolsFormat(tools)
 	}
 	return params, nil

--- a/adapter/responses/responses.go
+++ b/adapter/responses/responses.go
@@ -1,0 +1,195 @@
+// Package responses converts a universal conversation into the request
+// OpenAI's Responses API takes, over HTTP and over the WebSocket alike: the two
+// transports carry the same request.
+package responses
+
+import (
+	"encoding/json"
+
+	"github.com/gojargo/jargo/adapter"
+	"github.com/gojargo/jargo/frames"
+)
+
+// The kinds of entry a Responses request's input list holds.
+const (
+	ItemMessage    = "message"
+	ItemFuncCall   = "function_call"
+	ItemFuncOutput = "function_call_output"
+)
+
+// The roles the Responses API takes on an input message. It has no system role:
+// what would be a system message enters as a developer message, which is the
+// role it reserves for instructions given out of band.
+const (
+	RoleUser      = "user"
+	RoleAssistant = "assistant"
+	RoleDeveloper = "developer"
+)
+
+// toolTypeFunction is the only tool type the Responses API defines.
+const toolTypeFunction = "function"
+
+// InputItem is one entry of a Responses request's input list: a message, a
+// function call the model made, or the result of one.
+type InputItem struct {
+	Type string `json:"type"`
+	// Role and Content carry a message.
+	Role    string `json:"role,omitempty"`
+	Content string `json:"content,omitempty"`
+	// CallID, Name and Arguments carry a function call.
+	CallID    string `json:"call_id,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Arguments string `json:"arguments,omitempty"`
+	// Output carries a function call's result.
+	Output string `json:"output,omitempty"`
+}
+
+// Tool is a function tool advertised on the request. The Responses API flattens
+// the function fields onto the tool rather than nesting them.
+type Tool struct {
+	Type        string          `json:"type"`
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Parameters  json.RawMessage `json:"parameters,omitempty"`
+}
+
+// Params is what one Responses call takes from the conversation: the input list,
+// the instructions carried beside it, and the tools to advertise.
+type Params struct {
+	Input        []InputItem
+	Instructions string
+	Tools        []Tool
+}
+
+// Adapter converts a universal conversation into a Responses request. The zero
+// value is ready to use.
+type Adapter struct {
+	adapter.Base
+}
+
+// Compile-time check that the adapter satisfies the contract.
+var _ adapter.LLMAdapter[Params, Tool] = (*Adapter)(nil)
+
+// IDForLLMSpecificMessages implements adapter.LLMAdapter.
+func (*Adapter) IDForLLMSpecificMessages() string { return "openai" }
+
+// LLMInvocationParams converts the conversation into a Responses request.
+//
+// The Responses API takes the system prompt as its own field beside the input
+// rather than as a leading message, so it has one place to put it: an
+// instruction given for this call replaces the conversation's own prompt.
+func (a *Adapter) LLMInvocationParams(
+	convo *frames.LLMContext, opts adapter.Options,
+) (Params, error) {
+	instructions := a.ResolveSystemInstruction(convo.System(), opts.SystemInstruction, true)
+	params := Params{
+		Input:        ToInput(convo.Messages()),
+		Instructions: instructions,
+	}
+	// The API requires at least one input item when instructions are given, so a
+	// conversation with nothing said yet carries the instruction as a developer
+	// message instead of beside an empty list.
+	if instructions != "" && len(params.Input) == 0 {
+		params.Input = []InputItem{
+			{Type: ItemMessage, Role: RoleDeveloper, Content: instructions},
+		}
+		params.Instructions = ""
+	}
+	if tools := convo.Tools(); len(tools) > 0 {
+		params.Tools = a.ToProviderToolsFormat(tools)
+	}
+	return params, nil
+}
+
+// ToInput converts the conversation's messages into the Responses input list. A
+// tool turn becomes a function_call item and a function_call_output item
+// answering it, paired by the call id.
+func ToInput(msgs []frames.Message) []InputItem {
+	items := make([]InputItem, 0, len(msgs))
+	for _, m := range msgs {
+		switch {
+		case len(m.ToolResults) > 0:
+			for _, r := range m.ToolResults {
+				items = append(items, InputItem{
+					Type: ItemFuncOutput, CallID: r.ID, Output: r.Content,
+				})
+			}
+		case len(m.ToolCalls) > 0:
+			items = append(items, toolCallItems(m)...)
+		default:
+			items = append(items, InputItem{
+				Type: ItemMessage, Role: inputRole(m.Role), Content: m.Text,
+			})
+		}
+	}
+	return items
+}
+
+// inputRole maps a conversation role to the one the Responses API takes. It has
+// no system role, so a system message enters as a developer message: that is
+// the role it reserves for instructions given out of band, which is what a
+// system message is.
+func inputRole(role frames.Role) string {
+	if role == frames.RoleSystem || role == frames.RoleDeveloper {
+		return RoleDeveloper
+	}
+	if role == frames.RoleAssistant {
+		return RoleAssistant
+	}
+	return RoleUser
+}
+
+// toolCallItems renders an assistant turn's optional preamble and tool calls.
+func toolCallItems(m frames.Message) []InputItem {
+	items := make([]InputItem, 0, len(m.ToolCalls)+1)
+	if m.Text != "" {
+		items = append(items, InputItem{
+			Type: ItemMessage, Role: RoleAssistant, Content: m.Text,
+		})
+	}
+	for _, call := range m.ToolCalls {
+		args := string(call.Args)
+		if args == "" {
+			args = "{}"
+		}
+		items = append(items, InputItem{
+			Type: ItemFuncCall, CallID: call.ID, Name: call.Name, Arguments: args,
+		})
+	}
+	return items
+}
+
+// ToProviderToolsFormat implements adapter.LLMAdapter.
+func (*Adapter) ToProviderToolsFormat(tools []frames.Tool) []Tool {
+	out := make([]Tool, 0, len(tools))
+	for _, t := range tools {
+		out = append(out, Tool{
+			Type:        toolTypeFunction,
+			Name:        t.Name,
+			Description: t.Description,
+			Parameters:  t.Parameters,
+		})
+	}
+	return out
+}
+
+// MessagesForLogging implements adapter.LLMAdapter.
+func (a *Adapter) MessagesForLogging(convo *frames.LLMContext) []map[string]any {
+	params, err := a.LLMInvocationParams(convo, adapter.Options{})
+	if err != nil {
+		return nil
+	}
+	out := make([]map[string]any, 0, len(params.Input))
+	for _, item := range params.Input {
+		raw, err := json.Marshal(item)
+		if err != nil {
+			continue
+		}
+		var got map[string]any
+		if err := json.Unmarshal(raw, &got); err != nil {
+			continue
+		}
+		out = append(out, got)
+	}
+	return out
+}

--- a/adapter/responses/responses.go
+++ b/adapter/responses/responses.go
@@ -84,10 +84,11 @@ func (a *Adapter) LLMInvocationParams(
 	instructions := a.ResolveSystemInstruction(
 		a.SystemWithBuiltins(convo.System()), opts.SystemInstruction, true,
 	)
-	params := Params{
-		Input:        ToInput(convo.Messages()),
-		Instructions: instructions,
+	input, err := ToInput(convo.MessagesFor(a.IDForLLMSpecificMessages()))
+	if err != nil {
+		return Params{}, err
 	}
+	params := Params{Input: input, Instructions: instructions}
 	// The API requires at least one input item when instructions are given, so a
 	// conversation with nothing said yet carries the instruction as a developer
 	// message instead of beside an empty list.
@@ -106,10 +107,16 @@ func (a *Adapter) LLMInvocationParams(
 // ToInput converts the conversation's messages into the Responses input list. A
 // tool turn becomes a function_call item and a function_call_output item
 // answering it, paired by the call id.
-func ToInput(msgs []frames.Message) []InputItem {
+func ToInput(msgs []frames.Message) ([]InputItem, error) {
 	items := make([]InputItem, 0, len(msgs))
 	for _, m := range msgs {
 		switch {
+		case m.IsLLMSpecific():
+			native, err := adapter.NativeMessage[InputItem](m)
+			if err != nil {
+				return nil, err
+			}
+			items = append(items, native)
 		case len(m.ToolResults) > 0:
 			for _, r := range m.ToolResults {
 				items = append(items, InputItem{
@@ -124,7 +131,7 @@ func ToInput(msgs []frames.Message) []InputItem {
 			})
 		}
 	}
-	return items
+	return items, nil
 }
 
 // inputRole maps a conversation role to the one the Responses API takes. It has

--- a/adapter/responses/responses.go
+++ b/adapter/responses/responses.go
@@ -5,6 +5,7 @@ package responses
 
 import (
 	"encoding/json"
+	"log/slog"
 
 	"github.com/gojargo/jargo/adapter"
 	"github.com/gojargo/jargo/frames"
@@ -44,13 +45,31 @@ type InputItem struct {
 	Output string `json:"output,omitempty"`
 }
 
-// Tool is a function tool advertised on the request. The Responses API flattens
-// the function fields onto the tool rather than nesting them.
+// Tool is a tool advertised on the request. The Responses API flattens the
+// function fields onto the tool rather than nesting them. A tool the provider
+// implements itself, which this schema has no place for, is carried whole in
+// Raw.
 type Tool struct {
 	Type        string          `json:"type"`
 	Name        string          `json:"name"`
 	Description string          `json:"description,omitempty"`
 	Parameters  json.RawMessage `json:"parameters,omitempty"`
+	// Raw is the tool exactly as the provider takes it, and replaces the modeled
+	// fields entirely when set. It is how a provider-native tool (a hosted search
+	// tool, say, which the model runs itself rather than calling back for) is
+	// advertised without being forced into the function shape.
+	Raw map[string]any `json:"-"`
+}
+
+// MarshalJSON encodes the tool, sending Raw in place of the modeled fields when
+// it is set.
+func (t Tool) MarshalJSON() ([]byte, error) {
+	if len(t.Raw) > 0 {
+		return json.Marshal(t.Raw)
+	}
+	// plain drops the method set, so marshaling it does not recurse.
+	type plain Tool
+	return json.Marshal(plain(t))
 }
 
 // Params is what one Responses call takes from the conversation: the input list,
@@ -98,7 +117,8 @@ func (a *Adapter) LLMInvocationParams(
 		}
 		params.Instructions = ""
 	}
-	if tools := a.WithBuiltins(convo.Tools()); len(tools) > 0 {
+	if tools := a.WithBuiltins(convo.ToolsSchema()); len(tools.Standard) > 0 ||
+		len(tools.Custom) > 0 {
 		params.Tools = a.ToProviderToolsFormat(tools)
 	}
 	return params, nil
@@ -169,9 +189,9 @@ func toolCallItems(m frames.Message) []InputItem {
 }
 
 // ToProviderToolsFormat implements adapter.LLMAdapter.
-func (*Adapter) ToProviderToolsFormat(tools []frames.Tool) []Tool {
-	out := make([]Tool, 0, len(tools))
-	for _, t := range tools {
+func (*Adapter) ToProviderToolsFormat(schema frames.ToolsSchema) []Tool {
+	out := make([]Tool, 0, len(schema.Standard))
+	for _, t := range schema.Standard {
 		out = append(out, Tool{
 			Type:        toolTypeFunction,
 			Name:        t.Name,
@@ -179,7 +199,12 @@ func (*Adapter) ToProviderToolsFormat(tools []frames.Tool) []Tool {
 			Parameters:  t.Parameters,
 		})
 	}
-	return out
+	custom, err := adapter.CustomToolsFor[Tool](schema, frames.AdapterTypeOpenAI)
+	if err != nil {
+		slog.Error("leaving out a custom tool the adapter cannot read", "err", err)
+		return out
+	}
+	return append(out, custom...)
 }
 
 // MessagesForLogging implements adapter.LLMAdapter.

--- a/adapter/responses/responses_test.go
+++ b/adapter/responses/responses_test.go
@@ -1,0 +1,217 @@
+package responses
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/gojargo/jargo/adapter"
+	"github.com/gojargo/jargo/frames"
+)
+
+// capturedWarnings swaps the default logger for one writing into a buffer and
+// returns a reader for what was logged, restoring the logger when the test ends.
+func capturedWarnings(t *testing.T) func() string {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return buf.String
+}
+
+// paramsOf converts a conversation and fails the test if the conversion did.
+func paramsOf(t *testing.T, convo *frames.LLMContext, opts adapter.Options) Params {
+	t.Helper()
+	p, err := (&Adapter{}).LLMInvocationParams(convo, opts)
+	if err != nil {
+		t.Fatalf("LLMInvocationParams: %v", err)
+	}
+	return p
+}
+
+// TestSystemRoleBecomesDeveloper checks a system message said partway through
+// the conversation enters as a developer message. The Responses API has no
+// system role: developer is the role it reserves for instructions given out of
+// band, which is what a system message is.
+func TestSystemRoleBecomesDeveloper(t *testing.T) {
+	convo := frames.NewLLMContext("")
+	convo.AddUserMessage("hello")
+	convo.AddMessage(frames.Message{Role: frames.RoleSystem, Text: "be concise"})
+
+	items := paramsOf(t, convo, adapter.Options{}).Input
+	if len(items) != 2 {
+		t.Fatalf("items = %+v, want both messages", items)
+	}
+	if items[1].Role != RoleDeveloper || items[1].Content != "be concise" {
+		t.Errorf("item 1 = %+v, want the system message sent as a developer message", items[1])
+	}
+}
+
+// TestDeveloperRoleKept checks a developer message stays one: it is already the
+// role the API takes.
+func TestDeveloperRoleKept(t *testing.T) {
+	convo := frames.NewLLMContext("")
+	convo.AddMessage(frames.Message{Role: frames.RoleDeveloper, Text: "a tool reported late"})
+
+	items := paramsOf(t, convo, adapter.Options{}).Input
+	if items[0].Role != RoleDeveloper {
+		t.Errorf("role = %q, want it left as the developer role", items[0].Role)
+	}
+}
+
+// TestSystemInstructionReplacesTheContextPrompt checks that an instruction given
+// for one call stands in place of the conversation's own: the API has one
+// instructions field, so the two cannot both be sent.
+func TestSystemInstructionReplacesTheContextPrompt(t *testing.T) {
+	convo := frames.NewLLMContext("be brief")
+	convo.AddUserMessage("hello")
+	warnings := capturedWarnings(t)
+
+	p := paramsOf(t, convo, adapter.Options{SystemInstruction: "be concise"})
+
+	if p.Instructions != "be concise" {
+		t.Errorf("instructions = %q, want the call's own", p.Instructions)
+	}
+	if got := warnings(); !strings.Contains(got, "using the instruction") {
+		t.Errorf("warnings = %q, want the conflict reported", got)
+	}
+}
+
+// TestInstructionsBecomeADeveloperMessageWhenNothingSaid checks a conversation
+// with nothing said yet carries the instruction as a developer message. The API
+// requires at least one input item when instructions are given, so sending them
+// beside an empty list is a request it refuses.
+func TestInstructionsBecomeADeveloperMessageWhenNothingSaid(t *testing.T) {
+	convo := frames.NewLLMContext("be brief")
+
+	p := paramsOf(t, convo, adapter.Options{})
+	if p.Instructions != "" {
+		t.Errorf("instructions = %q, want none: they went into the input", p.Instructions)
+	}
+	if len(p.Input) != 1 {
+		t.Fatalf("input = %+v, want the instruction as its one item", p.Input)
+	}
+	if p.Input[0].Role != RoleDeveloper || p.Input[0].Content != "be brief" {
+		t.Errorf("item = %+v, want the instruction as a developer message", p.Input[0])
+	}
+}
+
+// TestNoInstructionsAndNothingSaid checks an empty conversation with no prompt
+// stays empty rather than gaining a message with nothing in it.
+func TestNoInstructionsAndNothingSaid(t *testing.T) {
+	p := paramsOf(t, frames.NewLLMContext(""), adapter.Options{})
+	if len(p.Input) != 0 || p.Instructions != "" {
+		t.Errorf("params = %+v, want nothing to send", p)
+	}
+}
+
+func TestIDForLLMSpecificMessages(t *testing.T) {
+	if got := (&Adapter{}).IDForLLMSpecificMessages(); got != "openai" {
+		t.Errorf("id = %q, want %q", got, "openai")
+	}
+}
+
+// TestToInputMessages checks a plain conversation becomes message items, and
+// that the system prompt is lifted out into the instructions field rather than
+// traveling as a message.
+func TestToInputMessages(t *testing.T) {
+	convo := frames.NewLLMContext("be brief")
+	convo.AddUserMessage("hello")
+	convo.AddAssistantMessage("hi there")
+
+	p := paramsOf(t, convo, adapter.Options{})
+	items, instructions := p.Input, p.Instructions
+	if instructions != "be brief" {
+		t.Errorf("instructions = %q, want the system prompt", instructions)
+	}
+	if len(items) != 2 {
+		t.Fatalf("items = %+v, want the two non-system messages", items)
+	}
+	if items[0].Type != ItemMessage || items[0].Role != "user" || items[0].Content != "hello" {
+		t.Errorf("item 0 = %+v, want the user message", items[0])
+	}
+	if items[1].Role != "assistant" || items[1].Content != "hi there" {
+		t.Errorf("item 1 = %+v, want the assistant message", items[1])
+	}
+}
+
+// TestToInputToolTurn checks a tool exchange renders as the function_call and
+// function_call_output items the Responses API expects, rather than the
+// chat-completions message shapes.
+func TestToInputToolTurn(t *testing.T) {
+	convo := frames.NewLLMContext("")
+	convo.AddUserMessage("weather?")
+	convo.AddAssistantMessage("let me check")
+	convo.AddAssistantToolCall(frames.ToolCall{
+		ID: "call_1", Name: "get_weather", Args: json.RawMessage(`{"city":"Paris"}`),
+	})
+	convo.AddToolResult(frames.ToolResult{ID: "call_1", Content: "sunny"})
+
+	items := paramsOf(t, convo, adapter.Options{}).Input
+	if len(items) != 4 {
+		t.Fatalf("items = %+v, want user, assistant text, function call, output", items)
+	}
+	if items[1].Type != ItemMessage || items[1].Content != "let me check" {
+		t.Errorf("item 1 = %+v, want the assistant's text alongside the call", items[1])
+	}
+	if items[2].Type != ItemFuncCall || items[2].CallID != "call_1" || items[2].Name != "get_weather" {
+		t.Errorf("item 2 = %+v, want the function call", items[2])
+	}
+	if items[2].Arguments != `{"city":"Paris"}` {
+		t.Errorf("arguments = %q, want the call's JSON", items[2].Arguments)
+	}
+	if items[3].Type != ItemFuncOutput || items[3].CallID != "call_1" || items[3].Output != "sunny" {
+		t.Errorf("item 3 = %+v, want the function output", items[3])
+	}
+}
+
+// TestToInputEmptyArguments checks a call with no arguments sends an empty
+// object, which the API requires, rather than an empty string.
+func TestToInputEmptyArguments(t *testing.T) {
+	convo := frames.NewLLMContext("")
+	convo.AddAssistantToolCall(frames.ToolCall{ID: "c1", Name: "now"})
+	items := paramsOf(t, convo, adapter.Options{}).Input
+	if len(items) != 1 || items[0].Arguments != "{}" {
+		t.Errorf("items = %+v, want a call with empty-object arguments", items)
+	}
+}
+
+// TestToProviderToolsFormat checks the Responses API's flattened tool shape: the function
+// fields sit on the tool rather than nested under a "function" key.
+func TestToProviderToolsFormat(t *testing.T) {
+	convo := frames.NewLLMContext("")
+	if got := paramsOf(t, convo, adapter.Options{}).Tools; got != nil {
+		t.Errorf("buildTools with no tools = %+v, want nil", got)
+	}
+
+	convo.SetTools([]frames.Tool{{
+		Name:        "get_weather",
+		Description: "look it up",
+		Parameters:  json.RawMessage(`{"type":"object"}`),
+	}})
+	tools := paramsOf(t, convo, adapter.Options{}).Tools
+	if len(tools) != 1 {
+		t.Fatalf("tools = %+v, want one", tools)
+	}
+	if tools[0].Type != "function" || tools[0].Name != "get_weather" {
+		t.Errorf("tool = %+v, want a flattened function tool", tools[0])
+	}
+
+	raw, err := json.Marshal(tools[0])
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, nested := m["function"]; nested {
+		t.Errorf("tool = %s, want the function fields flattened onto it", raw)
+	}
+	if m["name"] != "get_weather" {
+		t.Errorf("tool name = %v, want it at the top level", m["name"])
+	}
+}

--- a/frames/llm_context.go
+++ b/frames/llm_context.go
@@ -48,6 +48,54 @@ type Tool struct {
 	Handler any
 }
 
+// AdapterType names the wire format a custom tool is written in. Several
+// providers share one: everything speaking OpenAI's API reads a tool written
+// for OpenAI, whether it arrives over chat completions, the Responses API or a
+// realtime session.
+type AdapterType string
+
+const (
+	// AdapterTypeOpenAI is OpenAI's tool format: chat completions, the Responses
+	// API and the Realtime API alike.
+	AdapterTypeOpenAI AdapterType = "openai"
+	// AdapterTypeGemini is Gemini's tool format.
+	AdapterTypeGemini AdapterType = "gemini"
+)
+
+// ToolsSchema is the toolset a conversation advertises.
+//
+// Standard holds the tools every provider is offered, described the same way
+// for all of them. Custom holds tools written in one provider's own format, for
+// the ones no common description fits: a hosted search tool, say, which the
+// provider implements itself rather than calling back for. A provider is only
+// ever sent the custom tools written for its own format, so a conversation
+// carrying them is still usable with every other provider.
+//
+// Each custom tool must be the tool type its adapter's package defines. Not
+// every provider takes them: Anthropic has no custom tools, and anything under
+// a key it does not read is left out.
+type ToolsSchema struct {
+	Standard []Tool
+	Custom   map[AdapterType][]any
+}
+
+// clone returns a schema sharing nothing with this one, so a later change to
+// either is invisible to the other.
+func (s ToolsSchema) clone() ToolsSchema {
+	out := ToolsSchema{Standard: append([]Tool(nil), s.Standard...)}
+	if len(s.Custom) > 0 {
+		out.Custom = make(map[AdapterType][]any, len(s.Custom))
+		for k, v := range s.Custom {
+			out.Custom[k] = append([]any(nil), v...)
+		}
+	}
+	return out
+}
+
+// CustomFor returns the custom tools written for the named format, or nil if
+// there are none.
+func (s ToolsSchema) CustomFor(t AdapterType) []any { return s.Custom[t] }
+
 // ToolCall is a request from the model to invoke a tool. Args is the raw JSON
 // arguments the model produced.
 type ToolCall struct {
@@ -142,7 +190,7 @@ type LLMContext struct {
 	summary    string // rolling summary of compacted older turns; empty until the first Compact
 	recall     string // transient retrieved context (e.g. long-term memories) for the next generation
 	messages   []Message
-	tools      []Tool
+	tools      ToolsSchema
 	toolChoice ToolChoice
 }
 
@@ -239,7 +287,9 @@ func (c *LLMContext) SetSystem(system string) {
 	c.mu.Unlock()
 }
 
-// Tools returns a copy of the tools the model may call.
+// Tools returns a copy of the standard tools the model may call: the ones
+// described the same way for every provider. For the whole toolset, custom
+// tools included, see ToolsSchema.
 //
 // It is what the conversation advertises. A tool the LLM service implements
 // itself is not here: that belongs to the service, and lives on the adapter it
@@ -248,7 +298,16 @@ func (c *LLMContext) SetSystem(system string) {
 func (c *LLMContext) Tools() []Tool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return append([]Tool(nil), c.tools...)
+	return append([]Tool(nil), c.tools.Standard...)
+}
+
+// ToolsSchema returns a copy of the whole toolset the conversation advertises,
+// the tools written in one provider's own format included. It is what an
+// adapter reads.
+func (c *LLMContext) ToolsSchema() ToolsSchema {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.tools.clone()
 }
 
 // SetTools replaces the set of tools the model may call.
@@ -261,7 +320,17 @@ func (c *LLMContext) Tools() []Tool {
 // told. Use this directly only to seed the toolset before the pipeline starts.
 func (c *LLMContext) SetTools(tools []Tool) {
 	c.mu.Lock()
-	c.tools = tools
+	c.tools = ToolsSchema{Standard: tools}
+	c.mu.Unlock()
+}
+
+// SetToolsSchema replaces the whole toolset, the tools written in one
+// provider's own format included. The same caveat as SetTools applies: on a
+// running pipeline push an [LLMSetToolsFrame] so realtime services learn of the
+// change.
+func (c *LLMContext) SetToolsSchema(schema ToolsSchema) {
+	c.mu.Lock()
+	c.tools = schema.clone()
 	c.mu.Unlock()
 }
 

--- a/frames/llm_context.go
+++ b/frames/llm_context.go
@@ -110,14 +110,6 @@ type LLMContext struct {
 	messages   []Message
 	tools      []Tool
 	toolChoice ToolChoice
-
-	// What the LLM service adds on its own account for the next generation: a
-	// built-in tool it implements, and the instructions that go with it. They are
-	// kept apart from the application's own so that the service can add and
-	// withdraw them as its registrations change, without ever editing what the
-	// application set.
-	serviceTools        []Tool
-	serviceInstructions string
 }
 
 // summaryHeader introduces the rolling summary appended to the system prompt
@@ -142,7 +134,7 @@ func (c *LLMContext) System() string {
 // transient recalled context, and whatever the LLM service adds for its own
 // built-in tools. The caller must hold c.mu.
 func (c *LLMContext) systemLocked() string {
-	parts := make([]string, 0, 4)
+	parts := make([]string, 0, 3)
 	if c.system != "" {
 		parts = append(parts, c.system)
 	}
@@ -151,9 +143,6 @@ func (c *LLMContext) systemLocked() string {
 	}
 	if c.recall != "" {
 		parts = append(parts, c.recall)
-	}
-	if c.serviceInstructions != "" {
-		parts = append(parts, c.serviceInstructions)
 	}
 	return strings.Join(parts, "\n\n")
 }
@@ -216,43 +205,16 @@ func (c *LLMContext) SetSystem(system string) {
 	c.mu.Unlock()
 }
 
-// Tools returns a copy of the tools the model may call: the conversation's own,
-// followed by any the LLM service implements itself.
+// Tools returns a copy of the tools the model may call.
+//
+// It is what the conversation advertises. A tool the LLM service implements
+// itself is not here: that belongs to the service, and lives on the adapter it
+// converts through, so a conversation shared by two services does not offer
+// each of them the other's.
 func (c *LLMContext) Tools() []Tool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	out := make([]Tool, 0, len(c.tools)+len(c.serviceTools))
-	out = append(out, c.tools...)
-	out = append(out, c.serviceTools...)
-	return out
-}
-
-// AppTools returns a copy of the tools the application advertised, without the
-// ones the LLM service adds on its own account. It is what to ask when the
-// question is what the application offers, rather than what the model is being
-// shown.
-func (c *LLMContext) AppTools() []Tool {
-	c.mu.Lock()
-	defer c.mu.Unlock()
 	return append([]Tool(nil), c.tools...)
-}
-
-// SetServiceTools replaces the tools the LLM service implements itself, which
-// Tools appends to the conversation's own. Only the LLM service calls it; an
-// application sets its tools with SetTools or an [LLMSetToolsFrame].
-func (c *LLMContext) SetServiceTools(tools []Tool) {
-	c.mu.Lock()
-	c.serviceTools = append([]Tool(nil), tools...)
-	c.mu.Unlock()
-}
-
-// SetServiceInstructions replaces the instructions the LLM service adds to the
-// system prompt for the tools it implements itself. Only the LLM service calls
-// it; an application sets the prompt with SetSystem.
-func (c *LLMContext) SetServiceInstructions(instructions string) {
-	c.mu.Lock()
-	c.serviceInstructions = instructions
-	c.mu.Unlock()
 }
 
 // SetTools replaces the set of tools the model may call.

--- a/frames/llm_context.go
+++ b/frames/llm_context.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 	"sync"
 )
@@ -65,6 +66,9 @@ type ToolResult struct {
 // Message is a single conversation turn. A plain turn carries Text; an assistant
 // turn that invoked tools also carries ToolCalls; a turn returning tool outputs
 // carries ToolResults.
+//
+// A message may instead be written in one provider's own format, which is what
+// LLM and Native carry. See [NewLLMSpecificMessage].
 type Message struct {
 	Role Role
 	Text string
@@ -72,12 +76,42 @@ type Message struct {
 	ToolCalls []ToolCall
 	// ToolResults is set on a message returning the outputs of tool calls.
 	ToolResults []ToolResult
+	// LLM names the provider this message is written for. When it is set the
+	// message is that provider's own and no other's: only its adapter sends it,
+	// and every other adapter leaves it out (see LLMContext.MessagesFor).
+	LLM string
+	// Native is the message as that provider's API takes it, in the type that
+	// provider's adapter defines. It is only read when LLM is set, and the
+	// adapter it names is the only thing that knows how to read it.
+	Native any
 }
+
+// NewLLMSpecificMessage builds a message written in one provider's own format,
+// for something the universal conversation has no representation for: a
+// reasoning block a model wants handed back to it, a content type only one
+// provider takes.
+//
+// llm is the identifier that provider's adapter answers to
+// (adapter.LLMAdapter.IDForLLMSpecificMessages), and native is the message in
+// the type that adapter defines. A conversation carrying one can still be sent
+// to any provider: the ones it was not written for leave it out.
+func NewLLMSpecificMessage(llm string, native any) Message {
+	return Message{LLM: llm, Native: native}
+}
+
+// IsLLMSpecific reports whether the message is written in one provider's own
+// format rather than in the universal one.
+func (m Message) IsLLMSpecific() bool { return m.LLM != "" }
 
 // clone returns a message that shares nothing with this one. Copying the struct
 // alone would copy the slice headers, leaving both messages pointing at one
 // array: a tool result updated in place would then be rewritten under whoever
 // holds the other copy, mid-read.
+//
+// Native is copied as it stands. What it points at belongs to the provider's
+// adapter, which is the only thing that can read it, so there is nothing here
+// that could copy it; treat a native message as written once and not edited
+// afterwards.
 func (m Message) clone() Message {
 	if len(m.ToolCalls) > 0 {
 		m.ToolCalls = append([]ToolCall(nil), m.ToolCalls...)
@@ -351,14 +385,50 @@ func (c *LLMContext) Messages() []Message {
 	return cloneMessages(c.messages)
 }
 
+// MessagesFor returns the messages to send to the named provider: every
+// universal one, plus the provider's own, and none written for a different
+// provider. It is what an adapter reads rather than Messages, so a conversation
+// carrying one provider's native messages can still be sent to another.
+//
+// Leaving a message out is reported: a message written for a provider that
+// never sees it is almost always a mistake, and it would otherwise go missing
+// in silence.
+func (c *LLMContext) MessagesFor(llm string) []Message {
+	c.mu.Lock()
+	msgs := cloneMessages(c.messages)
+	c.mu.Unlock()
+
+	out := make([]Message, 0, len(msgs))
+	dropped := 0
+	for _, m := range msgs {
+		if m.IsLLMSpecific() && m.LLM != llm {
+			dropped++
+			continue
+		}
+		out = append(out, m)
+	}
+	if dropped > 0 {
+		slog.Error("leaving out conversation messages written for another provider",
+			"llm", llm, "messages", dropped)
+	}
+	return out
+}
+
 // EstimatedTokens is a rough estimate of the context's size in tokens, used to
 // decide when to compact. It approximates four characters per token across the
 // system prompt, the rolling summary, and every message.
+//
+// A message in a provider's own format is counted by what its rendering
+// measures, since nothing here can read the format itself.
 func (c *LLMContext) EstimatedTokens() int {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	n := len(c.system) + len(c.summary) + len(c.recall)
 	for _, m := range c.messages {
+		if m.IsLLMSpecific() {
+			n += len(fmt.Sprint(m.Native))
+			continue
+		}
 		n += len(m.Text)
 		for _, tc := range m.ToolCalls {
 			n += len(tc.Name) + len(tc.Args)
@@ -425,7 +495,13 @@ func cleanCut(msgs []Message, limit int) int {
 		limit = len(msgs) - 1
 	}
 	for i := limit; i >= 1; i-- {
-		if msgs[i].Role == RoleUser && len(msgs[i].ToolResults) == 0 {
+		m := msgs[i]
+		// A message in a provider's own format is not a turn this can read, so it
+		// is never a boundary to cut on.
+		if m.IsLLMSpecific() {
+			continue
+		}
+		if m.Role == RoleUser && len(m.ToolResults) == 0 {
 			return i
 		}
 	}

--- a/frames/llm_specific_test.go
+++ b/frames/llm_specific_test.go
@@ -1,0 +1,111 @@
+package frames_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gojargo/jargo/frames"
+)
+
+// TestMessagesForKeepsUniversalAndItsOwn checks a provider is sent every
+// universal message plus its own, and none written for another provider.
+func TestMessagesForKeepsUniversalAndItsOwn(t *testing.T) {
+	convo := frames.NewLLMContext("be helpful")
+	convo.AddUserMessage("hello")
+	convo.AddMessage(frames.NewLLMSpecificMessage("anthropic", "anthropic's own"))
+	convo.AddMessage(frames.NewLLMSpecificMessage("google", "gemini's own"))
+	convo.AddAssistantMessage("hi")
+	convo.AddMessage(frames.NewLLMSpecificMessage("openai", "openai's own"))
+
+	got := convo.MessagesFor("openai")
+	if len(got) != 3 {
+		t.Fatalf("messages = %+v, want the two universal ones and openai's", got)
+	}
+	if got[0].Text != "hello" || got[1].Text != "hi" {
+		t.Errorf("messages = %+v, want the universal ones kept", got[:2])
+	}
+	if !got[2].IsLLMSpecific() || got[2].Native != "openai's own" {
+		t.Errorf("message 2 = %+v, want openai's own", got[2])
+	}
+}
+
+// TestMessagesForLeavesOthersOut checks a provider sent none of its own still
+// gets the universal conversation.
+func TestMessagesForLeavesOthersOut(t *testing.T) {
+	convo := frames.NewLLMContext("")
+	convo.AddUserMessage("hello")
+	convo.AddMessage(frames.NewLLMSpecificMessage("anthropic", "anthropic's own"))
+
+	got := convo.MessagesFor("google")
+	if len(got) != 1 || got[0].Text != "hello" {
+		t.Errorf("messages = %+v, want only the universal one", got)
+	}
+}
+
+// TestMessagesReturnsEverything checks the plain reader is unfiltered: it is
+// what the conversation holds, not what one provider is sent.
+func TestMessagesReturnsEverything(t *testing.T) {
+	convo := frames.NewLLMContext("")
+	convo.AddUserMessage("hello")
+	convo.AddMessage(frames.NewLLMSpecificMessage("anthropic", "anthropic's own"))
+
+	if got := convo.Messages(); len(got) != 2 {
+		t.Errorf("messages = %+v, want both", got)
+	}
+}
+
+// TestMessagesForCopies checks the caller is given a copy: an adapter rewrites
+// what it is handed, and the conversation must not change under it.
+func TestMessagesForCopies(t *testing.T) {
+	convo := frames.NewLLMContext("")
+	convo.AddUserMessage("hello")
+
+	got := convo.MessagesFor("openai")
+	got[0].Text = "rewritten"
+
+	if convo.Messages()[0].Text != "hello" {
+		t.Error("the conversation changed under the caller, want it left as it was")
+	}
+}
+
+// TestEstimatedTokensCountsNativeMessages checks a message in a provider's own
+// format is not counted as nothing, which would let a conversation of them grow
+// past the point where it should have been compacted.
+func TestEstimatedTokensCountsNativeMessages(t *testing.T) {
+	convo := frames.NewLLMContext("")
+	empty := convo.EstimatedTokens()
+
+	convo.AddMessage(frames.NewLLMSpecificMessage("openai", "a message long enough to count"))
+	if convo.EstimatedTokens() <= empty {
+		t.Error("a provider's own message counted as nothing, want it counted")
+	}
+}
+
+// TestCompactDoesNotCutOnANativeMessage checks compaction never treats a
+// message it cannot read as a turn boundary, even when its role happens to read
+// as a user turn. Cutting there would drop a prefix on a point nothing verified
+// was a clean one.
+func TestCompactDoesNotCutOnANativeMessage(t *testing.T) {
+	convo := frames.NewLLMContext("")
+	convo.AddUserMessage("one")
+	convo.AddAssistantMessage("a")
+	// The only candidate boundary in range, and one this cannot read.
+	native := frames.NewLLMSpecificMessage("openai", "native")
+	native.Role = frames.RoleUser
+	convo.AddMessage(native)
+	convo.AddAssistantMessage("b")
+
+	compacted, err := convo.Compact(
+		t.Context(), 1,
+		func(context.Context, string, []frames.Message) (string, error) { return "summary", nil },
+	)
+	if err != nil {
+		t.Fatalf("Compact: %v", err)
+	}
+	if compacted {
+		t.Error("compaction cut on a message it cannot read, want it to find no boundary")
+	}
+	if got := convo.Messages(); len(got) != 4 {
+		t.Errorf("messages = %d, want all four kept", len(got))
+	}
+}

--- a/internal/providertest/roster_test.go
+++ b/internal/providertest/roster_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
 
 	"github.com/gojargo/jargo/frames"
@@ -74,10 +75,13 @@ func TestDeveloperRoleRoster(t *testing.T) {
 func developerRoleAsSent(t *testing.T, build CompatLLMBuilder) string {
 	t.Helper()
 
+	// Content is decoded loosely: an endpoint that merges two same-role messages
+	// sends the result as a list of parts rather than a string, so the shape
+	// varies across the roster even though the question asked of it does not.
 	var body struct {
 		Messages []struct {
-			Role    string `json:"role"`
-			Content string `json:"content"`
+			Role    string          `json:"role"`
+			Content json.RawMessage `json:"content"`
 		} `json:"messages"`
 	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -98,10 +102,30 @@ func developerRoleAsSent(t *testing.T, build CompatLLMBuilder) string {
 		t.Fatalf("Generate: %v", err)
 	}
 	for _, m := range body.Messages {
-		if m.Content == "a tool reported late" {
+		if slices.Contains(contentTexts(m.Content), "a tool reported late") {
 			return m.Role
 		}
 	}
 	t.Fatalf("the developer message never reached the endpoint: %+v", body.Messages)
 	return ""
+}
+
+// contentTexts returns every text a message's content carries, whether it was
+// sent as a plain string or as a list of parts.
+func contentTexts(raw json.RawMessage) []string {
+	var text string
+	if json.Unmarshal(raw, &text) == nil {
+		return []string{text}
+	}
+	var parts []struct {
+		Text string `json:"text"`
+	}
+	if json.Unmarshal(raw, &parts) != nil {
+		return nil
+	}
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		out = append(out, p.Text)
+	}
+	return out
 }

--- a/provider/anthropic/anthropic_test.go
+++ b/provider/anthropic/anthropic_test.go
@@ -6,29 +6,19 @@ import (
 	"testing"
 
 	sdk "github.com/anthropics/anthropic-sdk-go"
+	"github.com/gojargo/jargo/adapter"
 	"github.com/gojargo/jargo/frames"
 )
 
-func TestToToolsMapsSchema(t *testing.T) {
-	tools := []frames.Tool{{
-		Name:        "get_weather",
-		Description: "Get the weather",
-		Parameters:  json.RawMessage(`{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}`),
-	}}
-	out := toTools(tools)
-	if len(out) != 1 {
-		t.Fatalf("len = %d, want 1", len(out))
-	}
-	b, err := json.Marshal(out[0])
+// mustParams converts the conversation and fails the test if the conversion
+// did.
+func (s *Service) mustParams(t *testing.T, convo *frames.LLMContext) sdk.MessageNewParams {
+	t.Helper()
+	p, err := s.newParams(convo, adapter.Options{})
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("newParams: %v", err)
 	}
-	s := string(b)
-	for _, want := range []string{`"name":"get_weather"`, `"Get the weather"`, `"location"`, `"required":["location"]`} {
-		if !strings.Contains(s, want) {
-			t.Fatalf("tool JSON %s missing %q", s, want)
-		}
-	}
+	return p
 }
 
 func TestSupportsPrefill(t *testing.T) {
@@ -57,38 +47,19 @@ func TestSupportsPrefill(t *testing.T) {
 	}
 }
 
-func TestEnsureLastMessageIsUser(t *testing.T) {
-	user := sdk.NewUserMessage(sdk.NewTextBlock("hi"))
-	assistant := sdk.NewAssistantMessage(sdk.NewTextBlock("hello"))
-
-	got := ensureLastMessageIsUser([]sdk.MessageParam{user, assistant})
-	if len(got) != 3 || got[2].Role != sdk.MessageParamRoleUser {
-		t.Fatalf("ending on assistant should append a user message; got %d messages", len(got))
-	}
-
-	got = ensureLastMessageIsUser([]sdk.MessageParam{assistant, user})
-	if len(got) != 2 {
-		t.Fatalf("ending on user should be unchanged; got %d messages", len(got))
-	}
-
-	if got := ensureLastMessageIsUser(nil); len(got) != 0 {
-		t.Fatalf("empty list should stay empty; got %d messages", len(got))
-	}
-}
-
 func TestNewParamsPrefillFixup(t *testing.T) {
 	convo := frames.NewLLMContext("system")
 	convo.AddUserMessage("hi")
 	convo.AddAssistantMessage("hello") // context ends on an assistant message
 
 	// A no-prefill model gets a trailing user message injected.
-	noPrefill := NewLLM(Config{Model: "claude-opus-4-8"}).newParams(convo).Messages
+	noPrefill := NewLLM(Config{Model: "claude-opus-4-8"}).mustParams(t, convo).Messages
 	if n := len(noPrefill); n != 3 || noPrefill[n-1].Role != sdk.MessageParamRoleUser {
 		t.Fatalf("no-prefill model: want 3 messages ending in a user turn, got %d", n)
 	}
 
 	// A prefill-supported model keeps the assistant message last.
-	prefill := NewLLM(Config{Model: "claude-haiku-4-5"}).newParams(convo).Messages
+	prefill := NewLLM(Config{Model: "claude-haiku-4-5"}).mustParams(t, convo).Messages
 	if n := len(prefill); n != 2 || prefill[n-1].Role != sdk.MessageParamRoleAssistant {
 		t.Fatalf("prefill model: want the assistant message to stay last, got %d messages", n)
 	}
@@ -100,7 +71,7 @@ func TestNewParamsAppliesSampling(t *testing.T) {
 	s := NewLLM(Config{Temperature: &temp, TopP: &topP, TopK: &topK})
 	convo := frames.NewLLMContext("be brief")
 	convo.AddUserMessage("hi")
-	b, err := json.Marshal(s.newParams(convo))
+	b, err := json.Marshal(s.mustParams(t, convo))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -116,7 +87,7 @@ func TestNewParamsOmitsUnsetSampling(t *testing.T) {
 	s := NewLLM(Config{})
 	convo := frames.NewLLMContext("")
 	convo.AddUserMessage("hi")
-	b, err := json.Marshal(s.newParams(convo))
+	b, err := json.Marshal(s.mustParams(t, convo))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -137,7 +108,7 @@ func TestNewParamsAppliesThinking(t *testing.T) {
 		"adaptive": `"thinking":{"type":"adaptive"}`,
 	} {
 		s := NewLLM(Config{Thinking: &ThinkingConfig{Type: mode}})
-		b, err := json.Marshal(s.newParams(convo))
+		b, err := json.Marshal(s.mustParams(t, convo))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -148,7 +119,7 @@ func TestNewParamsAppliesThinking(t *testing.T) {
 
 	// "enabled" carries the token budget.
 	s := NewLLM(Config{MaxTokens: 4096, Thinking: &ThinkingConfig{Type: "enabled", BudgetTokens: 2048}})
-	b, err := json.Marshal(s.newParams(convo))
+	b, err := json.Marshal(s.mustParams(t, convo))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -163,7 +134,7 @@ func TestNewParamsOmitsThinkingWhenUnset(t *testing.T) {
 	s := NewLLM(Config{})
 	convo := frames.NewLLMContext("")
 	convo.AddUserMessage("hi")
-	b, err := json.Marshal(s.newParams(convo))
+	b, err := json.Marshal(s.mustParams(t, convo))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -187,33 +158,6 @@ func TestToUsageMapsFields(t *testing.T) {
 	}
 }
 
-func TestToMessagesBuildsToolTurns(t *testing.T) {
-	msgs := []frames.Message{
-		{Role: frames.RoleUser, Text: "weather?"},
-		{Role: frames.RoleAssistant, ToolCalls: []frames.ToolCall{
-			{ID: "c1", Name: "get_weather", Args: json.RawMessage(`{"location":"Paris"}`)},
-		}},
-		{Role: frames.RoleUser, ToolResults: []frames.ToolResult{
-			{ID: "c1", Name: "get_weather", Content: "sunny"},
-		}},
-		{Role: frames.RoleAssistant, Text: "It is sunny."},
-	}
-	out := toMessages(msgs)
-	if len(out) != 4 {
-		t.Fatalf("len = %d, want 4", len(out))
-	}
-	b, err := json.Marshal(out)
-	if err != nil {
-		t.Fatal(err)
-	}
-	s := string(b)
-	for _, want := range []string{`"tool_use"`, `"c1"`, `"get_weather"`, `"tool_result"`, `"tool_use_id":"c1"`, `sunny`} {
-		if !strings.Contains(s, want) {
-			t.Fatalf("messages JSON missing %q:\n%s", want, s)
-		}
-	}
-}
-
 // A cached prefix is only reused while it stays byte-identical. Recalled context
 // is replaced every turn, so the breakpoint has to sit before it: inside it, the
 // cache would be written on every request and never read back, which costs more
@@ -224,7 +168,7 @@ func TestNewParamsKeepsTheCachedPrefixStableAcrossRecall(t *testing.T) {
 	convo.AddUserMessage("hi")
 
 	cachedPrefix := func() string {
-		params := s.newParams(convo)
+		params := s.mustParams(t, convo)
 		var prefix []string
 		for _, block := range params.System {
 			if block.CacheControl.Type != "" {
@@ -257,7 +201,7 @@ func TestNewParamsStillSendsRecall(t *testing.T) {
 	convo.AddUserMessage("hi")
 	convo.SetRecall("I recall: the user has a cat")
 
-	b, err := json.Marshal(s.newParams(convo))
+	b, err := json.Marshal(s.mustParams(t, convo))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -274,7 +218,7 @@ func TestNewParamsWithoutCaching(t *testing.T) {
 	convo.AddUserMessage("hi")
 	convo.SetRecall("I recall: the user has a cat")
 
-	params := s.newParams(convo)
+	params := s.mustParams(t, convo)
 	if len(params.System) != 1 {
 		t.Fatalf("got %d system blocks, want 1", len(params.System))
 	}

--- a/provider/anthropic/llm.go
+++ b/provider/anthropic/llm.go
@@ -303,3 +303,8 @@ func supportsPrefill(model string) bool {
 	}
 	return false
 }
+
+// LLMAdapter returns the adapter this service converts through, so the base can
+// add the tools it implements itself to what every request advertises. It
+// implements llm.AdapterHolder.
+func (s *Service) LLMAdapter() llm.BuiltinToolHolder { return &s.adapter }

--- a/provider/anthropic/llm.go
+++ b/provider/anthropic/llm.go
@@ -2,12 +2,13 @@ package anthropic
 
 import (
 	"context"
-	"encoding/json"
 	"strings"
 
 	sdk "github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/option"
 	"github.com/anthropics/anthropic-sdk-go/packages/param"
+	"github.com/gojargo/jargo/adapter"
+	anthropicadapter "github.com/gojargo/jargo/adapter/anthropic"
 	"github.com/gojargo/jargo/frames"
 	"github.com/gojargo/jargo/service/llm"
 )
@@ -23,7 +24,9 @@ type Service struct {
 	temperature param.Opt[float64]
 	topP        param.Opt[float64]
 	topK        param.Opt[int64]
-	// cachePrompt gates the ephemeral cache breakpoint on the system prompt.
+	// adapter converts the conversation into the request Anthropic takes.
+	adapter anthropicadapter.Adapter
+	// cachePrompt gates the ephemeral cache breakpoints on the prompt.
 	cachePrompt bool
 	// thinking is the extended-thinking config sent on each request; thinkingSet
 	// reports whether it was configured (an unset union means "omit").
@@ -105,19 +108,25 @@ func NewLLMWithOptions(name string, cfg Config, extra ...option.RequestOption) *
 }
 
 // newParams builds the request params shared by both generation paths: model,
-// token cap, the converted conversation, sampling controls and the cached
-// system prompt.
-func (s *Service) newParams(convo *frames.LLMContext) sdk.MessageNewParams {
-	messages := toMessages(convo.Messages())
-	// Models without assistant-prefill support reject a request whose message
-	// list ends with an assistant message; give them a trailing user turn.
-	if !supportsPrefill(s.model) {
-		messages = ensureLastMessageIsUser(messages)
+// token cap, the converted conversation, sampling controls and the system
+// prompt.
+func (s *Service) newParams(
+	convo *frames.LLMContext, opts adapter.Options,
+) (sdk.MessageNewParams, error) {
+	opts.EnablePromptCaching = s.cachePrompt
+	// A model without assistant-prefill support rejects a request whose message
+	// list ends with an assistant message; give it a trailing user turn.
+	opts.EnsureLastMessageIsUser = !supportsPrefill(s.model)
+	p, err := s.adapter.LLMInvocationParams(convo, opts)
+	if err != nil {
+		return sdk.MessageNewParams{}, err
 	}
 	params := sdk.MessageNewParams{
 		Model:       s.model,
 		MaxTokens:   s.maxTokens,
-		Messages:    messages,
+		Messages:    p.Messages,
+		System:      p.System,
+		Tools:       p.Tools,
 		Temperature: s.temperature,
 		TopP:        s.topP,
 		TopK:        s.topK,
@@ -125,42 +134,7 @@ func (s *Service) newParams(convo *frames.LLMContext) sdk.MessageNewParams {
 	if s.thinkingSet {
 		params.Thinking = s.thinking
 	}
-	params.System = s.systemBlocks(convo)
-	return params
-}
-
-// systemBlocks renders the system prompt, with the cache breakpoint on the part
-// of it that survives between turns.
-//
-// A cached prefix is only reused while it stays byte-identical, and everything
-// after the breakpoint is free to vary without disturbing it. The recalled
-// context a memory service refreshes every turn is exactly that: putting it
-// inside the breakpoint rewrites the cache on every request and never reads one
-// back, which costs more than not caching at all.
-func (s *Service) systemBlocks(convo *frames.LLMContext) []sdk.TextBlockParam {
-	if !s.cachePrompt {
-		system := convo.System()
-		if system == "" {
-			return nil
-		}
-		return []sdk.TextBlockParam{{Text: system}}
-	}
-
-	stable, volatile := convo.SystemParts()
-	blocks := make([]sdk.TextBlockParam, 0, 2)
-	if stable != "" {
-		blocks = append(blocks, sdk.TextBlockParam{
-			Text:         stable,
-			CacheControl: sdk.NewCacheControlEphemeralParam(),
-		})
-	}
-	if volatile != "" {
-		blocks = append(blocks, sdk.TextBlockParam{Text: volatile})
-	}
-	if len(blocks) == 0 {
-		return nil
-	}
-	return blocks
+	return params, nil
 }
 
 // toUsage converts the SDK's per-request usage into the pipeline's token usage.
@@ -183,8 +157,15 @@ func toUsage(u sdk.Usage) frames.LLMTokenUsage {
 func (s *Service) Generate(ctx context.Context, convo *frames.LLMContext, emit llm.Emit) error {
 	report := s.UsageMetricsEnabled()
 	var acc sdk.Message
+	params, err := s.newParams(convo, adapter.Options{})
+	if err != nil {
+		return err
+	}
+	// A text-only generation advertises no tools, so the model has nothing to
+	// call and a reported call would be the provider inventing one.
+	params.Tools = nil
 	s.StartTTFBMetrics()
-	stream := s.client.Messages.NewStreaming(ctx, s.newParams(convo))
+	stream := s.client.Messages.NewStreaming(ctx, params)
 	s.StopTTFBMetrics()
 	for stream.Next() {
 		event := stream.Current()
@@ -220,9 +201,9 @@ func (s *Service) Generate(ctx context.Context, convo *frames.LLMContext, emit l
 // the request, and any tool-use / tool-result turns already in the context are
 // replayed as the matching Anthropic blocks.
 func (s *Service) GenerateWithTools(ctx context.Context, convo *frames.LLMContext, sink llm.Sink) error {
-	params := s.newParams(convo)
-	if tools := convo.Tools(); len(tools) > 0 {
-		params.Tools = toTools(tools)
+	params, err := s.newParams(convo, adapter.Options{})
+	if err != nil {
+		return err
 	}
 
 	var acc sdk.Message
@@ -265,16 +246,17 @@ func (s *Service) GenerateWithTools(ctx context.Context, convo *frames.LLMContex
 func (s *Service) RunInference(
 	ctx context.Context, convo *frames.LLMContext, opts llm.InferenceOptions,
 ) (string, error) {
-	params := s.newParams(convo)
+	params, err := s.newParams(
+		convo, adapter.Options{SystemInstruction: opts.SystemInstruction},
+	)
+	if err != nil {
+		return "", err
+	}
 	if opts.MaxTokens > 0 {
 		params.MaxTokens = int64(opts.MaxTokens)
 	}
-	if opts.SystemInstruction != "" {
-		// Anthropic carries the instruction beside the conversation rather than
-		// in it, so the one this inference was given stands in place of the
-		// conversation's own.
-		params.System = []sdk.TextBlockParam{{Text: opts.SystemInstruction}}
-	}
+	// An inference wants an answer, not a tool call, so the toolset is left off.
+	params.Tools = nil
 	msg, err := s.client.Messages.New(ctx, params)
 	if err != nil {
 		return "", llm.AsCompletionTimeout(ctx, err)
@@ -285,34 +267,6 @@ func (s *Service) RunInference(
 		}
 	}
 	return "", nil
-}
-
-// toTools converts the context's tools into Anthropic tool params. Each tool's
-// Parameters JSON-Schema object supplies the input schema's properties and
-// required fields.
-func toTools(tools []frames.Tool) []sdk.ToolUnionParam {
-	out := make([]sdk.ToolUnionParam, 0, len(tools))
-	for _, t := range tools {
-		var schema struct {
-			Properties json.RawMessage `json:"properties"`
-			Required   []string        `json:"required"`
-		}
-		if len(t.Parameters) > 0 {
-			_ = json.Unmarshal(t.Parameters, &schema)
-		}
-		tool := &sdk.ToolParam{
-			Name:        t.Name,
-			InputSchema: sdk.ToolInputSchemaParam{Required: schema.Required},
-		}
-		if t.Description != "" {
-			tool.Description = param.NewOpt(t.Description)
-		}
-		if len(schema.Properties) > 0 {
-			tool.InputSchema.Properties = schema.Properties
-		}
-		out = append(out, sdk.ToolUnionParam{OfTool: tool})
-	}
-	return out
 }
 
 // prefillSupportedPatterns lists the Claude models that still accept a request
@@ -348,93 +302,4 @@ func supportsPrefill(model string) bool {
 		}
 	}
 	return false
-}
-
-// ensureLastMessageIsUser appends a minimal user message when the list ends with
-// an assistant message, so a model without prefill support accepts the request.
-// The "." is a language-neutral no-op user turn; the stored context is untouched.
-func ensureLastMessageIsUser(msgs []sdk.MessageParam) []sdk.MessageParam {
-	if n := len(msgs); n > 0 && msgs[n-1].Role == sdk.MessageParamRoleAssistant {
-		return append(msgs, sdk.NewUserMessage(sdk.NewTextBlock(".")))
-	}
-	return msgs
-}
-
-// emptyText stands in for a message whose content came out empty. Anthropic
-// rejects an empty text block, and a message can end up with nothing to say:
-// an assistant turn that only requested tools has its text dropped below.
-const emptyText = "(empty)"
-
-// toMessages converts the conversation into Anthropic message params. Tool turns
-// become the assistant(tool_use) and user(tool_result) blocks the API requires.
-//
-// The conversation records one tool call per message, each followed by the
-// message answering it, so that it is valid at every instant. Anthropic wants
-// the two sides of a batch of parallel calls each in a single message, which is
-// what merging consecutive messages of the same role produces.
-func toMessages(msgs []frames.Message) []sdk.MessageParam {
-	out := make([]sdk.MessageParam, 0, len(msgs))
-	for _, m := range msgs {
-		switch {
-		case len(m.ToolResults) > 0:
-			blocks := make([]sdk.ContentBlockParamUnion, 0, len(m.ToolResults))
-			for _, r := range m.ToolResults {
-				blocks = append(blocks, sdk.NewToolResultBlock(r.ID, r.Content, false))
-			}
-			out = append(out, sdk.NewUserMessage(blocks...))
-		case len(m.ToolCalls) > 0:
-			// Any text the model spoke alongside the calls is dropped. It was
-			// already pushed downstream to be spoken and is committed as an
-			// assistant message of its own when the turn ends, so keeping it here
-			// too would say it twice.
-			blocks := make([]sdk.ContentBlockParamUnion, 0, len(m.ToolCalls))
-			for _, c := range m.ToolCalls {
-				input := any(c.Args)
-				if len(c.Args) == 0 {
-					input = json.RawMessage("{}")
-				}
-				blocks = append(blocks, sdk.NewToolUseBlock(c.ID, input, c.Name))
-			}
-			out = append(out, sdk.NewAssistantMessage(blocks...))
-		case m.Role == frames.RoleAssistant:
-			out = append(out, sdk.NewAssistantMessage(sdk.NewTextBlock(text(m.Text))))
-		case m.Role == frames.RoleSystem:
-			// The system prompt is sent separately, not as a message.
-		default:
-			// A user message, and a developer message too: Anthropic has neither a
-			// developer nor a system input role, so both enter as the user.
-			out = append(out, sdk.NewUserMessage(sdk.NewTextBlock(text(m.Text))))
-		}
-	}
-	return mergeSameRole(out)
-}
-
-// text substitutes the empty-content placeholder for an empty string.
-func text(s string) string {
-	if s == "" {
-		return emptyText
-	}
-	return s
-}
-
-// mergeSameRole folds each run of consecutive messages of the same role into one
-// message holding all their blocks. Anthropic pairs a tool result to its call by
-// id within the request, so the merge is what lets the conversation hold each
-// call in a message of its own while the request still presents a batch of
-// parallel calls the way the API expects it.
-func mergeSameRole(msgs []sdk.MessageParam) []sdk.MessageParam {
-	out := make([]sdk.MessageParam, 0, len(msgs))
-	for _, m := range msgs {
-		if n := len(out); n > 0 && out[n-1].Role == m.Role {
-			out[n-1].Content = append(out[n-1].Content, m.Content...)
-			continue
-		}
-		out = append(out, m)
-	}
-	for i := range out {
-		if len(out[i].Content) == 0 {
-			out[i].Content = []sdk.ContentBlockParamUnion{sdk.NewTextBlock(emptyText)}
-		}
-	}
-	return out
 }

--- a/provider/google/gemini/gemini_tools_test.go
+++ b/provider/google/gemini/gemini_tools_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gojargo/jargo/adapter"
 	"github.com/gojargo/jargo/frames"
 )
 
@@ -18,64 +19,14 @@ type fakeSink struct {
 func (f *fakeSink) Text(t string) error          { f.text.WriteString(t); return nil }
 func (f *fakeSink) Tool(c frames.ToolCall) error { f.calls = append(f.calls, c); return nil }
 
-func TestToContentsToolTurn(t *testing.T) {
-	convo := frames.NewLLMContext("be helpful")
-	convo.AddUserMessage("weather in Paris?")
-	convo.AddAssistantToolCall(frames.ToolCall{
-		ID: "call_0", Name: "get_weather", Args: json.RawMessage(`{"location":"Paris"}`),
-	})
-	convo.AddToolResult(frames.ToolResult{ID: "call_0", Name: "get_weather", Content: "sunny"})
-
-	b, err := json.Marshal(toContents(convo))
+// mustBody builds a request body and fails the test if the conversion did.
+func mustBody(t *testing.T, s *Service, convo *frames.LLMContext) map[string]any {
+	t.Helper()
+	body, err := s.requestBody(convo, adapter.Options{}, false)
 	if err != nil {
-		t.Fatalf("marshal: %v", err)
+		t.Fatalf("requestBody: %v", err)
 	}
-	got := string(b)
-	// user turn + tool-result turn use role "user"; the assistant tool-call turn
-	// uses role "model". Map keys marshal in alphabetical order.
-	wants := []string{
-		`"role":"user"`,
-		`"role":"model"`,
-		`"functionCall":{"args":{"location":"Paris"},"id":"call_0","name":"get_weather"}`,
-		`"functionResponse":{"id":"call_0","name":"get_weather","response":{"value":"sunny"}}`,
-	}
-	for _, want := range wants {
-		if !strings.Contains(got, want) {
-			t.Errorf("contents missing %s\nin: %s", want, got)
-		}
-	}
-}
-
-func TestFunctionResponseDict(t *testing.T) {
-	// A JSON object passes through unchanged.
-	raw, ok := functionResponseDict(`{"temp":20}`).(json.RawMessage)
-	if !ok || string(raw) != `{"temp":20}` {
-		t.Errorf("object should pass through, got %v", functionResponseDict(`{"temp":20}`))
-	}
-	// A plain string is wrapped under "value".
-	m, ok := functionResponseDict("sunny").(map[string]any)
-	if !ok || m["value"] != "sunny" {
-		t.Errorf("non-object should wrap as {value}, got %v", functionResponseDict("sunny"))
-	}
-}
-
-func TestToToolsStripsAdditionalProperties(t *testing.T) {
-	out := toTools([]frames.Tool{{
-		Name:        "get_weather",
-		Description: "Look up the weather",
-		Parameters:  json.RawMessage(`{"type":"object","additionalProperties":false,"properties":{"loc":{"type":"string"}}}`),
-	}})
-	b, err := json.Marshal(out)
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
-	}
-	got := string(b)
-	if strings.Contains(got, "additionalProperties") {
-		t.Errorf("additionalProperties should be stripped: %s", got)
-	}
-	if !strings.Contains(got, `"functionDeclarations"`) || !strings.Contains(got, `"name":"get_weather"`) {
-		t.Errorf("declaration shape wrong: %s", got)
-	}
+	return body
 }
 
 func TestGeminiToolStreamParsesParts(t *testing.T) {
@@ -118,7 +69,7 @@ func TestRequestBodyCarriesSafetySettings(t *testing.T) {
 	}
 	s := NewLLM(Config{APIKey: "k", SafetySettings: safety})
 
-	b, err := json.Marshal(s.requestBody(frames.NewLLMContext(""), false))
+	b, err := json.Marshal(mustBody(t, s, frames.NewLLMContext("")))
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
@@ -140,7 +91,7 @@ func TestRequestBodyCarriesSafetySettings(t *testing.T) {
 func TestRequestBodyOmitsSafetySettingsByDefault(t *testing.T) {
 	s := NewLLM(Config{APIKey: "k"})
 
-	b, err := json.Marshal(s.requestBody(frames.NewLLMContext(""), false))
+	b, err := json.Marshal(mustBody(t, s, frames.NewLLMContext("")))
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}

--- a/provider/google/gemini/llm.go
+++ b/provider/google/gemini/llm.go
@@ -321,3 +321,8 @@ func (s *Service) streamTools(req *http.Request, sink llm.Sink) error {
 		return nil // Skip malformed chunks.
 	})
 }
+
+// LLMAdapter returns the adapter this service converts through, so the base can
+// add the tools it implements itself to what every request advertises. It
+// implements llm.AdapterHolder.
+func (s *Service) LLMAdapter() llm.BuiltinToolHolder { return &s.adapter }

--- a/provider/google/gemini/llm.go
+++ b/provider/google/gemini/llm.go
@@ -9,6 +9,8 @@ import (
 	"maps"
 	"net/http"
 
+	"github.com/gojargo/jargo/adapter"
+	geminiadapter "github.com/gojargo/jargo/adapter/gemini"
 	"github.com/gojargo/jargo/frames"
 	"github.com/gojargo/jargo/service/llm"
 )
@@ -46,9 +48,11 @@ func (s apiKeyShaper) Authorize(_ context.Context, req *http.Request) error {
 // Service is a streaming Gemini LLM processor.
 type Service struct {
 	*llm.Base
-	cfg    Config
-	http   *http.Client
-	shaper RequestShaper
+	// adapter converts the conversation into the request Gemini takes.
+	adapter geminiadapter.Adapter
+	cfg     Config
+	http    *http.Client
+	shaper  RequestShaper
 }
 
 // NewLLM builds a Gemini LLM service.
@@ -92,7 +96,11 @@ type genChunk struct {
 
 // Generate streams a Gemini completion, emitting each text delta.
 func (s *Service) Generate(ctx context.Context, convo *frames.LLMContext, emit llm.Emit) error {
-	req, err := s.newRequest(ctx, s.requestBody(convo, false))
+	body, err := s.requestBody(convo, adapter.Options{}, false)
+	if err != nil {
+		return err
+	}
+	req, err := s.newRequest(ctx, body)
 	if err != nil {
 		return err
 	}
@@ -104,18 +112,15 @@ func (s *Service) Generate(ctx context.Context, convo *frames.LLMContext, emit l
 func (s *Service) RunInference(
 	ctx context.Context, convo *frames.LLMContext, opts llm.InferenceOptions,
 ) (string, error) {
-	body := s.requestBody(convo, false)
+	body, err := s.requestBody(
+		convo, adapter.Options{SystemInstruction: opts.SystemInstruction}, false,
+	)
+	if err != nil {
+		return "", err
+	}
 	if opts.MaxTokens > 0 {
 		if cfg, ok := body["generationConfig"].(map[string]any); ok {
 			cfg["maxOutputTokens"] = opts.MaxTokens
-		}
-	}
-	if opts.SystemInstruction != "" {
-		// Gemini carries the instruction beside the conversation rather than in
-		// it, so the one this inference was given stands in place of the
-		// conversation's own.
-		body["systemInstruction"] = map[string]any{
-			keyParts: []map[string]any{{keyText: opts.SystemInstruction}},
 		}
 	}
 	req, err := s.newRequestTo(ctx, body, false)
@@ -162,23 +167,29 @@ func (s *Service) genConfig() map[string]any {
 }
 
 // requestBody builds the generateContent body, optionally advertising tools.
-func (s *Service) requestBody(convo *frames.LLMContext, withTools bool) map[string]any {
+func (s *Service) requestBody(
+	convo *frames.LLMContext, opts adapter.Options, withTools bool,
+) (map[string]any, error) {
+	p, err := s.adapter.LLMInvocationParams(convo, opts)
+	if err != nil {
+		return nil, err
+	}
 	body := map[string]any{
-		"contents":         toContents(convo),
+		"contents":         p.Contents,
 		"generationConfig": s.genConfig(),
 	}
 	if len(s.cfg.SafetySettings) > 0 {
 		body["safetySettings"] = s.cfg.SafetySettings
 	}
-	if sys := convo.System(); sys != "" {
-		body["systemInstruction"] = map[string]any{keyParts: []map[string]any{{keyText: sys}}}
-	}
-	if withTools {
-		if tools := convo.Tools(); len(tools) > 0 {
-			body["tools"] = toTools(tools)
+	if p.SystemInstruction != "" {
+		body["systemInstruction"] = map[string]any{
+			keyParts: []map[string]any{{keyText: p.SystemInstruction}},
 		}
 	}
-	return body
+	if withTools && len(p.Tools) > 0 {
+		body["tools"] = p.Tools
+	}
+	return body, nil
 }
 
 // newRequest marshals reqBody and builds the streaming generateContent request.
@@ -239,7 +250,11 @@ func (s *Service) stream(req *http.Request, emit llm.Emit) error {
 // conversation's tools are sent on the request, and any tool turns already in
 // the context are replayed as functionCall / functionResponse parts.
 func (s *Service) GenerateWithTools(ctx context.Context, convo *frames.LLMContext, sink llm.Sink) error {
-	req, err := s.newRequest(ctx, s.requestBody(convo, true))
+	body, err := s.requestBody(convo, adapter.Options{}, true)
+	if err != nil {
+		return err
+	}
+	req, err := s.newRequest(ctx, body)
 	if err != nil {
 		return err
 	}
@@ -305,156 +320,4 @@ func (s *Service) streamTools(req *http.Request, sink llm.Sink) error {
 		}
 		return nil // Skip malformed chunks.
 	})
-}
-
-// unnamedToolResult names a tool result whose call cannot be found. Gemini
-// requires a name on every functionResponse, and a result can outlive the call
-// it answers: an asynchronous tool's messages carry only the call's id.
-const unnamedToolResult = "tool_call_result"
-
-// toContents converts the conversation into Gemini contents. The system prompt
-// is sent separately as systemInstruction, and the assistant role maps to
-// "model". A developer message enters as the user, Gemini having no developer
-// input role. Tool turns become functionCall parts (model) and functionResponse
-// parts (user), paired by the call id carried on both.
-func toContents(convo *frames.LLMContext) []map[string]any {
-	msgs := convo.Messages()
-	names := toolCallNames(msgs)
-	out := make([]map[string]any, 0, len(msgs))
-	for _, m := range msgs {
-		switch {
-		case len(m.ToolResults) > 0:
-			out = append(out, map[string]any{keyRole: "user", keyParts: toolResultParts(m.ToolResults, names)})
-		case len(m.ToolCalls) > 0:
-			out = append(out, map[string]any{keyRole: "model", keyParts: toolCallParts(m.Text, m.ToolCalls)})
-		default:
-			role := "user"
-			if m.Role == frames.RoleAssistant {
-				role = "model"
-			}
-			out = append(out, map[string]any{
-				keyRole:  role,
-				keyParts: []map[string]any{{keyText: m.Text}},
-			})
-		}
-	}
-	return out
-}
-
-// toolCallNames maps each tool call in the conversation to the name it was made
-// with, so a result can be named after the call it answers rather than after
-// whatever it happens to carry itself.
-func toolCallNames(msgs []frames.Message) map[string]string {
-	names := make(map[string]string)
-	for _, m := range msgs {
-		for _, c := range m.ToolCalls {
-			names[c.ID] = c.Name
-		}
-	}
-	return names
-}
-
-// toolCallParts renders an assistant turn's optional preamble and tool calls as
-// Gemini parts.
-func toolCallParts(text string, calls []frames.ToolCall) []map[string]any {
-	parts := make([]map[string]any, 0, len(calls)+1)
-	if text != "" {
-		parts = append(parts, map[string]any{keyText: text})
-	}
-	for _, c := range calls {
-		args := c.Args
-		if len(args) == 0 {
-			args = json.RawMessage("{}")
-		}
-		parts = append(parts, map[string]any{
-			"functionCall": map[string]any{keyID: c.ID, keyName: c.Name, "args": args},
-		})
-	}
-	return parts
-}
-
-// toolResultParts renders tool outputs as Gemini functionResponse parts. Each
-// carries the id of the call it answers, which is what tells apart the results
-// of a batch of parallel calls to the same tool.
-func toolResultParts(results []frames.ToolResult, names map[string]string) []map[string]any {
-	parts := make([]map[string]any, 0, len(results))
-	for _, r := range results {
-		parts = append(parts, map[string]any{
-			"functionResponse": map[string]any{
-				keyID:      r.ID,
-				keyName:    toolResultName(r, names),
-				"response": functionResponseDict(r.Content),
-			},
-		})
-	}
-	return parts
-}
-
-// toolResultName names a result after the call it answers, falling back to the
-// name recorded on the result itself and then to a placeholder.
-func toolResultName(r frames.ToolResult, names map[string]string) string {
-	if name, ok := names[r.ID]; ok && name != "" {
-		return name
-	}
-	if r.Name != "" {
-		return r.Name
-	}
-	return unnamedToolResult
-}
-
-// functionResponseDict shapes a tool result for Gemini's functionResponse,
-// which requires an object: a JSON object passes through, anything else is
-// wrapped as {"value": content}.
-func functionResponseDict(content string) any {
-	var obj map[string]any
-	if json.Unmarshal([]byte(content), &obj) == nil {
-		return json.RawMessage(content)
-	}
-	return map[string]any{"value": content}
-}
-
-// toTools converts the context's tools into Gemini functionDeclarations.
-func toTools(tools []frames.Tool) []map[string]any {
-	decls := make([]map[string]any, 0, len(tools))
-	for _, t := range tools {
-		d := map[string]any{keyName: t.Name}
-		if t.Description != "" {
-			d["description"] = t.Description
-		}
-		if params := geminiParameters(t.Parameters); params != nil {
-			d["parameters"] = params
-		}
-		decls = append(decls, d)
-	}
-	return []map[string]any{{"functionDeclarations": decls}}
-}
-
-// geminiParameters returns the tool's JSON-Schema parameters with
-// "additionalProperties" stripped (Gemini rejects it). On a parse error the raw
-// schema passes through unchanged.
-func geminiParameters(raw json.RawMessage) any {
-	if len(raw) == 0 {
-		return nil
-	}
-	var schema map[string]any
-	if json.Unmarshal(raw, &schema) != nil {
-		return raw
-	}
-	stripAdditionalProperties(schema)
-	return schema
-}
-
-// stripAdditionalProperties recursively removes "additionalProperties" keys.
-func stripAdditionalProperties(v any) {
-	switch t := v.(type) {
-	case map[string]any:
-		delete(t, "additionalProperties")
-		for _, val := range t {
-			stripAdditionalProperties(val)
-		}
-	case []any:
-		for _, val := range t {
-			stripAdditionalProperties(val)
-		}
-	}
 }

--- a/provider/mistral/llm.go
+++ b/provider/mistral/llm.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"maps"
 
+	mistraladapter "github.com/gojargo/jargo/adapter/mistral"
 	"github.com/gojargo/jargo/frames"
 	"github.com/gojargo/jargo/provider/openai/chat"
 	"github.com/gojargo/jargo/service/llm"
@@ -11,10 +12,10 @@ import (
 
 // NewLLM builds a Mistral AI LLM service. Mistral speaks the OpenAI
 // chat-completions API, with three departures from it: it has no developer
-// role, it constrains the shape of a conversation (see shapeMessages), and it
-// reports the calls to make from the whole message history rather than from
-// what it just streamed (see dropAnsweredCalls). It also names the sampling
-// seed differently.
+// role, it constrains the shape of a conversation (which its adapter settles),
+// and it reports the calls to make from the whole message history rather than
+// from what it just streamed (see dropAnsweredCalls). It also names the
+// sampling seed differently.
 func NewLLM(cfg chat.LLMConfig) *chat.LLMService {
 	if cfg.Seed != nil {
 		// Mistral reads the seed under a name of its own. Send it under that
@@ -32,7 +33,7 @@ func NewLLM(cfg chat.LLMConfig) *chat.LLMService {
 		BaseURL:         baseURL,
 		DefaultModel:    defaultModel,
 		NoDeveloperRole: true,
-		ShapeMessages:   shapeMessages,
+		Adapter:         &mistraladapter.Adapter{},
 		Base:            []llm.Option{llm.WithFunctionCallFilter(dropAnsweredCalls)},
 	}, cfg)
 }
@@ -68,56 +69,4 @@ func dropAnsweredCalls(convo *frames.LLMContext, calls []frames.ToolCall) []fram
 		kept = append(kept, c)
 	}
 	return kept
-}
-
-// shapeMessages rewrites the conversation to satisfy the three constraints
-// Mistral puts on a message history that the OpenAI schema does not:
-//
-//  1. A tool result must be followed by an assistant message. One that is not
-//     is rejected, so a minimal assistant message is inserted after it.
-//  2. Only the leading run of system messages is accepted. A system message
-//     after any other message is sent as a user message instead.
-//  3. A conversation ending on an assistant message is a partial reply Mistral
-//     is being asked to continue, which it only does when the message is marked
-//     as a prefix.
-func shapeMessages(msgs []chat.Message) []chat.Message {
-	if len(msgs) == 0 {
-		return msgs
-	}
-
-	out := make([]chat.Message, 0, len(msgs)+1)
-	for i, m := range msgs {
-		out = append(out, m)
-		if m.Role != chat.RoleTool {
-			continue
-		}
-		if i == len(msgs)-1 || msgs[i+1].Role != chat.RoleAssistant {
-			out = append(out, chat.Message{Role: chat.RoleAssistant, Content: " "})
-		}
-	}
-
-	for i := range out {
-		if out[i].Role == chat.RoleSystem {
-			continue
-		}
-		// Past the leading run, every remaining system message is demoted.
-		for j := i; j < len(out); j++ {
-			if out[j].Role == chat.RoleSystem {
-				out[j].Role = chat.RoleUser
-			}
-		}
-		break
-	}
-
-	if last := &out[len(out)-1]; last.Role == chat.RoleAssistant {
-		if _, ok := last.Extra["prefix"]; !ok {
-			extra := maps.Clone(last.Extra)
-			if extra == nil {
-				extra = map[string]any{}
-			}
-			extra["prefix"] = true
-			last.Extra = extra
-		}
-	}
-	return out
 }

--- a/provider/mistral/llm_internal_test.go
+++ b/provider/mistral/llm_internal_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/gojargo/jargo/frames"
-	"github.com/gojargo/jargo/provider/openai/chat"
 )
 
 // answeredConvo is a conversation in which call_a has been made and answered
@@ -49,85 +48,5 @@ func TestDropAnsweredCalls(t *testing.T) {
 	// match, so the call runs rather than being swallowed by the first result.
 	if kept := dropAnsweredCalls(convo, []frames.ToolCall{toolCall("", "get_time")}); len(kept) != 1 {
 		t.Errorf("kept = %+v, want a call with no id to run", kept)
-	}
-}
-
-// TestShapeMessagesFollowsATooResultWithAnAssistantMessage checks the first of
-// Mistral's constraints: a tool result that ends the conversation, which is
-// exactly what the completion answering a tool call sees.
-func TestShapeMessagesFollowsATooResultWithAnAssistantMessage(t *testing.T) {
-	out := shapeMessages([]chat.Message{
-		{Role: chat.RoleUser, Content: "weather?"},
-		{Role: chat.RoleAssistant, ToolCalls: []chat.ToolCall{{ID: "call_a"}}},
-		{Role: chat.RoleTool, ToolCallID: "call_a", Content: "sunny"},
-	})
-
-	if len(out) != 4 {
-		t.Fatalf("messages = %+v, want an assistant message inserted after the tool result", out)
-	}
-	if out[3].Role != chat.RoleAssistant || out[3].Content != " " {
-		t.Errorf("inserted message = %+v, want a minimal assistant message", out[3])
-	}
-	// It now trails the conversation, so it is a partial reply to continue.
-	if out[3].Extra["prefix"] != true {
-		t.Errorf("trailing assistant message = %+v, want it marked as a prefix", out[3])
-	}
-
-	// A tool result already followed by an assistant message needs no insertion.
-	out = shapeMessages([]chat.Message{
-		{Role: chat.RoleTool, ToolCallID: "call_a", Content: "sunny"},
-		{Role: chat.RoleAssistant, Content: "it is sunny"},
-		{Role: chat.RoleUser, Content: "thanks"},
-	})
-	if len(out) != 3 {
-		t.Errorf("messages = %+v, want no insertion", out)
-	}
-}
-
-// TestShapeMessagesDemotesLateSystemMessages checks the second constraint: only
-// the leading run of system messages is accepted.
-func TestShapeMessagesDemotesLateSystemMessages(t *testing.T) {
-	out := shapeMessages([]chat.Message{
-		{Role: chat.RoleSystem, Content: "be brief"},
-		{Role: chat.RoleSystem, Content: "and polite"},
-		{Role: chat.RoleUser, Content: "hello"},
-		{Role: chat.RoleSystem, Content: "the user is in a hurry"},
-	})
-
-	if out[0].Role != chat.RoleSystem || out[1].Role != chat.RoleSystem {
-		t.Errorf("leading messages = %+v, want the opening system block kept", out[:2])
-	}
-	if out[3].Role != chat.RoleUser {
-		t.Errorf("late system message = %+v, want it sent as a user message", out[3])
-	}
-	if out[3].Content != "the user is in a hurry" {
-		t.Errorf("content = %q, want what the system message carried", out[3].Content)
-	}
-}
-
-// TestShapeMessagesMarksATrailingAssistantMessage checks the third constraint,
-// and that a conversation ending any other way is left as it is.
-func TestShapeMessagesMarksATrailingAssistantMessage(t *testing.T) {
-	out := shapeMessages([]chat.Message{
-		{Role: chat.RoleUser, Content: "hello"},
-		{Role: chat.RoleAssistant, Content: "hi, I was saying"},
-	})
-	if out[1].Extra["prefix"] != true {
-		t.Errorf("trailing assistant message = %+v, want it marked as a prefix", out[1])
-	}
-
-	out = shapeMessages([]chat.Message{
-		{Role: chat.RoleAssistant, Content: "hi"},
-		{Role: chat.RoleUser, Content: "hello"},
-	})
-	if _, ok := out[1].Extra["prefix"]; ok {
-		t.Errorf("trailing user message = %+v, want nothing added to it", out[1])
-	}
-	if _, ok := out[0].Extra["prefix"]; ok {
-		t.Errorf("assistant message mid-conversation = %+v, want nothing added to it", out[0])
-	}
-
-	if got := shapeMessages(nil); got != nil {
-		t.Errorf("shapeMessages(nil) = %+v, want nil", got)
 	}
 }

--- a/provider/openai/chat/compat_test.go
+++ b/provider/openai/chat/compat_test.go
@@ -1,9 +1,10 @@
 package chat
 
 import (
-	"encoding/json"
 	"testing"
 
+	"github.com/gojargo/jargo/adapter"
+	openaiadapter "github.com/gojargo/jargo/adapter/openai"
 	"github.com/gojargo/jargo/frames"
 )
 
@@ -38,9 +39,31 @@ func messagesOf(t *testing.T, body map[string]any) []map[string]any {
 	return out
 }
 
-// TestShapeMessagesRewritesWhatIsSent checks the hook sees the converted
-// conversation and decides what actually goes out.
-func TestShapeMessagesRewritesWhatIsSent(t *testing.T) {
+// shapingAdapter converts the conversation as OpenAI does and then appends a
+// message of its own, standing in for an endpoint that constrains the shape of
+// a conversation beyond what OpenAI's schema says.
+type shapingAdapter struct {
+	openaiadapter.Adapter
+	saw *[]string
+}
+
+func (a *shapingAdapter) LLMInvocationParams(
+	convo *frames.LLMContext, opts adapter.Options,
+) (openaiadapter.Params, error) {
+	p, err := a.Adapter.LLMInvocationParams(convo, opts)
+	if err != nil {
+		return openaiadapter.Params{}, err
+	}
+	for _, m := range p.Messages {
+		*a.saw = append(*a.saw, m.Role)
+	}
+	p.Messages = append(p.Messages, Message{Role: RoleAssistant, Content: "partial"})
+	return p, nil
+}
+
+// TestAdapterDecidesWhatIsSent checks the endpoint's own adapter sees the
+// converted conversation and decides what actually goes out.
+func TestAdapterDecidesWhatIsSent(t *testing.T) {
 	convo := frames.NewLLMContext("be brief")
 	convo.AddUserMessage("hello")
 
@@ -48,54 +71,15 @@ func TestShapeMessagesRewritesWhatIsSent(t *testing.T) {
 	body := bodyOf(t, Compat{
 		Name:         "ShapedLLM",
 		DefaultModel: "m",
-		ShapeMessages: func(msgs []Message) []Message {
-			for _, m := range msgs {
-				saw = append(saw, m.Role)
-			}
-			return append(msgs, Message{Role: RoleAssistant, Content: "partial"})
-		},
+		Adapter:      &shapingAdapter{saw: &saw},
 	}, LLMConfig{APIKey: "k"}, convo)
 
 	if len(saw) != 2 || saw[0] != RoleSystem || saw[1] != RoleUser {
-		t.Errorf("the hook saw %v, want the converted conversation", saw)
+		t.Errorf("the adapter saw %v, want the converted conversation", saw)
 	}
 	msgs := messagesOf(t, body)
 	if len(msgs) != 3 || msgs[2]["role"] != RoleAssistant || msgs[2]["content"] != "partial" {
-		t.Errorf("messages sent = %v, want the hook's rewrite", msgs)
-	}
-}
-
-// TestMessageExtraIsMerged checks a field OpenAI's schema has no place for is
-// encoded alongside the modeled ones, and that it wins where the names collide.
-func TestMessageExtraIsMerged(t *testing.T) {
-	raw, err := json.Marshal(Message{
-		Role:    RoleAssistant,
-		Content: "half a thought",
-		Extra:   map[string]any{"prefix": true},
-	})
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
-	}
-	var got map[string]any
-	if err := json.Unmarshal(raw, &got); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if got["prefix"] != true || got["role"] != RoleAssistant || got["content"] != "half a thought" {
-		t.Errorf("encoded message = %v, want the extra field alongside the modeled ones", got)
-	}
-	if _, ok := got["extra"]; ok {
-		t.Error("the extra map was encoded as a field of its own")
-	}
-
-	raw, err = json.Marshal(Message{Role: RoleAssistant, Extra: map[string]any{"role": "user"}})
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
-	}
-	if err := json.Unmarshal(raw, &got); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if got["role"] != RoleUser {
-		t.Errorf("role = %v, want the extra field to win over the modeled one", got["role"])
+		t.Errorf("messages sent = %v, want the adapter's rewrite", msgs)
 	}
 }
 

--- a/provider/openai/chat/compat_test.go
+++ b/provider/openai/chat/compat_test.go
@@ -38,57 +38,6 @@ func messagesOf(t *testing.T, body map[string]any) []map[string]any {
 	return out
 }
 
-// TestDeveloperMessagesConvertedToUser checks the role an asynchronous tool's
-// late results travel under: kept as it is for an endpoint that has the
-// developer role, and sent as a user message for one that does not, which is
-// what stops such an endpoint rejecting the turn. The conversation itself is
-// left as it was either way: the conversion is how this endpoint is addressed,
-// not a change to what was said.
-func TestDeveloperMessagesConvertedToUser(t *testing.T) {
-	convo := frames.NewLLMContext("")
-	convo.AddMessage(frames.Message{Role: frames.RoleDeveloper, Text: "Extra context."})
-	convo.AddUserMessage("Hello")
-
-	kept := toMessages(convo, false)
-	if kept[0].Role != RoleDeveloper {
-		t.Errorf("role = %q, want it left as the developer role", kept[0].Role)
-	}
-
-	converted := toMessages(convo, true)
-	if converted[0].Role != RoleUser {
-		t.Errorf("role = %q, want the developer message sent as a user message", converted[0].Role)
-	}
-	if converted[0].Content != "Extra context." {
-		t.Errorf("content = %q, want what the developer message carried", converted[0].Content)
-	}
-	if got := convo.Messages()[0].Role; got != frames.RoleDeveloper {
-		t.Errorf("the conversation now reads %q, want the developer message untouched", got)
-	}
-}
-
-// TestDeveloperConversionDoesNotAffectOtherRoles checks the conversion reaches
-// the developer role and nothing else.
-func TestDeveloperConversionDoesNotAffectOtherRoles(t *testing.T) {
-	convo := frames.NewLLMContext("System prompt.")
-	convo.AddMessage(frames.Message{Role: frames.RoleDeveloper, Text: "Dev guidance."})
-	convo.AddUserMessage("Hello")
-	convo.AddAssistantMessage("Hi")
-
-	msgs := toMessages(convo, true)
-	want := []string{RoleSystem, RoleUser, RoleUser, RoleAssistant}
-	if len(msgs) != len(want) {
-		t.Fatalf("messages = %+v, want %d of them", msgs, len(want))
-	}
-	for i, role := range want {
-		if msgs[i].Role != role {
-			t.Errorf("message %d role = %q, want %q", i, msgs[i].Role, role)
-		}
-	}
-	if msgs[1].Content != "Dev guidance." {
-		t.Errorf("content = %q, want what the developer message carried", msgs[1].Content)
-	}
-}
-
 // TestShapeMessagesRewritesWhatIsSent checks the hook sees the converted
 // conversation and decides what actually goes out.
 func TestShapeMessagesRewritesWhatIsSent(t *testing.T) {

--- a/provider/openai/chat/llm.go
+++ b/provider/openai/chat/llm.go
@@ -108,10 +108,9 @@ type LLMService struct {
 	http   *http.Client
 	shaper RequestShaper
 	// adapter converts the conversation into the request this endpoint takes.
-	adapter openai.Adapter
+	adapter adapter.LLMAdapter[openai.Params, openai.Tool]
 	// How this endpoint departs from OpenAI's own API, fixed at construction.
 	noDeveloperRole bool
-	shapeMessages   func([]Message) []Message
 }
 
 // Validate reports whether the configuration is usable.
@@ -136,11 +135,11 @@ type Compat struct {
 	// sent as user messages instead, which is what carries an asynchronous
 	// tool's late results to a model that would otherwise reject the role.
 	NoDeveloperRole bool
-	// ShapeMessages rewrites the conversation once it has been converted, just
-	// before it is sent. It is for an endpoint that constrains the shape of a
-	// conversation beyond what OpenAI's schema says, and it may add, drop or
-	// rewrite messages. Nil sends the conversation as converted.
-	ShapeMessages func([]Message) []Message
+	// Adapter converts the conversation into the request this endpoint takes. It
+	// is for an endpoint that constrains the shape of a conversation beyond what
+	// OpenAI's schema says: such an adapter embeds the OpenAI one and rewrites
+	// what it produced. Nil converts the conversation as OpenAI itself takes it.
+	Adapter adapter.LLMAdapter[openai.Params, openai.Tool]
 	// Base configures the shared LLM base this service is built on.
 	Base []llm.Option
 }
@@ -170,12 +169,16 @@ func NewCompatLLM(c Compat, cfg LLMConfig) *LLMService {
 	if shaper == nil {
 		shaper = defaultShaper{}
 	}
+	a := c.Adapter
+	if a == nil {
+		a = &openai.Adapter{}
+	}
 	s := &LLMService{
 		cfg:             cfg,
 		http:            &http.Client{},
 		shaper:          shaper,
+		adapter:         a,
 		noDeveloperRole: c.NoDeveloperRole,
-		shapeMessages:   c.ShapeMessages,
 	}
 	s.Base = llm.New(c.Name, s, c.Base...)
 	s.Base.SetModel(cfg.Model)
@@ -587,18 +590,10 @@ func (s *LLMService) RunInference(
 	return completion.Choices[0].Message.Content, nil
 }
 
-// params converts the conversation for this endpoint: the adapter's conversion,
-// then whatever the endpoint insists on beyond it.
+// params converts the conversation into what this endpoint takes.
 func (s *LLMService) params(
 	convo *frames.LLMContext, opts adapter.Options,
 ) (openai.Params, error) {
 	opts.ConvertDeveloperToUser = s.noDeveloperRole
-	p, err := s.adapter.LLMInvocationParams(convo, opts)
-	if err != nil {
-		return openai.Params{}, err
-	}
-	if s.shapeMessages != nil {
-		p.Messages = s.shapeMessages(p.Messages)
-	}
-	return p, nil
+	return s.adapter.LLMInvocationParams(convo, opts)
 }

--- a/provider/openai/chat/llm.go
+++ b/provider/openai/chat/llm.go
@@ -597,3 +597,14 @@ func (s *LLMService) params(
 	opts.ConvertDeveloperToUser = s.noDeveloperRole
 	return s.adapter.LLMInvocationParams(convo, opts)
 }
+
+// LLMAdapter returns the adapter this service converts through, so the base can
+// add the tools it implements itself to what every request advertises. It
+// implements llm.AdapterHolder.
+func (s *LLMService) LLMAdapter() llm.BuiltinToolHolder {
+	holder, ok := s.adapter.(llm.BuiltinToolHolder)
+	if !ok {
+		return nil
+	}
+	return holder
+}

--- a/provider/openai/chat/llm.go
+++ b/provider/openai/chat/llm.go
@@ -8,12 +8,13 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"maps"
 	"net/http"
 	"os"
 	"strings"
 	"time"
 
+	"github.com/gojargo/jargo/adapter"
+	"github.com/gojargo/jargo/adapter/openai"
 	"github.com/gojargo/jargo/frames"
 	"github.com/gojargo/jargo/internal/validate"
 	"github.com/gojargo/jargo/service/llm"
@@ -24,19 +25,16 @@ const (
 	// defaultRetryTimeout bounds the first attempt when a service was built to
 	// retry a request that times out.
 	defaultRetryTimeout = 5 * time.Second
-	// toolTypeFunction is the only tool type OpenAI's chat API defines.
-	toolTypeFunction = "function"
 )
 
-// The message roles the chat-completions API defines. They are exported for a
-// provider that has to rewrite the conversation before it is sent (see
-// Compat.ShapeMessages).
+// The message roles the chat-completions API defines. They are aliases of the
+// adapter's own, which is where the wire format lives.
 const (
-	RoleSystem    = "system"
-	RoleUser      = "user"
-	RoleAssistant = "assistant"
-	RoleTool      = "tool"
-	RoleDeveloper = "developer"
+	RoleSystem    = openai.RoleSystem
+	RoleUser      = openai.RoleUser
+	RoleAssistant = openai.RoleAssistant
+	RoleTool      = openai.RoleTool
+	RoleDeveloper = openai.RoleDeveloper
 )
 
 // LLMConfig configures an OpenAI (or OpenAI-compatible) LLM service. The
@@ -109,6 +107,8 @@ type LLMService struct {
 	cfg    LLMConfig
 	http   *http.Client
 	shaper RequestShaper
+	// adapter converts the conversation into the request this endpoint takes.
+	adapter openai.Adapter
 	// How this endpoint departs from OpenAI's own API, fixed at construction.
 	noDeveloperRole bool
 	shapeMessages   func([]Message) []Message
@@ -182,56 +182,19 @@ func NewCompatLLM(c Compat, cfg LLMConfig) *LLMService {
 	return s
 }
 
-// Message is one message of the conversation as the chat-completions API takes
-// it. It is exported for Compat.ShapeMessages, which sees the whole
-// conversation just before it is sent.
-type Message struct {
-	Role       string     `json:"role"`
-	Content    string     `json:"content"`
-	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`
-	ToolCallID string     `json:"tool_call_id,omitempty"`
-	// Extra sets fields on this message that OpenAI's schema has no place for,
-	// merged over the modeled ones when the message is encoded. It is how an
-	// endpoint that reads a field of its own is served without that field
-	// reaching the endpoints that would reject it.
-	Extra map[string]any `json:"-"`
-}
-
-// MarshalJSON encodes the message, merging Extra over the modeled fields.
-func (m Message) MarshalJSON() ([]byte, error) {
-	// plain drops the method set, so marshaling it does not recurse.
-	type plain Message
-	if len(m.Extra) == 0 {
-		return json.Marshal(plain(m))
-	}
-	return mergeExtra(plain(m), m.Extra)
-}
-
-// ToolCall is an assistant tool-call entry on a message.
-type ToolCall struct {
-	ID       string           `json:"id"`
-	Type     string           `json:"type"`
-	Function ToolCallFunction `json:"function"`
-}
-
-// ToolCallFunction is the function a tool call invokes, with its arguments as
-// the raw JSON string the model produced.
-type ToolCallFunction struct {
-	Name      string `json:"name"`
-	Arguments string `json:"arguments"`
-}
-
-// openaiTool is a function tool advertised on the request.
-type openaiTool struct {
-	Type     string     `json:"type"`
-	Function openaiFunc `json:"function"`
-}
-
-type openaiFunc struct {
-	Name        string          `json:"name"`
-	Description string          `json:"description,omitempty"`
-	Parameters  json.RawMessage `json:"parameters,omitempty"`
-}
+// The chat-completions wire types. They live in the adapter, which is what
+// converts a conversation into them; these aliases keep them reachable under
+// this package's name.
+type (
+	// Message is one message of the conversation as the chat-completions API
+	// takes it.
+	Message = openai.Message
+	// ToolCall is an assistant tool-call entry on a message.
+	ToolCall = openai.ToolCall
+	// ToolCallFunction is the function a tool call invokes, with its arguments as
+	// the raw JSON string the model produced.
+	ToolCallFunction = openai.ToolCallFunction
+)
 
 type chatRequest struct {
 	Model               string         `json:"model"`
@@ -246,7 +209,7 @@ type chatRequest struct {
 	PresencePenalty     *float64       `json:"presence_penalty,omitempty"`
 	Seed                *int           `json:"seed,omitempty"`
 	ServiceTier         string         `json:"service_tier,omitempty"`
-	Tools               []openaiTool   `json:"tools,omitempty"`
+	Tools               []openai.Tool  `json:"tools,omitempty"`
 	ToolChoice          string         `json:"tool_choice,omitempty"`
 }
 
@@ -262,22 +225,7 @@ func encodeBody(req chatRequest, extra map[string]any) ([]byte, error) {
 	if len(extra) == 0 {
 		return json.Marshal(req)
 	}
-	return mergeExtra(req, extra)
-}
-
-// mergeExtra encodes v and merges extra over the fields it produced, so a
-// caller-supplied field wins over the modeled one of the same name.
-func mergeExtra(v any, extra map[string]any) ([]byte, error) {
-	raw, err := json.Marshal(v)
-	if err != nil {
-		return nil, err
-	}
-	var m map[string]any
-	if err := json.Unmarshal(raw, &m); err != nil {
-		return nil, err
-	}
-	maps.Copy(m, extra)
-	return json.Marshal(m)
+	return openai.MergeExtra(req, extra)
 }
 
 type toolCallDelta struct {
@@ -346,7 +294,15 @@ func (textSink) Tool(frames.ToolCall) error { return nil }
 
 // Generate streams a chat completion, emitting each content delta.
 func (s *LLMService) Generate(ctx context.Context, convo *frames.LLMContext, emit llm.Emit) error {
-	return s.generate(ctx, s.baseRequest(convo), textSink{emit})
+	reqBody, err := s.baseRequest(convo, adapter.Options{})
+	if err != nil {
+		return err
+	}
+	// A text-only generation advertises no tools, so the model has nothing to
+	// call and a reported call would be the provider inventing one.
+	reqBody.Tools = nil
+	reqBody.ToolChoice = ""
+	return s.generate(ctx, reqBody, textSink{emit})
 }
 
 // GenerateWithTools streams a tool-capable completion. It emits text deltas to
@@ -354,19 +310,26 @@ func (s *LLMService) Generate(ctx context.Context, convo *frames.LLMContext, emi
 // the model produced. The conversation's tools are sent on the request, and any
 // tool turns already in the context are replayed as the matching messages.
 func (s *LLMService) GenerateWithTools(ctx context.Context, convo *frames.LLMContext, sink llm.Sink) error {
-	reqBody := s.baseRequest(convo)
-	if tools := convo.Tools(); len(tools) > 0 {
-		reqBody.Tools = toTools(tools)
-		reqBody.ToolChoice = string(convo.ToolChoice())
+	reqBody, err := s.baseRequest(convo, adapter.Options{})
+	if err != nil {
+		return err
 	}
 	return s.generate(ctx, reqBody, sink)
 }
 
 // baseRequest builds the streaming request shared by both generation paths.
-func (s *LLMService) baseRequest(convo *frames.LLMContext) chatRequest {
+func (s *LLMService) baseRequest(
+	convo *frames.LLMContext, opts adapter.Options,
+) (chatRequest, error) {
+	p, err := s.params(convo, opts)
+	if err != nil {
+		return chatRequest{}, err
+	}
 	return chatRequest{
 		Model:               s.cfg.Model,
-		Messages:            s.messages(convo),
+		Messages:            p.Messages,
+		Tools:               p.Tools,
+		ToolChoice:          p.ToolChoice,
 		Stream:              true,
 		StreamOptions:       &streamOptions{IncludeUsage: true},
 		MaxTokens:           s.cfg.MaxTokens,
@@ -377,7 +340,7 @@ func (s *LLMService) baseRequest(convo *frames.LLMContext) chatRequest {
 		PresencePenalty:     s.cfg.PresencePenalty,
 		Seed:                s.cfg.Seed,
 		ServiceTier:         s.cfg.ServiceTier,
-	}
+	}, nil
 }
 
 // generate sends one streaming request and feeds what comes back to sink.
@@ -577,14 +540,15 @@ func (c *toolCoalescer) emit(sink llm.Sink) error {
 func (s *LLMService) RunInference(
 	ctx context.Context, convo *frames.LLMContext, opts llm.InferenceOptions,
 ) (string, error) {
-	reqBody := s.baseRequest(convo)
+	reqBody, err := s.baseRequest(convo, adapter.Options{SystemInstruction: opts.SystemInstruction})
+	if err != nil {
+		return "", err
+	}
 	reqBody.Stream = false
 	reqBody.StreamOptions = nil
-	if opts.SystemInstruction != "" {
-		reqBody.Messages = append(
-			[]Message{{Role: RoleSystem, Content: opts.SystemInstruction}}, reqBody.Messages...,
-		)
-	}
+	// An inference wants an answer, not a tool call, so the toolset is left off.
+	reqBody.Tools = nil
+	reqBody.ToolChoice = ""
 	if opts.MaxTokens > 0 {
 		// Whichever bound this service states is the one to override; a model
 		// that reads only one of the two is told through the field it reads.
@@ -623,71 +587,18 @@ func (s *LLMService) RunInference(
 	return completion.Choices[0].Message.Content, nil
 }
 
-// messages converts the conversation for this endpoint: the shared conversion,
+// params converts the conversation for this endpoint: the adapter's conversion,
 // then whatever the endpoint insists on beyond it.
-func (s *LLMService) messages(convo *frames.LLMContext) []Message {
-	msgs := toMessages(convo, s.noDeveloperRole)
+func (s *LLMService) params(
+	convo *frames.LLMContext, opts adapter.Options,
+) (openai.Params, error) {
+	opts.ConvertDeveloperToUser = s.noDeveloperRole
+	p, err := s.adapter.LLMInvocationParams(convo, opts)
+	if err != nil {
+		return openai.Params{}, err
+	}
 	if s.shapeMessages != nil {
-		msgs = s.shapeMessages(msgs)
+		p.Messages = s.shapeMessages(p.Messages)
 	}
-	return msgs
-}
-
-// toMessages converts the conversation into OpenAI chat messages, with the
-// system prompt as the leading system message. Tool turns become an assistant
-// message carrying tool_calls and one "tool" message per result.
-//
-// developerAsUser sends a developer message as a user message, for an endpoint
-// that has no developer role. What the role carries, the late results of an
-// asynchronous tool, is worth more to the model than the role it arrives under.
-func toMessages(convo *frames.LLMContext, developerAsUser bool) []Message {
-	var out []Message
-	if sys := convo.System(); sys != "" {
-		out = append(out, Message{Role: RoleSystem, Content: sys})
-	}
-	for _, m := range convo.Messages() {
-		switch {
-		case len(m.ToolResults) > 0:
-			for _, r := range m.ToolResults {
-				out = append(out, Message{Role: RoleTool, ToolCallID: r.ID, Content: r.Content})
-			}
-		case len(m.ToolCalls) > 0:
-			msg := Message{Role: RoleAssistant, Content: m.Text}
-			for _, c := range m.ToolCalls {
-				args := string(c.Args)
-				if args == "" {
-					args = "{}"
-				}
-				msg.ToolCalls = append(msg.ToolCalls, ToolCall{
-					ID:       c.ID,
-					Type:     toolTypeFunction,
-					Function: ToolCallFunction{Name: c.Name, Arguments: args},
-				})
-			}
-			out = append(out, msg)
-		default:
-			role := string(m.Role)
-			if developerAsUser && m.Role == frames.RoleDeveloper {
-				role = RoleUser
-			}
-			out = append(out, Message{Role: role, Content: m.Text})
-		}
-	}
-	return out
-}
-
-// toTools converts the context's tools into OpenAI function tools.
-func toTools(tools []frames.Tool) []openaiTool {
-	out := make([]openaiTool, 0, len(tools))
-	for _, t := range tools {
-		out = append(out, openaiTool{
-			Type: toolTypeFunction,
-			Function: openaiFunc{
-				Name:        t.Name,
-				Description: t.Description,
-				Parameters:  t.Parameters,
-			},
-		})
-	}
-	return out
+	return p, nil
 }

--- a/provider/openai/chat/llm_test.go
+++ b/provider/openai/chat/llm_test.go
@@ -348,8 +348,8 @@ func TestGenerateWithToolsAdvertisesTools(t *testing.T) {
 		t.Fatalf("tools = %v, want the one advertised tool", srv.body["tools"])
 	}
 	tool, _ := tools[0].(map[string]any)
-	if tool["type"] != toolTypeFunction {
-		t.Errorf("tool type = %v, want %q", tool["type"], toolTypeFunction)
+	if tool["type"] != "function" {
+		t.Errorf("tool type = %v, want %q", tool["type"], "function")
 	}
 	fn, _ := tool["function"].(map[string]any)
 	if fn["name"] != "get_weather" || fn["description"] != "Look up the weather" {

--- a/provider/openai/chat/llm_tools_test.go
+++ b/provider/openai/chat/llm_tools_test.go
@@ -1,7 +1,6 @@
 package chat
 
 import (
-	"encoding/json"
 	"strings"
 	"testing"
 
@@ -24,66 +23,6 @@ func toolDelta(index int, id, name, args string) toolCallDelta {
 	d.Function.Name = name
 	d.Function.Arguments = args
 	return d
-}
-
-func TestToMessagesToolTurn(t *testing.T) {
-	convo := frames.NewLLMContext("be helpful")
-	convo.AddUserMessage("weather in Paris?")
-	convo.AddAssistantToolCall(frames.ToolCall{
-		ID: "call_a", Name: "get_weather", Args: json.RawMessage(`{"location":"Paris"}`),
-	})
-	convo.AddToolResult(frames.ToolResult{ID: "call_a", Name: "get_weather", Content: "sunny, 20C"})
-
-	msgs := toMessages(convo, false)
-	if len(msgs) != 4 {
-		t.Fatalf("want 4 messages (system, user, assistant, tool), got %d", len(msgs))
-	}
-	if msgs[0].Role != "system" || msgs[1].Role != "user" {
-		t.Fatalf("unexpected leading roles: %q, %q", msgs[0].Role, msgs[1].Role)
-	}
-
-	asst := msgs[2]
-	if asst.Role != "assistant" || len(asst.ToolCalls) != 1 {
-		t.Fatalf("assistant tool message malformed: %+v", asst)
-	}
-	tc := asst.ToolCalls[0]
-	if tc.ID != "call_a" || tc.Type != "function" || tc.Function.Name != "get_weather" {
-		t.Errorf("tool_call fields wrong: %+v", tc)
-	}
-	if tc.Function.Arguments != `{"location":"Paris"}` {
-		t.Errorf("tool_call arguments = %q", tc.Function.Arguments)
-	}
-
-	res := msgs[3]
-	if res.Role != "tool" || res.ToolCallID != "call_a" || res.Content != "sunny, 20C" {
-		t.Errorf("tool result message wrong: %+v", res)
-	}
-}
-
-func TestToMessagesEmptyArgsDefaults(t *testing.T) {
-	convo := frames.NewLLMContext("")
-	convo.AddAssistantToolCall(frames.ToolCall{ID: "c1", Name: "now"})
-	msgs := toMessages(convo, false)
-	if got := msgs[0].ToolCalls[0].Function.Arguments; got != "{}" {
-		t.Errorf("empty args should default to {}, got %q", got)
-	}
-}
-
-func TestToTools(t *testing.T) {
-	out := toTools([]frames.Tool{{
-		Name:        "get_weather",
-		Description: "Look up the weather",
-		Parameters:  json.RawMessage(`{"type":"object"}`),
-	}})
-	if len(out) != 1 {
-		t.Fatalf("want 1 tool, got %d", len(out))
-	}
-	if out[0].Type != "function" || out[0].Function.Name != "get_weather" {
-		t.Errorf("tool shape wrong: %+v", out[0])
-	}
-	if string(out[0].Function.Parameters) != `{"type":"object"}` {
-		t.Errorf("parameters not passed through: %s", out[0].Function.Parameters)
-	}
 }
 
 func TestToolCoalescer(t *testing.T) {

--- a/provider/openai/realtime/s2s.go
+++ b/provider/openai/realtime/s2s.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 
 	"github.com/coder/websocket"
+	realtimeadapter "github.com/gojargo/jargo/adapter/realtime"
 	"github.com/gojargo/jargo/frames"
 	"github.com/gojargo/jargo/processor"
 	"github.com/gojargo/jargo/service/wsutil"
@@ -20,6 +21,8 @@ import (
 
 // Service is the Realtime speech-to-speech processor.
 type Service struct {
+	// adapter converts the conversation into what a session takes from it.
+	adapter realtimeadapter.Adapter
 	*processor.Base
 	cfg Config
 
@@ -208,27 +211,9 @@ func (s *Service) sessionUpdate() sessionUpdateMsg {
 }
 
 // toolSession renders the function-calling part of a session payload. It is
-// empty when no tools are advertised, so a session without function calling is
-// configured exactly as before.
+// nil when the conversation advertises no tools.
 func (s *Service) toolSession(tools []frames.Tool, choice frames.ToolChoice) map[string]any {
-	if len(tools) == 0 {
-		return nil
-	}
-	specs := make([]map[string]any, 0, len(tools))
-	for _, t := range tools {
-		spec := map[string]any{keyType: "function", "name": t.Name}
-		if t.Description != "" {
-			spec["description"] = t.Description
-		}
-		if len(t.Parameters) > 0 {
-			spec["parameters"] = t.Parameters
-		}
-		specs = append(specs, spec)
-	}
-	if choice == "" {
-		choice = frames.ToolChoiceAuto
-	}
-	return map[string]any{"tools": specs, "tool_choice": string(choice)}
+	return s.adapter.SessionParams(tools, choice).Session()
 }
 
 // currentTools returns the tools currently advertised to the session.

--- a/provider/openai/realtime/s2s.go
+++ b/provider/openai/realtime/s2s.go
@@ -38,7 +38,7 @@ type Service struct {
 	// advertised to the session. The model generates continuously, so it does not
 	// re-read the context between turns: every change must be pushed to it with a
 	// session.update. They are guarded by mu.
-	tools      []frames.Tool
+	tools      frames.ToolsSchema
 	toolChoice frames.ToolChoice
 
 	connector Connector
@@ -124,13 +124,13 @@ func (s *Service) ProcessFrame(ctx context.Context, f frames.Frame, dir processo
 	case *frames.LLMContextFrame:
 		// Seed the function-calling configuration from the shared context.
 		if fr.Context != nil {
-			s.syncTools(fr.Context.Tools(), fr.Context.ToolChoice())
+			s.syncTools(fr.Context.ToolsSchema(), fr.Context.ToolChoice())
 		}
 		return s.PushFrame(ctx, f, dir)
 	case *frames.LLMSetToolsFrame:
 		// The toolset changed mid-conversation. A text LLM would pick this up on
 		// its next run; this model is generating continuously, so tell it now.
-		s.syncTools(fr.Tools, s.currentToolChoice())
+		s.syncTools(frames.ToolsSchema{Standard: fr.Tools}, s.currentToolChoice())
 		return s.PushFrame(ctx, f, dir)
 	case *frames.LLMSetToolChoiceFrame:
 		s.syncTools(s.currentTools(), fr.ToolChoice)
@@ -213,12 +213,14 @@ func (s *Service) sessionUpdate() sessionUpdateMsg {
 
 // toolSession renders the function-calling part of a session payload. It is
 // nil when the conversation advertises no tools.
-func (s *Service) toolSession(tools []frames.Tool, choice frames.ToolChoice) map[string]any {
-	return s.adapter.SessionParams(tools, choice).Session()
+func (s *Service) toolSession(
+	schema frames.ToolsSchema, choice frames.ToolChoice,
+) map[string]any {
+	return s.adapter.SessionParams(schema, choice).Session()
 }
 
-// currentTools returns the tools currently advertised to the session.
-func (s *Service) currentTools() []frames.Tool {
+// currentTools returns the toolset currently advertised to the session.
+func (s *Service) currentTools() frames.ToolsSchema {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.tools
@@ -235,13 +237,13 @@ func (s *Service) currentToolChoice() frames.ToolChoice {
 // what the live session was told, pushes a session.update so the continuously
 // running model picks the change up. It is a no-op before the session connects;
 // the initial sessionUpdate carries whatever has been recorded by then.
-func (s *Service) syncTools(tools []frames.Tool, choice frames.ToolChoice) {
+func (s *Service) syncTools(schema frames.ToolsSchema, choice frames.ToolChoice) {
 	s.mu.Lock()
-	if sameTools(s.tools, tools) && s.toolChoice == choice {
+	if sameTools(s.tools, schema) && s.toolChoice == choice {
 		s.mu.Unlock()
 		return
 	}
-	s.tools = tools
+	s.tools = schema
 	s.toolChoice = choice
 	live := s.conn != nil
 	s.mu.Unlock()
@@ -249,7 +251,7 @@ func (s *Service) syncTools(tools []frames.Tool, choice frames.ToolChoice) {
 	if !live {
 		return
 	}
-	session := s.toolSession(tools, choice)
+	session := s.toolSession(schema, choice)
 	if session == nil {
 		// Clearing the toolset still has to reach the model.
 		session = map[string]any{"tools": []map[string]any{}}
@@ -260,14 +262,21 @@ func (s *Service) syncTools(tools []frames.Tool, choice frames.ToolChoice) {
 }
 
 // sameTools reports whether two toolsets are equivalent for session purposes.
-func sameTools(a, b []frames.Tool) bool {
-	if len(a) != len(b) {
+// A custom tool is compared by identity of the slice it came in, which is enough
+// to tell a toolset that was replaced from one that was not.
+func sameTools(a, b frames.ToolsSchema) bool {
+	if len(a.Standard) != len(b.Standard) || len(a.Custom) != len(b.Custom) {
 		return false
 	}
-	for i := range a {
-		if a[i].Name != b[i].Name ||
-			a[i].Description != b[i].Description ||
-			!bytes.Equal(a[i].Parameters, b[i].Parameters) {
+	for i := range a.Standard {
+		if a.Standard[i].Name != b.Standard[i].Name ||
+			a.Standard[i].Description != b.Standard[i].Description ||
+			!bytes.Equal(a.Standard[i].Parameters, b.Standard[i].Parameters) {
+			return false
+		}
+	}
+	for k, av := range a.Custom {
+		if len(b.Custom[k]) != len(av) {
 			return false
 		}
 	}

--- a/provider/openai/realtime/s2s.go
+++ b/provider/openai/realtime/s2s.go
@@ -16,6 +16,7 @@ import (
 	realtimeadapter "github.com/gojargo/jargo/adapter/realtime"
 	"github.com/gojargo/jargo/frames"
 	"github.com/gojargo/jargo/processor"
+	"github.com/gojargo/jargo/service/llm"
 	"github.com/gojargo/jargo/service/wsutil"
 )
 
@@ -432,3 +433,8 @@ func (s *Service) reportUsage(ctx context.Context, ev serverEvent) {
 // the result, so the pipeline counts it when it collects the processors that
 // report metrics.
 func (s *Service) CanGenerateMetrics() bool { return true }
+
+// LLMAdapter returns the adapter this service converts through, so the base can
+// add the tools it implements itself to what every request advertises. It
+// implements llm.AdapterHolder.
+func (s *Service) LLMAdapter() llm.BuiltinToolHolder { return &s.adapter }

--- a/provider/openai/responses/http.go
+++ b/provider/openai/responses/http.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/gojargo/jargo/adapter"
 	"github.com/gojargo/jargo/frames"
 	"github.com/gojargo/jargo/service/llm"
 )
@@ -56,7 +57,11 @@ func (s *HTTPService) RunInference(
 
 // run issues one turn and feeds its event stream to the state machine.
 func (s *HTTPService) run(ctx context.Context, convo *frames.LLMContext, sink llm.Sink, withTools bool) error {
-	body, err := encodeBody(s.cfg.newRequest(convo, withTools), s.cfg.Extra)
+	reqBody, err := s.cfg.newRequest(convo, adapter.Options{}, withTools)
+	if err != nil {
+		return err
+	}
+	body, err := encodeBody(reqBody, s.cfg.Extra)
 	if err != nil {
 		return err
 	}

--- a/provider/openai/responses/responses.go
+++ b/provider/openai/responses/responses.go
@@ -23,6 +23,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/gojargo/jargo/adapter"
+	responsesadapter "github.com/gojargo/jargo/adapter/responses"
 	"github.com/gojargo/jargo/frames"
 	"github.com/gojargo/jargo/internal/validate"
 	"github.com/gojargo/jargo/service/llm"
@@ -100,29 +102,15 @@ type Config struct {
 // Validate reports whether the configuration is usable.
 func (c Config) Validate() error { return validate.Struct(c) }
 
-// inputItem is one entry of a Responses request's input list: a message, a
-// function call the model made, or the result of one.
-type inputItem struct {
-	Type string `json:"type"`
-	// Role and Content carry a message.
-	Role    string `json:"role,omitempty"`
-	Content string `json:"content,omitempty"`
-	// CallID, Name and Arguments carry a function call.
-	CallID    string `json:"call_id,omitempty"`
-	Name      string `json:"name,omitempty"`
-	Arguments string `json:"arguments,omitempty"`
-	// Output carries a function call's result.
-	Output string `json:"output,omitempty"`
-}
-
-// responsesTool is a function tool advertised on the request. The Responses API
-// flattens the function fields onto the tool rather than nesting them.
-type responsesTool struct {
-	Type        string          `json:"type"`
-	Name        string          `json:"name"`
-	Description string          `json:"description,omitempty"`
-	Parameters  json.RawMessage `json:"parameters,omitempty"`
-}
+// The Responses wire types. They live in the adapter, which is what converts a
+// conversation into them; these aliases keep them reachable under this
+// package's name.
+type (
+	// inputItem is one entry of a Responses request's input list.
+	inputItem = responsesadapter.InputItem
+	// responsesTool is a function tool advertised on the request.
+	responsesTool = responsesadapter.Tool
+)
 
 // request is a Responses API request.
 type request struct {
@@ -143,88 +131,36 @@ type request struct {
 	PreviousResponseID string `json:"previous_response_id,omitempty"`
 }
 
-// buildInput converts a conversation into the Responses input list, and returns
-// the system instructions to send alongside it. The Responses API takes the
-// system prompt as its own field rather than as a leading message, so the
-// context's system prompt (which already folds in any rolling summary and
-// recalled memories) becomes the instructions. It wins over the configured one.
-func (c Config) buildInput(convo *frames.LLMContext) ([]inputItem, string) {
-	instructions := c.Instructions
-	if sys := convo.System(); sys != "" {
-		instructions = sys
-	}
-	messages := convo.Messages()
-	items := make([]inputItem, 0, len(messages))
-
-	for _, m := range messages {
-		switch {
-		case len(m.ToolResults) > 0:
-			for _, r := range m.ToolResults {
-				items = append(items, inputItem{
-					Type: itemFuncOutput, CallID: r.ID, Output: r.Content,
-				})
-			}
-		case len(m.ToolCalls) > 0:
-			if m.Text != "" {
-				items = append(items, inputItem{
-					Type: itemMessage, Role: string(frames.RoleAssistant), Content: m.Text,
-				})
-			}
-			for _, call := range m.ToolCalls {
-				args := string(call.Args)
-				if args == "" {
-					args = "{}"
-				}
-				items = append(items, inputItem{
-					Type: itemFuncCall, CallID: call.ID, Name: call.Name, Arguments: args,
-				})
-			}
-		default:
-			items = append(items, inputItem{
-				Type: itemMessage, Role: string(m.Role), Content: m.Text,
-			})
-		}
-	}
-	return items, instructions
-}
-
-// buildTools renders the tools a conversation advertises.
-func buildTools(convo *frames.LLMContext) []responsesTool {
-	tools := convo.Tools()
-	if len(tools) == 0 {
-		return nil
-	}
-	out := make([]responsesTool, 0, len(tools))
-	for _, t := range tools {
-		out = append(out, responsesTool{
-			Type:        "function",
-			Name:        t.Name,
-			Description: t.Description,
-			Parameters:  t.Parameters,
-		})
-	}
-	return out
-}
-
 // newRequest builds the request for a conversation, without the streaming or
 // continuation fields the transports set themselves.
-func (c Config) newRequest(convo *frames.LLMContext, withTools bool) request {
-	input, instructions := c.buildInput(convo)
+func (c Config) newRequest(
+	convo *frames.LLMContext, opts adapter.Options, withTools bool,
+) (request, error) {
+	var a responsesadapter.Adapter
+	// The configured instructions are this service's own default, standing in
+	// when neither the call nor the conversation states one.
+	if opts.SystemInstruction == "" && convo.System() == "" {
+		opts.SystemInstruction = c.Instructions
+	}
+	p, err := a.LLMInvocationParams(convo, opts)
+	if err != nil {
+		return request{}, err
+	}
 	req := request{
 		Model:           c.Model,
-		Input:           input,
+		Input:           p.Input,
 		Stream:          true,
 		Store:           c.Store,
-		Instructions:    instructions,
+		Instructions:    p.Instructions,
 		MaxOutputTokens: c.MaxOutputTokens,
 		Temperature:     c.Temperature,
 		TopP:            c.TopP,
 		ServiceTier:     c.ServiceTier,
 	}
 	if withTools {
-		req.Tools = buildTools(convo)
+		req.Tools = p.Tools
 	}
-	return req
+	return req, nil
 }
 
 // runInference answers the conversation once over HTTP and returns the text.
@@ -235,7 +171,12 @@ func runInference(
 	ctx context.Context, cfg Config, client *http.Client,
 	convo *frames.LLMContext, opts llm.InferenceOptions,
 ) (string, error) {
-	body := cfg.newRequest(convo, false)
+	body, err := cfg.newRequest(
+		convo, adapter.Options{SystemInstruction: opts.SystemInstruction}, false,
+	)
+	if err != nil {
+		return "", err
+	}
 	body.Stream = false
 	if opts.MaxTokens > 0 {
 		body.MaxOutputTokens = opts.MaxTokens

--- a/provider/openai/responses/responses_test.go
+++ b/provider/openai/responses/responses_test.go
@@ -4,9 +4,20 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/gojargo/jargo/adapter"
 	"github.com/gojargo/jargo/frames"
 	"github.com/gojargo/jargo/internal/providertest"
 )
+
+// mustRequest builds a request and fails the test if the conversion did.
+func mustRequest(t *testing.T, cfg Config, convo *frames.LLMContext) request {
+	t.Helper()
+	req, err := cfg.newRequest(convo, adapter.Options{}, false)
+	if err != nil {
+		t.Fatalf("newRequest: %v", err)
+	}
+	return req
+}
 
 // TestConfigValidate pins which Config fields the provider requires.
 func TestConfigValidate(t *testing.T) {
@@ -23,29 +34,6 @@ func TestNewServices(t *testing.T) {
 	providertest.Service(t, "OpenAIResponsesHTTPLLM", NewHTTPLLM(Config{APIKey: "k"}))
 }
 
-// TestBuildInputMessages checks a plain conversation becomes message items, and
-// that the system prompt is lifted out into the instructions field rather than
-// traveling as a message.
-func TestBuildInputMessages(t *testing.T) {
-	convo := frames.NewLLMContext("be brief")
-	convo.AddUserMessage("hello")
-	convo.AddAssistantMessage("hi there")
-
-	items, instructions := Config{}.buildInput(convo)
-	if instructions != "be brief" {
-		t.Errorf("instructions = %q, want the system prompt", instructions)
-	}
-	if len(items) != 2 {
-		t.Fatalf("items = %+v, want the two non-system messages", items)
-	}
-	if items[0].Type != itemMessage || items[0].Role != "user" || items[0].Content != "hello" {
-		t.Errorf("item 0 = %+v, want the user message", items[0])
-	}
-	if items[1].Role != "assistant" || items[1].Content != "hi there" {
-		t.Errorf("item 1 = %+v, want the assistant message", items[1])
-	}
-}
-
 // TestBuildInputConfiguredInstructions checks the configured prompt is used when
 // the context carries no system message, and yields to one that does.
 func TestBuildInputConfiguredInstructions(t *testing.T) {
@@ -53,91 +41,14 @@ func TestBuildInputConfiguredInstructions(t *testing.T) {
 
 	convo := frames.NewLLMContext("")
 	convo.AddUserMessage("hi")
-	if _, got := cfg.buildInput(convo); got != "from config" {
+	if got := mustRequest(t, cfg, convo).Instructions; got != "from config" {
 		t.Errorf("instructions = %q, want the configured prompt", got)
 	}
 
 	withSystem := frames.NewLLMContext("from context")
-	if _, got := cfg.buildInput(withSystem); got != "from context" {
-		t.Errorf("instructions = %q, want the context's system message to win", got)
-	}
-}
-
-// TestBuildInputToolTurn checks a tool exchange renders as the function_call and
-// function_call_output items the Responses API expects, rather than the
-// chat-completions message shapes.
-func TestBuildInputToolTurn(t *testing.T) {
-	convo := frames.NewLLMContext("")
-	convo.AddUserMessage("weather?")
-	convo.AddAssistantMessage("let me check")
-	convo.AddAssistantToolCall(frames.ToolCall{
-		ID: "call_1", Name: "get_weather", Args: json.RawMessage(`{"city":"Paris"}`),
-	})
-	convo.AddToolResult(frames.ToolResult{ID: "call_1", Content: "sunny"})
-
-	items, _ := Config{}.buildInput(convo)
-	if len(items) != 4 {
-		t.Fatalf("items = %+v, want user, assistant text, function call, output", items)
-	}
-	if items[1].Type != itemMessage || items[1].Content != "let me check" {
-		t.Errorf("item 1 = %+v, want the assistant's text alongside the call", items[1])
-	}
-	if items[2].Type != itemFuncCall || items[2].CallID != "call_1" || items[2].Name != "get_weather" {
-		t.Errorf("item 2 = %+v, want the function call", items[2])
-	}
-	if items[2].Arguments != `{"city":"Paris"}` {
-		t.Errorf("arguments = %q, want the call's JSON", items[2].Arguments)
-	}
-	if items[3].Type != itemFuncOutput || items[3].CallID != "call_1" || items[3].Output != "sunny" {
-		t.Errorf("item 3 = %+v, want the function output", items[3])
-	}
-}
-
-// TestBuildInputEmptyArguments checks a call with no arguments sends an empty
-// object, which the API requires, rather than an empty string.
-func TestBuildInputEmptyArguments(t *testing.T) {
-	convo := frames.NewLLMContext("")
-	convo.AddAssistantToolCall(frames.ToolCall{ID: "c1", Name: "now"})
-	items, _ := Config{}.buildInput(convo)
-	if len(items) != 1 || items[0].Arguments != "{}" {
-		t.Errorf("items = %+v, want a call with empty-object arguments", items)
-	}
-}
-
-// TestBuildTools checks the Responses API's flattened tool shape: the function
-// fields sit on the tool rather than nested under a "function" key.
-func TestBuildTools(t *testing.T) {
-	convo := frames.NewLLMContext("")
-	if got := buildTools(convo); got != nil {
-		t.Errorf("buildTools with no tools = %+v, want nil", got)
-	}
-
-	convo.SetTools([]frames.Tool{{
-		Name:        "get_weather",
-		Description: "look it up",
-		Parameters:  json.RawMessage(`{"type":"object"}`),
-	}})
-	tools := buildTools(convo)
-	if len(tools) != 1 {
-		t.Fatalf("tools = %+v, want one", tools)
-	}
-	if tools[0].Type != "function" || tools[0].Name != "get_weather" {
-		t.Errorf("tool = %+v, want a flattened function tool", tools[0])
-	}
-
-	raw, err := json.Marshal(tools[0])
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
-	}
-	var m map[string]any
-	if err := json.Unmarshal(raw, &m); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if _, nested := m["function"]; nested {
-		t.Errorf("tool = %s, want the function fields flattened onto it", raw)
-	}
-	if m["name"] != "get_weather" {
-		t.Errorf("tool name = %v, want it at the top level", m["name"])
+	withSystem.AddUserMessage("hi")
+	if got := mustRequest(t, cfg, withSystem).Instructions; got != "from context" {
+		t.Errorf("instructions = %q, want the conversation's own prompt to win", got)
 	}
 }
 
@@ -167,7 +78,7 @@ func TestNewRequestOmitsUnset(t *testing.T) {
 	convo := frames.NewLLMContext("")
 	convo.AddUserMessage("hi")
 
-	raw, err := encodeBody(Config{Model: "gpt-4.1"}.newRequest(convo, false), nil)
+	raw, err := encodeBody(mustRequest(t, Config{Model: "gpt-4.1"}, convo), nil)
 	if err != nil {
 		t.Fatalf("encodeBody: %v", err)
 	}

--- a/provider/openai/responses/ws.go
+++ b/provider/openai/responses/ws.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/coder/websocket"
+	"github.com/gojargo/jargo/adapter"
 	"github.com/gojargo/jargo/frames"
 	"github.com/gojargo/jargo/service/llm"
 	"github.com/gojargo/jargo/service/wsutil"
@@ -176,7 +177,10 @@ func (s *Service) turn(ctx context.Context, convo *frames.LLMContext, sink llm.S
 		return err
 	}
 
-	req := s.cfg.newRequest(convo, withTools)
+	req, err := s.cfg.newRequest(convo, adapter.Options{}, withTools)
+	if err != nil {
+		return err
+	}
 	full := req.Input
 	sent := s.applyContinuation(&req)
 

--- a/provider/perplexity/llm.go
+++ b/provider/perplexity/llm.go
@@ -1,13 +1,20 @@
 package perplexity
 
-import "github.com/gojargo/jargo/provider/openai/chat"
+import (
+	perplexityadapter "github.com/gojargo/jargo/adapter/perplexity"
+	"github.com/gojargo/jargo/provider/openai/chat"
+)
 
-// NewLLM builds a Perplexity LLM service.
+// NewLLM builds a Perplexity LLM service. Perplexity speaks the OpenAI
+// chat-completions API, with two departures from it: it has no developer role,
+// and it is stricter than OpenAI about the shape of a conversation (which its
+// adapter settles).
 func NewLLM(cfg chat.LLMConfig) *chat.LLMService {
 	return chat.NewCompatLLM(chat.Compat{
 		Name:            "PerplexityLLM",
 		BaseURL:         baseURL,
 		DefaultModel:    defaultModel,
 		NoDeveloperRole: true,
+		Adapter:         &perplexityadapter.Adapter{},
 	}, cfg)
 }

--- a/service/llm/asynctool.go
+++ b/service/llm/asynctool.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/gojargo/jargo/adapter"
 	"github.com/gojargo/jargo/frames"
 )
 
@@ -142,24 +143,53 @@ func (b *Base) cancelToolEnabled() bool {
 	return b.cancelToolActive
 }
 
+// BuiltinToolHolder is implemented by an adapter the service can add the tools
+// it implements itself to. adapter.Base satisfies it, so every jargo adapter
+// does.
+type BuiltinToolHolder interface {
+	// SetBuiltin adds a tool sent on every request from now on.
+	SetBuiltin(adapter.Builtin)
+	// RemoveBuiltin withdraws the tool registered under name.
+	RemoveBuiltin(name string) bool
+}
+
+// AdapterHolder is implemented by a service that converts a conversation
+// through an adapter, which is where a tool the service implements itself
+// belongs: the conversation is shared, so writing the tool into it would offer
+// it to every other service reading that conversation.
+type AdapterHolder interface {
+	// LLMAdapter returns the adapter this service converts through.
+	LLMAdapter() BuiltinToolHolder
+}
+
 // applyAsyncToolCancellation adds the built-in tool and its instructions to what
-// this inference sends, without touching the stored conversation. They belong to
-// the service rather than to the conversation, so they come and go with what is
-// registered instead of being written into a context the application owns.
-func (b *Base) applyAsyncToolCancellation(convo *frames.LLMContext) {
+// this service sends, or withdraws them. They belong to the service rather than
+// to the conversation, so they come and go with what is registered instead of
+// being written into a context the application owns.
+func (b *Base) applyAsyncToolCancellation() {
 	if !b.asyncToolCancellation {
-		// The service never offers the tool, so it has nothing to say about the
-		// conversation either way. Leaving it alone matters: another service may
-		// share this conversation and have its own to add.
+		// The service never offers the tool, so it has nothing to add either way.
+		return
+	}
+	holder, ok := b.gen.(AdapterHolder)
+	if !ok {
+		// A service that converts without an adapter has nowhere to put the tool.
+		// It cannot offer cancellation, and saying so once is better than the model
+		// being told to call a tool it is never sent.
+		b.warnNoAdapter.Do(func() {
+			slog.Warn("async tool cancellation needs a service that converts through an adapter",
+				"service", b.Name())
+		})
 		return
 	}
 	if !b.cancelToolEnabled() {
-		convo.SetServiceTools(nil)
-		convo.SetServiceInstructions("")
+		holder.LLMAdapter().RemoveBuiltin(CancelAsyncToolName)
 		return
 	}
-	convo.SetServiceTools([]frames.Tool{cancelAsyncToolSchema})
-	convo.SetServiceInstructions(asyncToolCancellationInstructions)
+	holder.LLMAdapter().SetBuiltin(adapter.Builtin{
+		Tool:         cancelAsyncToolSchema,
+		Instructions: asyncToolCancellationInstructions,
+	})
 }
 
 // cancelAsyncToolHandler abandons the call the model named. It reports which id

--- a/service/llm/llm.go
+++ b/service/llm/llm.go
@@ -305,6 +305,9 @@ type Base struct {
 	callTimeout   time.Duration
 	runInParallel bool
 	groupCalls    bool
+	// warnNoAdapter reports once that cancellation was asked for on a service
+	// with no adapter to put the tool on.
+	warnNoAdapter sync.Once
 	// asyncToolCancellation offers the model a built-in tool for abandoning an
 	// asynchronous call, while any asynchronous tool is registered.
 	asyncToolCancellation bool
@@ -820,7 +823,7 @@ func (b *Base) run(ctx context.Context, convo *frames.LLMContext) error {
 	// tool carries, drop the ones for tools no longer advertised, and only then
 	// settle what this service adds on its own account.
 	b.syncToolHandlers(ctx, convo)
-	b.applyAsyncToolCancellation(convo)
+	b.applyAsyncToolCancellation()
 	if len(convo.Tools()) > 0 {
 		if tg, ok := b.gen.(ToolGenerator); ok {
 			return b.runWithTools(ctx, convo, tg)

--- a/service/llm/llm_tools_test.go
+++ b/service/llm/llm_tools_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gojargo/jargo/adapter"
 	"github.com/gojargo/jargo/frames"
 	"github.com/gojargo/jargo/pipeline"
 	"github.com/gojargo/jargo/processor"
@@ -935,16 +936,24 @@ func TestGroupedFunctionCallsShareAGroup(t *testing.T) {
 	<-runDone
 }
 
-// asyncToolGen requests the named tool once, then answers with text.
+// asyncToolGen requests the named tool once, then answers with text. It stands
+// in for a service that converts through an adapter, which is where the tools
+// the service implements itself are added.
 type asyncToolGen struct {
-	mu   sync.Mutex
-	turn int
-	name string
+	// adapter is what the base adds its built-in tools to, and what this
+	// generator reads back to see what the model was actually offered.
+	adapter adapter.Base
+	mu      sync.Mutex
+	turn    int
+	name    string
 	// tools records what the model was offered on the first inference.
 	tools []frames.Tool
 	// system records the prompt it was given on the first inference.
 	system string
 }
+
+// LLMAdapter implements llm.AdapterHolder.
+func (g *asyncToolGen) LLMAdapter() llm.BuiltinToolHolder { return &g.adapter }
 
 func (g *asyncToolGen) Generate(context.Context, *frames.LLMContext, llm.Emit) error { return nil }
 
@@ -955,8 +964,9 @@ func (g *asyncToolGen) GenerateWithTools(
 	turn := g.turn
 	g.turn++
 	if turn == 0 {
-		g.tools = convo.Tools()
-		g.system = convo.System()
+		// What an adapter would send, which is where a built-in tool now lives.
+		g.tools = g.adapter.WithBuiltins(convo.Tools())
+		g.system = g.adapter.SystemWithBuiltins(convo.System())
 	}
 	g.mu.Unlock()
 	if turn == 0 {

--- a/service/llm/llm_tools_test.go
+++ b/service/llm/llm_tools_test.go
@@ -965,7 +965,7 @@ func (g *asyncToolGen) GenerateWithTools(
 	g.turn++
 	if turn == 0 {
 		// What an adapter would send, which is where a built-in tool now lives.
-		g.tools = g.adapter.WithBuiltins(convo.Tools())
+		g.tools = g.adapter.WithBuiltins(convo.ToolsSchema()).Standard
 		g.system = g.adapter.SystemWithBuiltins(convo.System())
 	}
 	g.mu.Unlock()

--- a/service/llm/registry.go
+++ b/service/llm/registry.go
@@ -17,7 +17,7 @@ import (
 // each time. Only handlers registered from a toolset are ever dropped: one
 // registered by hand is the application's to remove.
 func (b *Base) syncToolHandlers(ctx context.Context, convo *frames.LLMContext) {
-	tools := convo.AppTools()
+	tools := convo.Tools()
 
 	advertised := make(map[string]bool, len(tools))
 	for _, t := range tools {


### PR DESCRIPTION
Every provider converted the universal conversation into its own wire format
inline, so the conversion could only be exercised through the service that owned
it. This introduces the adapter layer: a plain value the service owns and calls,
which makes each conversion a pure function of the conversation and testable
with table tests.

Landing in stages, one commit each, every one building and passing
`go test -race ./...` and `golangci-lint run`.

## Status

- [x] 1. Adapter interface + OpenAI adapter
- [x] 2. Mistral adapter, delete `Compat.ShapeMessages`
- [x] 3. Perplexity adapter
- [x] 4. Anthropic adapter (covers bedrock)
- [x] 5. Gemini adapter (covers vertex)
- [x] 6. Responses adapter (HTTP + WebSocket)
- [x] 7. Realtime adapter
- [x] 8. Relocate built-in tools onto the adapter
- [x] 9. `frames`: provider-native messages
- [x] 10. `frames`: tools schema and per-adapter custom tools
- [ ] 11. `frames`: multimodal content parts + logging redaction — **out of scope, tracked in #88**

Steps 1-10 are complete, which is the whole adapter layer plus the two context
changes it needed. Step 11 is deliberately out of scope: it changes the
conversation's data model rather than the conversion around it, and its blast
radius reaches both aggregators, compaction and every provider. It is recorded
in full in #88, including the ten reference test cases waiting on it.

## Five live defects fixed

None of these is a refactor. Each was found by reading the reference
implementation against jargo, and each was shipping:

- **Perplexity** enforces strict role alternation, rejects non-initial system
  messages, and rejects a trailing assistant message. jargo applied none of
  them, so it sent histories the API refuses.
- **Anthropic** silently dropped a system message found in the message list, and
  sent a system-only conversation with an empty message list, which the API
  rejects.
- **Anthropic** cached only the system prompt, so the whole conversation was
  re-read every turn. The two most recent user messages are now marked too.
- **Gemini** gave the model nothing to answer when every message was a tool call
  or result, because it reads the system instruction as framing rather than as
  something to act on.
- **Responses** sent a system message under the role `"system"`, which that API
  does not define, and sent instructions beside an empty input list, which it
  refuses.

## Two feature gaps found, deliberately not closed here

Both were surfaced while porting, and neither is an adapter gap, so neither
belongs in this PR:

- **Gemini Live and Nova Sonic** take no toolset and no conversation from the
  context at all. Their upstream adapters convert messages and tools these
  services have nothing to do with, so porting them means first building context
  seeding and tool calling for two speech-to-speech services.
- **Built-in tools sat in the wrong layer.** Fixed in step 8: they were written
  into the shared `frames.LLMContext`, which mutated a context the application
  owns and leaked the tool to any other service sharing that conversation.

## Public API breaks

- `chat.Compat.ShapeMessages` removed, replaced by `chat.Compat.Adapter`
  (step 2, recorded in CHANGELOG.md). The chat-completions wire types moved to
  `adapter/openai` and are aliased under their old names, so referring to them
  is unaffected.
- `LLMContext.SetServiceTools`, `LLMContext.SetServiceInstructions` and
  `LLMContext.AppTools` removed (step 8, recorded in CHANGELOG.md).
  `LLMContext.Tools` now returns exactly what the application advertised.
- `frames.Message` gained `LLM` and `Native` (step 9). Additive: a message that
  sets neither behaves exactly as before.
- `LLMContext` now holds a `frames.ToolsSchema` (step 10). `SetTools` and
  `Tools` keep their signatures and meaning; `SetToolsSchema` and `ToolsSchema`
  are new, and `adapter.LLMAdapter.ToProviderToolsFormat` takes the schema.
