### PR TITLE
build: add a Makefile for the recipes that are more than one command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,9 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
-      - run: go test -race -coverprofile=coverage.out ./...
+      # `make cover` so the profile CI uploads is produced by the same recipe a
+      # developer runs locally.
+      - run: make cover
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage
@@ -47,8 +49,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - run: sudo apt-get update && sudo apt-get install -y libsoxr-dev
+      # Both cgo tags are compiled, so both sets of dev headers are needed.
+      - run: sudo apt-get update && sudo apt-get install -y libsoxr-dev libopus-dev
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
-      - run: go build ./...
+      # Every supported combination: cgo-free, cgo without tags, libsoxr,
+      # libopus, and both together. A tag that stops compiling is caught here
+      # rather than by whoever next opts into it.
+      - run: make build-matrix
+
+  # The *.pb.go clients are checked in, so nothing else would notice a .proto
+  # edit that was never regenerated. Regenerate with the pinned buf and plugin
+  # versions and fail if the result differs from the tree.
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+      - run: make generate-check

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,12 +8,14 @@ on:
       - "website/**"
       - "assets/**"
       - ".github/workflows/docs.yml"
+      - "Makefile"
   pull_request:
     paths:
       - "docs/**"
       - "website/**"
       - "assets/**"
       - ".github/workflows/docs.yml"
+      - "Makefile"
   # Lets a docs deploy be triggered by hand without an empty commit.
   workflow_dispatch:
 
@@ -25,9 +27,6 @@ concurrency:
   group: pages-${{ github.ref }}
   cancel-in-progress: false
 
-env:
-  HUGO_VERSION: 0.152.0
-
 jobs:
   # Runs on pull requests too, so a broken link or template fails review rather
   # than main.
@@ -38,10 +37,13 @@ jobs:
         with:
           fetch-depth: 0 # enableGitInfo needs history for page dates
 
+      # Provisioning the runner stays here; the version is read from the Makefile
+      # so the pin has one home and cannot drift from what developers install.
       - name: Install Hugo (extended)
         run: |
+          version="$(make -s print-HUGO_VERSION)"
           curl -sSL -o /tmp/hugo.deb \
-            "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb"
+            "https://github.com/gohugoio/hugo/releases/download/v${version}/hugo_extended_${version}_linux-amd64.deb"
           sudo dpkg -i /tmp/hugo.deb
           hugo version
 
@@ -59,23 +61,16 @@ jobs:
       # --baseURL from the Pages config on a real deploy; the hugo.toml default is
       # used for pull-request builds, which are only checked, never published.
       - name: Build
-        working-directory: website
-        run: |
-          hugo --gc --minify --printPathWarnings \
-            ${{ steps.pages.outputs.base_url && format('--baseURL "{0}/"', steps.pages.outputs.base_url) || '' }}
+        run: make docs-build
+        env:
+          HUGO_BASEURL: ${{ steps.pages.outputs.base_url && format('{0}/', steps.pages.outputs.base_url) || '' }}
 
       # The render-link hook warns on any unresolved relative link; treat that as
       # a failure so docs links cannot rot silently. Run before the artifact
-      # upload so a broken link blocks the deploy.
+      # upload so a broken link blocks the deploy. `make docs-check` is the same
+      # recipe locally, which is the point of it living in the Makefile.
       - name: Check for unresolved links
-        working-directory: website
-        run: |
-          set -o pipefail
-          hugo --gc --renderToMemory --logLevel warn 2>&1 | tee /tmp/hugo-check.log
-          if grep -F "render-link: unresolved" /tmp/hugo-check.log; then
-            echo "::error::unresolved documentation links — see the warnings above"
-            exit 1
-          fi
+        run: make docs-check
 
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         if: github.event_name != 'pull_request'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,12 +17,11 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
-      # Run the gitleaks binary directly via its image — the marketplace action
-      # requires a paid licence for GitHub organisations.
+      # Runs the gitleaks binary directly via its image: the marketplace action
+      # requires a paid licence for GitHub organisations. The image and its
+      # flags live in the Makefile so the same scan can be run locally.
       - name: gitleaks
-        run: |
-          docker run --rm -v "$PWD:/repo" ghcr.io/gitleaks/gitleaks:latest \
-            dir /repo --redact --no-banner --verbose
+        run: make secrets
 
   trivy:
     runs-on: ubuntu-latest
@@ -79,11 +78,11 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
-      - run: go install golang.org/x/vuln/cmd/govulncheck@v1.5.0
       # Reports only vulnerabilities jargo's code actually reaches, so this gates
       # the build. Stdlib advisories are cleared by the latest 1.26.x toolchain
