### PR TITLE
feat(eval): assert on the text that reached synthesis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   A scenario that fails once and passes the next time is readable from the trace
   rather than by re-running it.
 
+- **A scenario can assert on what reached synthesis.** The `tts_response` event
+  carries the text the bot's TTS reports speaking, one segment as each arrives,
+  and takes `text_contains` and `eval` like `llm_response` does, aggregating
+  across the segments of a turn. Every assertion before it stopped at the text
+  the model produced, so a turn whose reply never reached the speech service
+  passed while the caller heard nothing. It is audio mode only: a text-mode turn
+  asks for no spoken response, so no synthesis runs.
+
 ### Changed
 
 - **A tool the LLM service implements itself lives on its adapter, not on the
@@ -222,6 +230,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   system message is deliberately left alone: demoting it would depend on how much
   of the conversation had happened so far, and Perplexity rejects a message whose
   role changes between turns.
+
+- **`bot-tts-text` reports what the TTS spoke, not what it was asked to speak.**
+  The RTVI processor built the message from `TTSSpeakFrame`, which is text on its
+  way into the service: a client rendered it as spoken caption before synthesis
+  had happened, and nothing was sent for a reply the LLM produced, which is the
+  ordinary path. It is built from `TTSTextFrame` now, the text the service
+  reports speaking, aligned to playback.
 
 - **Every OpenAI-compatible provider reports its token usage.** The
   chat-completions service never asked for the counts and never reported any, so

