### PR TITLE
Keep service credentials out of the logs

### DIFF
--- a/observers/loggers.go
+++ b/observers/loggers.go
@@ -202,7 +202,25 @@ func formatValue(v reflect.Value) (string, bool) {
 	default:
 		// Everything else renders as itself.
 	}
+	if named, ok := selfNaming(v); ok {
+		return named, true
+	}
 	return fmt.Sprintf("%v", v.Interface()), true
+}
+
+// selfNaming renders a value that identifies itself by name, which is what a
+// frame carries when it names a service: the switcher frames, a settings update
+// aimed at one service, a summarizer given its own model.
+//
+// The value is never formatted. Its fields are the machinery it runs on rather
+// than anything a log reader wants, and a service holds the configuration it was
+// built with, so writing them out would put its API key in the log.
+func selfNaming(v reflect.Value) (string, bool) {
+	named, ok := v.Interface().(interface{ Name() string })
+	if !ok {
+		return "", false
+	}
+	return named.Name(), true
 }
 
 // composite reports whether a type is one whose values are too big to render

--- a/observers/loggers_test.go
+++ b/observers/loggers_test.go
@@ -410,3 +410,37 @@ func TestLogObserversDefaultToTheProcessLogger(t *testing.T) {
 		handover(o, newFakeLLM(), newFakeSTT(), frames.NewTextFrame("hi"), processor.Downstream)
 	}
 }
+
+// keyedSTT stands in for a service holding the credentials it was built with,
+// which is what every real service holds.
+type keyedSTT struct {
+	*processor.Base
+	apiKey string
+}
+
+func newKeyedSTT(apiKey string) *keyedSTT {
+	s := &keyedSTT{apiKey: apiKey}
+	s.Base = processor.New("KeyedSTT", s)
+	return s
+}
+
+// TestDebugLogNamesAServiceRatherThanFormattingIt covers the frames that carry a
+// service rather than data: a switch, a settings update aimed at one service, a
+// summarizer given its own model. Rendering the service writes out the
+// configuration it was built with, and that holds an API key.
+func TestDebugLogNamesAServiceRatherThanFormattingIt(t *testing.T) {
+	var buf bytes.Buffer
+	o := observers.NewDebugLog(observers.DebugLogConfig{Logger: debugLog(&buf)})
+
+	svc := newKeyedSTT("sk-not-in-the-log")
+	handover(o, newPlain("Src"), newPlain("Dst"),
+		frames.NewManuallySwitchServiceFrame(svc), processor.Downstream)
+
+	got := buf.String()
+	if strings.Contains(got, "sk-not-in-the-log") {
+		t.Errorf("logged %q, want the service's API key left out", got)
+	}
+	if !strings.Contains(got, "Service: "+svc.Name()) {
+		t.Errorf("logged %q, want the service named", got)
+	}
+}

--- a/processor/logger.go
+++ b/processor/logger.go
@@ -70,7 +70,11 @@ func (l *FrameLogger) ProcessFrame(ctx context.Context, f frames.Frame, dir Dire
 		if dir == Upstream {
 			arrow = "<"
 		}
-		slog.DebugContext(ctx, arrow+" "+l.prefix+": "+f.Name(), "frame", f, "direction", dir)
+		// The frame renders itself. Handing the value to the logger instead
+		// would let a structured handler walk its fields, and a frame that
+		// names a service (a switch, a settings update) carries the service
+		// itself, whose configuration holds an API key.
+		slog.DebugContext(ctx, arrow+" "+l.prefix+": "+f.String(), "direction", dir)
 	}
 	return l.PushFrame(ctx, f, dir)
 }

--- a/processor/logger_test.go
+++ b/processor/logger_test.go
@@ -83,3 +83,42 @@ func TestFrameLoggerCanLogEverything(t *testing.T) {
 		t.Errorf("logs = %q, want the speaking frame logged", got)
 	}
 }
+
+// keyedService stands in for a service holding the credentials it was built
+// with. The key is an exported field, which is what a structured handler walks
+// into when it is handed the frame itself.
+type keyedService struct{ APIKey string }
+
+func newKeyedService(apiKey string) *keyedService { return &keyedService{APIKey: apiKey} }
+
+func (s *keyedService) Name() string { return "KeyedSTT" }
+
+// TestFrameLoggerDoesNotWalkIntoAFrame covers the frames that carry a service
+// rather than data: the log line is what the frame says about itself, which
+// names the service it points at. Handing the frame to the logger instead would
+// let a structured handler render its fields, and with them the API key the
+// service was built with.
+func TestFrameLoggerDoesNotWalkIntoAFrame(t *testing.T) {
+	var buf bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+
+	p := processor.NewFrameLogger("Logger")
+	_, down := linkAndStart(t, p)
+
+	svc := newKeyedService("sk-not-in-the-log")
+	f := frames.NewManuallySwitchServiceFrame(svc)
+	if err := p.QueueFrame(context.Background(), f, processor.Downstream); err != nil {
+		t.Fatal(err)
+	}
+	mustReceive[*frames.ManuallySwitchServiceFrame](t, down.got, "ManuallySwitchServiceFrame")
+
+	got := buf.String()
+	if strings.Contains(got, "sk-not-in-the-log") {
+		t.Errorf("logs = %q, want the service's API key left out", got)
+	}
+	if !strings.Contains(got, svc.Name()) {
+		t.Errorf("logs = %q, want the service named", got)
+	}
+}

--- a/service/llm/asynctool.go
+++ b/service/llm/asynctool.go
@@ -74,29 +74,36 @@ func buildCancelToolSchema(functionName string) frames.Tool {
 				"the pending result stale. Call it with no arguments to stop the one running "+
 				"call; only when several %[1]s calls are running does it need a tool_call_id "+
 				"to say which.", functionName),