-      # that setup-go resolves from go.mod.
-      - run: govulncheck ./...
+      # that setup-go resolves from go.mod. The govulncheck version is pinned in
+      # the Makefile, which installs it and runs the scan.
+      - run: make vuln
 
   codeql:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ vendor/
 # Per-developer local Claude memory (never committed)
 CLAUDE.local.md
 
+# Native runtimes fetched by `make deps-onnx` / `make deps-rnnoise`
+/.native/
+
 # Hugo documentation site build output (website/; sources are in docs/)
 /website/public/
 /website/resources/_gen/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,22 @@ Formatting and lint are enforced by **golangci-lint** (`.golangci.yml`):
 - `golangci-lint fmt` — apply the configured formatters (`gofmt -s`, `gofumpt`,
   `goimports`). Code must be clean under all three.
 
+Everything above is a one-liner and stays here. Anything longer lives in the
+[`Makefile`](Makefile), which the workflows call for the steps they share, so a
+CI failure can be reproduced locally. `make help` lists the targets; the ones
+worth knowing:
+
+- `make build-matrix`: compile all five cgo tag combinations, as CI does.
+- `make cover`: the coverage run and its total, the profile CI uploads. Break it
+  down with `make cover-func` or `make cover-html`.
+- `make generate`: regenerate the Riva protobuf clients with pinned tool
+  versions. CI runs `make generate-check` and fails if the tree is stale.
+- `make docs-check`: build the site and fail on unresolved documentation links.
+- `make deps`, `make deps-onnx`, `make deps-rnnoise`: install the cgo headers
+  and the two native runtimes above. The last two need no root: they install
+  under `.native/` and print the `JARGO_*_LIB` values to export.
+- `make vuln`, `make secrets`: the govulncheck and gitleaks scans CI gates on.
+
 ## Conventions
 
 - **No upstream references in code.** Keep Pipecat/Python out of `.go` comments;

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,248 @@
+# jargo developer commands.
+#
+# The Go toolchain is the build system. This file holds only the recipes that
+# are more than a single command, so nothing here restates what AGENTS.md
+# already gives you as a one-liner (`go build ./...`, `go test ./...`,
+# `golangci-lint run`). Run `make help` for the list.
+#
+# The GitHub Actions workflows call these same targets wherever the two overlap,
+# so a docs link failure or a vulnerability finding can be reproduced locally.
+# Steps that talk to GitHub's own infrastructure (SARIF upload, Codecov, keyless
+# signing, Pages deploys, multi-arch buildx) stay in the workflows as actions.
+
+# Make runs each recipe line in /bin/sh with no errexit and no pipefail, which
+# would let a failing `hugo | tee` report success. CI gates on these recipes, so
+# make the shell strict.
+SHELL := /usr/bin/env bash
+.SHELLFLAGS := -eu -o pipefail -c
+.DEFAULT_GOAL := help
+
+GO ?= go
+
+# `go install` writes to GOBIN when it is set and to GOPATH/bin otherwise. Put
+# whichever it is on PATH so `go generate` finds the protoc plugins that
+# `make tools-proto` puts there.
+GO_BIN := $(shell $(GO) env GOBIN)
+ifeq ($(GO_BIN),)
+GO_BIN := $(shell $(GO) env GOPATH)/bin
+endif
+export PATH := $(GO_BIN):$(PATH)
+
+# Tool versions, pinned so CI and a developer machine run the same thing. The
+# two protoc plugin pins must match the versions stamped into the headers of the
+# generated *.pb.go files, or `make generate-check` reports a false stale.
+BUF_VERSION ?= v1.72.0
+PROTOC_GEN_GO_VERSION ?= v1.36.11
+PROTOC_GEN_GO_GRPC_VERSION ?= v1.5.1
+GOVULNCHECK_VERSION ?= v1.5.0
+GITLEAKS_IMAGE ?= ghcr.io/gitleaks/gitleaks:latest
+
+# Hugo is installed out of band. This is the single pin for it: the docs
+# workflow provisions the runner from `make -s print-HUGO_VERSION`, and the
+# require-hugo guard names it when the binary is missing locally.
+HUGO_VERSION ?= 0.152.0
+WEBSITE_DIR := website
+HUGO_CHECK_LOG ?= /tmp/hugo-check.log
+# Set by the docs workflow from the Pages configuration; empty for local builds,
+# which fall back to the baseURL in website/hugo.toml.
+HUGO_BASEURL ?=
+
+COVERPROFILE ?= coverage.out
+
+# Native runtimes loaded at run time through purego. NATIVE_DIR is a prefix
+# inside the repo so nothing here needs root; docker/runtime.Dockerfile installs
+# the same two libraries into /usr/local for the container image.
+ORT_VERSION ?= 1.26.0
+ORT_ARCH ?= $(if $(filter aarch64 arm64,$(shell uname -m)),aarch64,x64)
+NATIVE_DIR ?= $(CURDIR)/.native
+
+##@ General
+
+.PHONY: help
+help: ## Print the available targets
+	@awk 'BEGIN { FS = ":.*##"; printf "\nUsage: make <target>\n" } \
+		/^[a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-16s\033[0m %s\n", $$1, $$2 } \
+		/^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) }' $(MAKEFILE_LIST)
+	@echo
+
+# Lets a workflow read a pin from here rather than keeping a second copy of it,
+# for example `make -s print-HUGO_VERSION` in the docs workflow.
+.PHONY: print-%
+print-%:
+	@echo "$($*)"
+
+##@ Test
+
+.PHONY: test
+test: ## Run the tests with the race detector, as CI does
+	$(GO) test -race ./...
+
+.PHONY: cover
+cover: ## Run the tests and write the coverage profile CI uploads
+	$(GO) test -race -coverprofile=$(COVERPROFILE) ./...
+	@$(GO) tool cover -func=$(COVERPROFILE) | tail -1
+	@echo
+	@echo "Codecov applies the ignore: rules in codecov.yml (examples/, generated"
+	@echo "protobuf), so the reported total reads roughly 13 points above this one."
+	@echo "Break it down with 'make cover-func' or 'make cover-html'."
+
+.PHONY: require-coverprofile
+require-coverprofile:
+	@test -f $(COVERPROFILE) || { \
+		echo "no $(COVERPROFILE) yet, run: make cover" >&2; \
+		exit 1; \
+	}
+
+# Kept off `cover` itself: the per-function report is around 1600 lines, which
+# is worth asking for and not worth printing on every CI run.
+.PHONY: cover-func
+cover-func: require-coverprofile ## Break the coverage profile down by function
+	$(GO) tool cover -func=$(COVERPROFILE)
+
+.PHONY: cover-html
+cover-html: require-coverprofile ## Open the coverage profile in a browser
+	$(GO) tool cover -html=$(COVERPROFILE)
+
+##@ Build
+
+.PHONY: build-matrix
+build-matrix: ## Compile every supported cgo tag combination
+	@echo "==> cgo-free (the default build)"
+	CGO_ENABLED=0 $(GO) build ./...
+	@echo "==> cgo, no tags"
+	CGO_ENABLED=1 $(GO) build ./...
+	@echo "==> -tags libsoxr"
+	CGO_ENABLED=1 $(GO) build -tags libsoxr ./...
+	@echo "==> -tags libopus"
+	CGO_ENABLED=1 $(GO) build -tags libopus ./...
+	@echo "==> -tags 'libsoxr libopus'"
+	CGO_ENABLED=1 $(GO) build -tags "libsoxr libopus" ./...
+
+##@ Generate
+
+.PHONY: tools-proto
+tools-proto: ## Install buf and the protoc plugins at their pinned versions
+	$(GO) install github.com/bufbuild/buf/cmd/buf@$(BUF_VERSION)
+	$(GO) install google.golang.org/protobuf/cmd/protoc-gen-go@$(PROTOC_GEN_GO_VERSION)
+	$(GO) install google.golang.org/grpc/cmd/protoc-gen-go-grpc@$(PROTOC_GEN_GO_GRPC_VERSION)
+
+.PHONY: generate
+generate: tools-proto ## Regenerate the Riva protobuf clients from the .proto files
+	$(GO) generate ./...
+
+.PHONY: generate-check
+generate-check: generate ## Fail if the checked-in generated code is stale
+	@if ! git diff --quiet -- provider/nvidia/internal/rivapb; then \
+		echo "generated protobuf is out of date, commit the result of: make generate" >&2; \
+		git --no-pager diff --stat -- provider/nvidia/internal/rivapb >&2; \
+		exit 1; \
+	fi
+
+##@ Security
+
+.PHONY: vuln
+vuln: ## Report vulnerabilities jargo's code actually reaches
+	$(GO) install golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION)
+	govulncheck ./...
+
+.PHONY: secrets
+secrets: ## Scan the checked-out tree for secrets, as the security workflow does
+	docker run --rm -v "$(CURDIR):/repo" $(GITLEAKS_IMAGE) \
+		dir /repo --redact --no-banner --verbose
+
+##@ Docs
+
+.PHONY: require-hugo
+require-hugo:
+	@command -v hugo >/dev/null || { \
+		echo "hugo (extended) $(HUGO_VERSION) is required: https://gohugo.io/installation/" >&2; \
+		exit 1; \
+	}
+
+.PHONY: docs-serve
+docs-serve: require-hugo ## Serve the documentation site with live reload
+	cd $(WEBSITE_DIR) && hugo serve --buildDrafts --printPathWarnings
+
+.PHONY: docs-build
+docs-build: require-hugo ## Build the documentation site into website/public
+	cd $(WEBSITE_DIR) && hugo --gc --minify --printPathWarnings \
+		$(if $(HUGO_BASEURL),--baseURL "$(HUGO_BASEURL)")
+
+.PHONY: docs-check
+docs-check: require-hugo ## Fail on any unresolved link in the documentation
+	@cd $(WEBSITE_DIR) && hugo --gc --renderToMemory --logLevel warn 2>&1 | tee $(HUGO_CHECK_LOG)
+	@# The ::error:: prefix is a GitHub Actions annotation, omitted off CI.
+	@if grep -F "render-link: unresolved" $(HUGO_CHECK_LOG); then \
+		echo "$${GITHUB_ACTIONS:+::error::}unresolved documentation links, see the warnings above" >&2; \
+		exit 1; \
+	fi
+
+##@ Native dependencies
+
+# These three follow docker/build.Dockerfile and docker/runtime.Dockerfile,
+# which are Debian and Linux only, so the host install is too. On another system
+# install the same four libraries by hand: libsoxr, libopus, the ONNX Runtime
+# and RNNoise.
+.PHONY: require-linux
+require-linux:
+	@[[ "$$(uname -s)" == "Linux" ]] || { \
+		echo "this target is Linux only, see the comment above it in the Makefile" >&2; \
+		exit 1; \
+	}
+
+.PHONY: deps
+deps: require-linux ## Install the cgo headers the libsoxr and libopus tags link against
+	sudo apt-get update
+	sudo apt-get install -y libsoxr-dev libopus-dev pkg-config
+
+.PHONY: deps-onnx
+deps-onnx: require-linux ## Fetch the ONNX Runtime for VAD and turn detection
+	@mkdir -p $(NATIVE_DIR)
+	curl -fsSL -o $(NATIVE_DIR)/ort.tgz \
+		"https://github.com/microsoft/onnxruntime/releases/download/v$(ORT_VERSION)/onnxruntime-linux-$(ORT_ARCH)-$(ORT_VERSION).tgz"
+	tar -xzf $(NATIVE_DIR)/ort.tgz -C $(NATIVE_DIR) --strip-components=1
+	@rm -f $(NATIVE_DIR)/ort.tgz
+	@echo
+	@echo "export JARGO_ONNXRUNTIME_LIB=$(NATIVE_DIR)/lib/libonnxruntime.so"
+
+.PHONY: deps-rnnoise
+deps-rnnoise: require-linux ## Build RNNoise from source for the optional denoiser
+	@mkdir -p $(NATIVE_DIR)/src
+	rm -rf $(NATIVE_DIR)/src/rnnoise
+	git clone --depth 1 https://github.com/xiph/rnnoise $(NATIVE_DIR)/src/rnnoise
+	cd $(NATIVE_DIR)/src/rnnoise \
+		&& ./autogen.sh \
+		&& ./configure --disable-static --prefix=$(NATIVE_DIR) \
+		&& make -j"$$(nproc)" \
+		&& make install
+	@echo
+	@echo "export JARGO_RNNOISE_LIB=$(NATIVE_DIR)/lib/librnnoise.so.0"
+
+##@ Packaging
+
+# These build for the host platform only. The docker workflow publishes the real
+# images multi-arch through buildx with tags from docker/metadata-action, and
+# the release workflow signs artifacts with keyless cosign, neither of which is
+# reproducible locally. Treat both as smoke tests of the Dockerfiles.
+
+.PHONY: image-build
+image-build: ## Build the jargo-build base image for the host platform
+	docker build -f docker/build.Dockerfile -t jargo-build:local .
+
+.PHONY: image-runtime
+image-runtime: ## Build the distroless runtime base image for the host platform
+	docker build -f docker/runtime.Dockerfile --build-arg ORT_VERSION=$(ORT_VERSION) \
+		-t jargo:local .
+
+.PHONY: release-snapshot
+release-snapshot: ## Build the release artifacts without tagging or publishing
+	@command -v goreleaser >/dev/null || { \
+		echo "goreleaser is required: https://goreleaser.com/install/" >&2; \
+		exit 1; \
+	}
+	goreleaser release --snapshot --clean
+
+.PHONY: clean
+clean: ## Remove build output, coverage profiles and the fetched native libraries
+	rm -rf $(NATIVE_DIR) dist $(WEBSITE_DIR)/public $(WEBSITE_DIR)/resources/_gen
+	rm -f $(COVERPROFILE)