--- a/eval/audio_test.go
+++ b/eval/audio_test.go
@@ -34,8 +34,8 @@ func (f fakeSynth) RunTTS(_ context.Context, _, _ string, yield func(fr frames.F
 
 // fakeAudioSTT stands in for a VAD + STT stack without the ONNX runtime: it
 // watches the streamed mic audio, marks the user speaking on the first non-silent
-// frame, and — once a stretch of silence follows — ends the turn and emits a
-// canned transcription. That drives the aggregator exactly as a real STT would.
+// frame, and ends the turn once a stretch of silence follows, emitting a canned
+// transcription. That drives the aggregator exactly as a real STT would.
 type fakeAudioSTT struct {
 	*processor.Base
 	speaking bool
@@ -113,6 +113,112 @@ func buildAudioBot(in, out processor.Processor) *pipeline.Task {
 		// The observer reports pipeline events; the processor carries them.
 		Observers: []pipeline.Observer{rtvi.NewObserver(rtviProc)},
 	})
+}
+
+// buildSpeakingBot is the audio bot with a speech service in it, so the bot's
+// reply is synthesized and reported as spoken. Only then is there a tts_response
+// for a scenario to assert on.
+func buildSpeakingBot(in, out processor.Processor) *pipeline.Task {
+	agg := aggregators.New(frames.NewLLMContext("test"))
+	rtviProc := rtvi.NewProcessor()
+	return pipeline.NewTask(pipeline.New(
+		in, newFakeAudioSTT(), agg.User(), newFakeLLM(),
+		tts.New("fakeTTS", fakeSynth{}), rtviProc, out, agg.Assistant(),
+	), pipeline.TaskParams{
+		AudioInSampleRate: audioRate,
+		// The observer reports pipeline events; the processor carries them.
+		Observers: []pipeline.Observer{rtvi.NewObserver(rtviProc)},
+	})
+}
+
+// TestHarnessTTSResponse asserts on the text that reached synthesis, which is a
+// step past what the model wrote: llm_response passes on a reply the TTS never
+// got, and tts_response does not.
+func TestHarnessTTSResponse(t *testing.T) {
+	scenario, err := eval.Load(writeScenario(t, `
+name: spoken
+turns:
+  - user: "hello"
+    expect:
+      - event: llm_response
+        text_contains: "you said"
+      - event: tts_response
+        text_contains: "you said"
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	res, err := eval.Host(ctx, scenario, buildSpeakingBot, eval.Options{
+		UserTTS: tts.New("userTTS", fakeSynth{}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.Passed() {
+		t.Fatalf("expected pass, got:\n%s", res)
+	}
+}
+
+// unspeakable stands in for a chunk that filters down to nothing, the way a lone
+// period split off an ellipsis does. The TTS base skips a chunk with nothing left
+// to say, so the turn is silent and no text is ever reported as spoken.
+type unspeakable struct{}
+
+func (unspeakable) Filter(string) string { return "" }
+
+// buildSilentBot answers every turn and speaks none of it.
+func buildSilentBot(in, out processor.Processor) *pipeline.Task {
+	agg := aggregators.New(frames.NewLLMContext("test"))
+	rtviProc := rtvi.NewProcessor()
+	speech := tts.New("fakeTTS", fakeSynth{})
+	speech.SetTextFilters(unspeakable{})
+	return pipeline.NewTask(pipeline.New(
+		in, newFakeAudioSTT(), agg.User(), newFakeLLM(), speech, rtviProc, out, agg.Assistant(),
+	), pipeline.TaskParams{
+		AudioInSampleRate: audioRate,
+		Observers:         []pipeline.Observer{rtvi.NewObserver(rtviProc)},
+	})
+}
+
+// TestHarnessTTSResponseCatchesSilentTurn is the fault a tts_response
+// expectation exists for: the model answered, nothing speakable reached
+// synthesis, and the turn was silent. llm_response passes on it, because the
+// text was written; tts_response is what fails.
+func TestHarnessTTSResponseCatchesSilentTurn(t *testing.T) {
+	scenario, err := eval.Load(writeScenario(t, `
+name: silent
+turns:
+  - user: "hello"
+    expect:
+      - event: llm_response
+        text_contains: "you said"
+      - event: tts_response
+        text_contains: "you said"
+        within_ms: 2000
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	res, err := eval.Host(ctx, scenario, buildSilentBot, eval.Options{
+		UserTTS: tts.New("userTTS", fakeSynth{}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Passed() {
+		t.Fatal("expected a failure for the reply that was never spoken")
+	}
+	if len(res.Failures) != 1 || res.Failures[0].Event != eval.EventTTSResponse {
+		t.Fatalf("expected the one failure to be on tts_response, got:\n%s", res)
+	}
 }
 
 // TestHarnessAudioMode drives the full real input path: the harness synthesizes

--- a/eval/harness_test.go
+++ b/eval/harness_test.go
@@ -21,7 +21,8 @@ import (
 // fakeLLM answers each turn deterministically so the harness can be exercised
 // end-to-end without a real model: it echoes the user's text, and on a weather
 // question it emits a get_weather tool call, followed by a get_restaurants call
-// when the turn asks about food too.
+// when the turn asks about food too. A turn that asks twice gets the weather
+// call twice, which is the repeated call a scenario has to be able to catch.
 type fakeLLM struct {
 	*processor.Base
 }
@@ -83,6 +84,14 @@ func (f *fakeLLM) ProcessFrame(ctx context.Context, frame frames.Frame, dir proc
 		call := frames.NewFunctionCallInProgressFrame("call-1", "get_weather", args, true, "g1")
 		if err := f.PushFrame(ctx, call, processor.Downstream); err != nil {
 			return err
+		}
+		// The same call a second time, standing in for a provider that re-requests
+		// a call it already made.
+		if strings.Contains(lower, "twice") {
+			again := frames.NewFunctionCallInProgressFrame("call-1b", "get_weather", args, true, "g1")
+			if err := f.PushFrame(ctx, again, processor.Downstream); err != nil {
+				return err
+			}
 		}
 	default:
 		if err := f.PushFrame(ctx, frames.NewLLMTextFrame("you said: "+last), processor.Downstream); err != nil {
@@ -266,6 +275,49 @@ turns:
 		t.Fatal("expected a failure for the reply that must not arrive")
 	}
 	if !strings.Contains(res.Failures[0].Reason, "you said: hello") {
+		t.Fatalf("unexpected failure reason: %s", res.Failures[0].Reason)
+	}
+}
+
+// "this tool was called, and not again" is the two-expectation pattern: the call
+// itself, then an absent one holding a quiet window open behind it. A turn that
+// calls once satisfies both.
+func TestHarnessCallNotRepeatedPasses(t *testing.T) {
+	res := host(t, `
+name: calls-the-tool-once
+turns:
+  - user: "what's the weather in Paris?"
+    expect:
+      - event: function_call
+        name: get_weather
+      - event: function_call
+        absent: true
+        within_ms: 700
+`)
+	if !res.Passed() {
+		t.Fatalf("expected pass, got:\n%s", res)
+	}
+}
+
+// The same pattern against a turn that calls the tool twice: the first call
+// satisfies the first expectation, and the repeat trips the absent one. This is
+// what fails if a filter that drops an already-made call regresses.
+func TestHarnessCallRepeatedFailsAbsent(t *testing.T) {
+	res := host(t, `
+name: calls-the-tool-twice
+turns:
+  - user: "what's the weather in Paris? ask twice"
+    expect:
+      - event: function_call
+        name: get_weather
+      - event: function_call
+        absent: true
+        within_ms: 2000
+`)
+	if res.Passed() {
+		t.Fatal("expected a failure for the tool call the bot repeated")
+	}
+	if !strings.Contains(res.Failures[0].Reason, "get_weather") {
 		t.Fatalf("unexpected failure reason: %s", res.Failures[0].Reason)
 	}
 }

--- a/eval/scenario.go
+++ b/eval/scenario.go
@@ -1,15 +1,16 @@
 // Package eval is a behavioral eval harness for jargo bots. It drives a real
 // bot over RTVI, plays scripted conversation turns, and asserts on the semantic
-// events the bot emits — a level above unit tests, which check one processor at
-// a time.
+// events the bot emits. That is a level above unit tests, which check one
+// processor at a time.
 //
 // A scenario is a YAML file of turns and the events each turn should produce.
 // The same scenario runs from a Go test (the bot hosted in-process, see Run) or
-// from the command line against a running bot. This first iteration covers
-// text-mode scenarios: each user turn is delivered as RTVI send-text and the
-// assertions read the bot's LLM output and tool calls. Audio-mode scenarios
-// (synthesized user speech, transcription of the bot's audio) build on the same
-// core later.
+// from the command line against a running bot. In text mode each user turn is
+// delivered as RTVI send-text, so the audio processors sit idle; in audio mode
+// (Options.UserTTS) it is synthesized and streamed as microphone audio, so the
+// bot's own VAD, turn detection and STT run for real. Transcribing the bot's
+// audio back, to assert on what was actually heard, builds on the same core
+// later.
 //
 // # Expectation fields
 //
@@ -17,6 +18,7 @@
 //	within_ms: <int>         latency budget, measured from the turn's user input
 //	text_contains: <str>     substring check on the event's text, case-sensitive
 //	eval: <str>              criterion an LLM judge checks the bot's reply against
+//	                         (llm_response and tts_response, which carry its text)
 //	name: <str>              for function_call: the tool the call must be to
 //	args: <mapping>          for function_call: an argument subset the call must carry
 //	calls: <list>            for function_call: several calls, in any order
@@ -44,9 +46,23 @@
 //
 //	turns: !include shared_turns.yaml
 //
+// # Asserting on the bot's reply
+//
+// Two events carry the bot's own words, and they sit at different points in the
+// pipeline:
+//
+//	llm_response   the text the model produced (bot-llm-text)
+//	tts_response   the text the TTS reports speaking (bot-tts-text)
+//
+// llm_response is available in both modes. tts_response is audio mode only: a
+// text-mode turn asks for no spoken response, so no TTS runs and no segment is
+// produced. Assert on it when what matters is that the reply reached synthesis
+// rather than that the model wrote it, which is the difference between a turn
+// that answered and a turn that was heard.
+//
 // A turn often answers in more than one response: an interim filler ("Let me
-// check on that.") and then the answer. So a content check on llm_response
-// aggregates. It accumulates the text of successive responses and re-checks on
+// check on that.") and then the answer. So a content check on either of them
+// aggregates. It accumulates the text of successive segments and re-checks on
 // each, until the check passes, the judge rejects, or within_ms expires. A
 // missing substring is not a failure on its own, because more text may follow,
 // which is why an assertion on text the bot never produces waits out its whole
@@ -174,6 +190,10 @@ const (
 	EventLLMStarted = "llm_started"
 	// EventLLMResponse carries the bot's LLM text, joined across the response.
 	EventLLMResponse = "llm_response"
+	// EventTTSResponse carries the text the bot's TTS reports speaking, one
+	// segment as each arrives (audio mode only: a text-mode turn asks for no
+	// spoken response, so no TTS runs and no segment is ever produced).
+	EventTTSResponse = "tts_response"
 	// EventFunctionCall fires when the bot invokes a tool.
 	EventFunctionCall = "function_call"
 	// EventBotInterrupted fires when the bot's in-flight output is cut off, by a
@@ -197,6 +217,7 @@ const (
 //nolint:gochecknoglobals // fixed lookup table
 var judgeableEvents = map[string]bool{
 	EventLLMResponse: true,
+	EventTTSResponse: true,
 }
 
 // vadEvents are the events the bot reports only when asked to. The harness asks
@@ -343,10 +364,11 @@ type Expectation struct {
 	// Event is the friendly event name to match (see the Event constants).
 	Event string `yaml:"event"`
 	// TextContains, when set, requires the event's text to contain this
-	// substring (case-insensitive). Applies to llm_response.
+	// substring, case-sensitively. Applies to llm_response and tts_response.
 	TextContains string `yaml:"text_contains,omitempty"`
 	// Eval, when set, is a natural-language criterion an LLM judge checks the
-	// bot's reply against. Applies to llm_response.
+	// bot's reply against. Applies to llm_response and tts_response, the two
+	// events carrying text the bot itself produced.
 	Eval string `yaml:"eval,omitempty"`
 	// Name is the single-call shorthand for Calls: the tool name a function_call
 	// event must match.
@@ -573,7 +595,7 @@ func (e *Expectation) validate() error {
 	}
 	if e.Eval != "" && !judgeableEvents[e.Event] {
 		slog.Warn("eval: a judge criterion is only meaningful on an event carrying the bot's own text",
-			"event", e.Event, "judgeable", EventLLMResponse)
+			"event", e.Event, "judgeable", []string{EventLLMResponse, EventTTSResponse})
 	}
 	// An absent expectation matches on event type only: a content or call check
 	// describes an event that must arrive, which contradicts absence.

--- a/eval/scenario.go
+++ b/eval/scenario.go
@@ -112,6 +112,23 @@
 // and it waits out its whole budget: set within_ms explicitly to keep the quiet
 // window short.
 //
+// The same two-expectation shape is how "this tool was called, and not again"
+// is written. The first expectation claims the call, and the absent one behind
+// it holds a quiet window open that a repeat trips:
+//
+//	expect:
+//	  - event: function_call
+//	    name: dispatch_alert
+//	  - event: function_call
+//	    absent: true
+//	    within_ms: 3000
+//
+// That is the assertion to reach for against a provider that re-requests a call
+// it already made, where running the tool twice is the expensive fault. Because
+// absent matches on event type, the window forbids any further call, not only
+// another dispatch_alert, so put it on a turn whose tool calls are all listed
+// above it.
+//
 // # Scheduling a turn
 //
 // A turn's input goes out as soon as the previous turn finishes, unless the turn

--- a/eval/session.go
+++ b/eval/session.go
@@ -57,8 +57,9 @@ var errSendAfterNotSeen = errors.New("send_after never fired")
 type Event struct {
 	// Kind is one of the Event* name constants.
 	Kind string
-	// Text is the reply text on an llm_response, or the transcript on a
-	// user_transcription. Empty for events that carry no text.
+	// Text is the reply text on an llm_response, the spoken text on a
+	// tts_response, or the transcript on a user_transcription. Empty for events
+	// that carry no text.
 	Text string
 	// Function is the tool name on a function_call.
 	Function string
@@ -617,7 +618,10 @@ func (s *session) matchExpectation(
 // bot's own text does; a bare event, or a check on a user transcription,
 // matches once.
 func (s *session) aggregates(exp Expectation) bool {
-	return exp.Event == EventLLMResponse && (exp.TextContains != "" || exp.Eval != "")
+	if exp.Event != EventLLMResponse && exp.Event != EventTTSResponse {
+		return false
+	}
+	return exp.TextContains != "" || exp.Eval != ""
 }
 
 // matchAggregate accumulates response segments and re-checks the expectation on
@@ -902,6 +906,17 @@ func (s *session) translate(in rtvi.Incoming) *Event {
 		return &Event{Kind: EventUserTranscription, Text: d.Text}
 	case rtvi.TypeBotLLMStarted, rtvi.TypeBotLLMText, rtvi.TypeBotLLMStopped:
 		return s.translateLLM(in)
+	case rtvi.TypeBotTTSText:
+		// The text the TTS reports speaking, one segment per spoken sentence,
+		// emitted as it arrives. It cannot be bounded on bot-tts-stopped the way
+		// llm_response is bounded on bot-llm-stopped, because some services report
+		// the text after the audio has finished. The matcher aggregates the
+		// segments of the turn instead.
+		var d rtvi.TextData
+		if json.Unmarshal(in.Data, &d) != nil {
+			return nil
+		}
+		return &Event{Kind: EventTTSResponse, Text: d.Text}
 	case rtvi.TypeLLMFunctionCall:
 		var d rtvi.LLMFunctionCallData
 		_ = json.Unmarshal(in.Data, &d)

--- a/processor/rtvi/processor.go
+++ b/processor/rtvi/processor.go
@@ -230,7 +230,11 @@ func botMessageFor(f frames.Frame) (Message, bool) {
 		return event(TypeBotTTSStarted), true
 	case *frames.TTSStoppedFrame:
 		return event(TypeBotTTSStopped), true
-	case *frames.TTSSpeakFrame:
+	case *frames.TTSTextFrame:
+		// The text the TTS reports speaking, aligned to playback, which is what a
+		// client renders as the spoken caption. Not TTSSpeakFrame: that is text on
+		// its way into the service, and it never reaches a client as something
+		// spoken, because nothing guarantees the synthesizer accepted it.
 		return BotTTSText(fr.Text), true
 	default:
 		return Message{}, false

--- a/processor/rtvi/rtvi_test.go
+++ b/processor/rtvi/rtvi_test.go
@@ -134,13 +134,27 @@ func TestProcessorLifecycleAndFunctionCalls(t *testing.T) {
 	if got := waitMessage(t, out); got.Type != rtvi.TypeBotTTSStarted {
 		t.Fatalf("expected bot-tts-started, got %+v", got)
 	}
+	// The text the TTS reports speaking, not the text on its way into it.
+	task.QueueFrame(frames.NewTTSTextFrame("sunny"))
+	got := waitMessage(t, out)
+	if got.Type != rtvi.TypeBotTTSText {
+		t.Fatalf("expected bot-tts-text, got %+v", got)
+	}
+	if d, ok := got.Data.(rtvi.TextData); !ok || d.Text != "sunny" {
+		t.Fatalf("unexpected bot-tts-text data: %+v", got.Data)
+	}
+
+	// A TTSSpeakFrame is input to the service, so it reports nothing spoken. The
+	// bot-tts-stopped that follows is what proves nothing was emitted for it.
+	task.QueueFrame(frames.NewTTSSpeakFrame("not spoken yet"))
+
 	task.QueueFrame(frames.NewTTSStoppedFrame())
 	if got := waitMessage(t, out); got.Type != rtvi.TypeBotTTSStopped {
 		t.Fatalf("expected bot-tts-stopped, got %+v", got)
 	}
 
 	task.QueueFrame(frames.NewFunctionCallInProgressFrame("call-1", "get_weather", nil, true, "g1"))
-	got := waitMessage(t, out)
+	got = waitMessage(t, out)
 	if got.Type != rtvi.TypeLLMFunctionCall {
 		t.Fatalf("expected llm-function-call-in-progress, got %+v", got)
 	}


### PR DESCRIPTION
Closes #90. Closes #89.

## #90: nothing a scenario could assert reached the spoken output

Adds `tts_response`, the text the bot's TTS reports speaking. It takes
`text_contains` and `eval` like `llm_response` does, and aggregates across the
segments of a turn. Audio mode only: a text-mode turn asks for no spoken
response, so no synthesis runs.

It cannot be bounded on `bot-tts-stopped` the way `llm_response` is bounded on
`bot-llm-stopped`, because some services report the text after the audio has
finished, so the matcher aggregates the segments instead.

Two tests: a spoken reply satisfies it, and a reply that never reaches synthesis
fails it while `llm_response` still passes. The second is the whole point, and it
is the shape of #86.

The issue lists two more events. Neither is in this PR:

- **audio produced for a turn.** Upstream answers this with `response`, the
  transcription of the bot's real audio, which needs bot audio streamed back
  over the eval socket and a local STT to read it. That is the audio-mode module
  work, and it lands `image:`, the modality blocks and the frame-pacing fix with
  it. Worth staging on its own rather than bolting a cheaper signal onto this.
- **synthesis refused.** No counterpart upstream, so there is nothing to port.
  Note that `tts_response` does not stand in for it: the text is reported whether
  or not the provider accepted the chunk. What it does catch is text the model
  produced that never reached the service at all, which is what #86 was.

### The fix underneath it

`bot-tts-text` was built from `TTSSpeakFrame`, which is text on its way *into*
the service. A client rendered the caption before synthesis had happened, and a
reply coming from the LLM produced no message at all, because that path never
carries a `TTSSpeakFrame`. It is built from `TTSTextFrame` now. That is a bug in
its own right and is the first commit; `tts_response` reads the corrected
message.

## #89: a scenario cannot assert how many times a tool was called

No new field, because the format already expresses it. `absent:` matches on
event type alone, so the pair

```yaml
- event: function_call
  name: dispatch_alert
- event: function_call
  absent: true
  within_ms: 3000
```

claims the call and then holds a quiet window open that a repeat trips. This is
documented next to `absent:` and covered both ways round: a turn calling once
passes, a turn calling twice fails on the repeat.

A `count:` field would have been a second way to write an assertion the format
already has. The one thing the pattern does not do is scope the window to a
single tool, so it belongs on a turn whose calls are all listed above it. That
is called out in the docs.