-		Parameters: json.RawMessage(fmt.Sprintf(`{
-			"type": "object",
-			"properties": {
-				"tool_call_id": {
-					"type": "string",
-					"description": %s
-				}
-			},
-			"required": []
-		}`, cancelToolIDDescription(functionName))),
+		Parameters: cancelToolParameters(functionName),
 	}
 }
 
-// cancelToolIDDescription describes the tool_call_id a cancel tool takes, as a
-// JSON string ready to sit in the schema.
-func cancelToolIDDescription(functionName string) string {
-	described, err := json.Marshal(fmt.Sprintf(
+// cancelToolParameters is the schema for the one argument a cancel tool takes.
+//
+// It is encoded rather than written out as text with the name substituted in,
+// so a function name carrying a quote cannot break out of the string it sits in
+// and reshape the schema around it.
+func cancelToolParameters(functionName string) json.RawMessage {
+	described := fmt.Sprintf(
 		"Which %s call to stop. Needed only when several are running, and carried "+
-			"by the message in the conversation that reported each one running.", functionName))
+			"by the message in the conversation that reported each one running.", functionName)
+	schema, err := json.Marshal(map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"tool_call_id": map[string]any{
+				"type":        "string",
+				"description": described,
+			},
+		},
+		"required": []string{},
+	})
 	if err != nil {
-		return `""`
+		// Strings and maps of them always encode. Fall back to the same shape
+		// without the description rather than to nothing, so the tool still
+		// takes the argument.
+		return json.RawMessage(`{"type":"object","properties":{"tool_call_id":{"type":"string"}},"required":[]}`)
 	}
-	return string(described)
+	return schema
 }
 
 // WithCancellableByLLM says whether the model may cancel this tool's calls while

--- a/service/llm/canceltool_test.go
+++ b/service/llm/canceltool_test.go
@@ -406,3 +406,43 @@ func TestRefusedWhenNoRunningCallHasThatID(t *testing.T) {
 		t.Errorf("reason = %q, want it to say the id matched nothing", reason)
 	}
 }
+
+// TestTheCancelToolSchemaHoldsAnAwkwardName covers the schema being encoded
+// rather than written out with the name pasted into it: a name carrying a quote
+// belongs inside the description, not in the shape of the schema around it.
+func TestTheCancelToolSchemaHoldsAnAwkwardName(t *testing.T) {
+	awkward := `write"report`
+
+	gen := &advertisingGen{}
+	svc := llm.New("FakeLLM", gen)
+	svc.RegisterFunction(awkward, noop,
+		llm.WithCancelOnInterruption(false), llm.WithCancellableByLLM(true))
+
+	var schema struct {
+		Type       string         `json:"type"`
+		Properties map[string]any `json:"properties"`
+		Required   []string       `json:"required"`
+	}
+	var found bool
+	for _, tool := range gen.adapter.WithBuiltins(frames.ToolsSchema{}).Standard {
+		if tool.Name != llm.CancelToolName(awkward) {
+			continue
+		}
+		found = true
+		if err := json.Unmarshal(tool.Parameters, &schema); err != nil {
+			t.Fatalf("the schema did not parse: %v", err)
+		}
+	}
+	if !found {
+		t.Fatal("no cancel tool was advertised for the function")
+	}
+	if schema.Type != "object" {
+		t.Errorf("type = %q, want an object", schema.Type)
+	}
+	if _, ok := schema.Properties["tool_call_id"]; !ok {
+		t.Errorf("properties = %v, want a tool_call_id among them, and nothing else added", schema.Properties)
+	}
+	if len(schema.Properties) != 1 {
+		t.Errorf("properties = %v, want only the tool_call_id", schema.Properties)
+	}
+}


### PR DESCRIPTION
Three CodeQL alerts, two of them real leaks with a test each.

## A debug log formatted the service a frame carried (alert 102, high)

`observers.DebugLog` renders every exported field of a frame, and the frames that carry a service rather than data (a switch, a settings update aimed at one service, a summarizer given its own model) hold the service itself. Rendering it with `%v` wrote out the configuration it was built with:

```
fields="Service: &{0x36beec1dc000 sk-not-in-the-log}"
```

A value that names itself is now rendered by that name. That is what the event registry already does with the object that raised an event, for the reason its comment gives: the object is very often a service holding an API key. Nothing else loses detail, because only services, processors and frames carry a `Name()`, and no frame field holds a frame.

## The frame logger handed the frame to the logger (alert 104, high)

`processor.FrameLogger` put the frame in the line as a value alongside the message, so a structured handler walked its exported fields:

```json
{"msg":"> Frame: ManuallySwitchServiceFrame#2","frame":{"Service":{"APIKey":"sk-not-in-the-log"}}}
```

The message now carries the frame's own rendering, which names the service it points at and stops there. That also drops the extra attribute the line had no reason to carry.

## The cancel tool schema was a text template (alert 101, critical)

Not a leak, and not exploitable as it stood: the description was already run through the JSON encoder, so a quote in a function name was escaped before it reached the template. The alert is a false positive on that path. The schema is now encoded whole rather than pasted together, so its safety no longer rests on knowing that one helper returns its own quotes, and the alert goes with it.

## Left open

`utils/events/events.go:311` (alert 100, high) is a false positive. `sourceName` returns the object's `Name()` or its type name and never formats the object, which its comment already says and is exactly the rule the two fixes above apply. It wants dismissing in the Security tab, not changing.

## Verification

Each fix has a test that fails without it (the schema one pins the shape rather than catching a live bug, since the old path was already safe). `go test ./...`, `go vet ./...` and `golangci-lint run` all pass.