### PR DESCRIPTION
The Go toolchain stays the build system. This adds a `Makefile` only for the
recipes that are more than a single command, so nothing in it restates a
one-liner that `AGENTS.md` already gives you (`go build ./...`,
`go test ./...`, `golangci-lint run`). `make help` lists the targets.

What it holds is the work that had no runnable home:

- The documentation link check, which existed only inside `docs.yml` and could
  not be run before pushing.
- The five cgo tag combinations: cgo-free, cgo without tags, `libsoxr`,
  `libopus`, and both together.
- The host install of the ONNX Runtime and RNNoise. Until now that was only
  knowable by reading `docker/runtime.Dockerfile`. Both install under
  `.native/` with no root and print the `JARGO_*_LIB` values to export.
- The pinned tool versions the scans and codegen use.

## What the workflows now call

The workflows call the same targets wherever the two overlap, so a CI failure
in the link check or the vulnerability scan can be reproduced locally.

| Workflow | Was | Now |
| --- | --- | --- |
| `ci.yml` test | `go test -race -coverprofile=...` | `make cover` |
| `ci.yml` build | `go build ./...` | `make build-matrix` |
| `ci.yml` generate | nothing | `make generate-check` |
| `docs.yml` | two inline hugo blocks | `make docs-build`, `make docs-check` |
| `security.yml` | inline gitleaks and govulncheck | `make secrets`, `make vuln` |

Steps that talk to GitHub's own infrastructure stay as actions, because
wrapping them would lose their caching, annotations and identity for nothing:
golangci-lint, CodeQL, Trivy, the Codecov upload, multi-arch buildx, keyless
cosign signing and the Pages deploy. Runner provisioning (`apt-get`) stays in
the workflows too.

The Hugo pin now has one home. The docs workflow reads it with
`make -s print-HUGO_VERSION` instead of keeping its own copy.

## Two gates are new, not moved

- The build job compiles every tag combination instead of the default alone.
  `libopus` was never built in CI, so it needs `libopus-dev` on the runner now.
  A tag that stops compiling is caught here rather than by whoever next opts
  into it.
- A `generate` job regenerates the Riva protobuf clients and fails if the
  checked-in result is stale. The `*.pb.go` files are committed, so nothing
  previously noticed a `.proto` edit that was never regenerated.

## Strict shell

Recipes run under bash with `-eu -o pipefail`. Make otherwise runs each line in
`/bin/sh` with neither, which would let the link check's `hugo | tee` pipeline
report success when hugo fails. Confirmed against a scratch makefile: the same
failing pipeline exits 0 under default Make and fails under these flags. Since
CI gates on these recipes, that mattered before wiring anything up.

## Verification

Run locally on this branch:

- `make generate-check`: buf v1.72.0 with protoc-gen-go v1.36.11 and
  protoc-gen-go-grpc v1.5.1 reproduce the checked-in `*.pb.go` exactly, so the
  new gate starts green. The plugin pins were taken from the generated file
  headers rather than guessed.
- `make build-matrix`: all five combinations compile.
- `make cover`: passes at 67.2%. The per-function report is around 1600 lines,
  so it moved to `make cover-func` rather than printing on every CI run.
- `make vuln`: clean. `make deps-onnx`: fetches and extracts, symlink resolves.
- All 22 targets pass `make -n`; the three workflow files parse as YAML.

Not executed here: `docs-build` and `docs-check` (no hugo on the machine,
though the guard fires correctly), and `deps`, `deps-rnnoise`, `image-*`,
`release-snapshot` and `secrets`, which need sudo, docker or goreleaser.
`deps-rnnoise` is a transcription of the recipe in `docker/runtime.Dockerfile`,
not something proven end to end. This PR is the first run of the changed
workflows.

## Open questions

- The `generate` job installs buf from source, which took a couple of minutes
  locally. If that is too slow for every PR it can move behind a `**/*.proto`
  path filter.
- No `CHANGELOG.md` entry, on the grounds that it documents changes to jargo
  the library and this is developer tooling. Happy to add one.
