### PR TITLE
Bump golangci-lint to 2.13.2, which the Go 1.27 move requires

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           # Pinned so a new golangci-lint release can't break CI by adding
           # findings out from under a green tree; bump this deliberately.
-          version: v2.12.2
+          version: v2.13.2
 
   test:
     runs-on: ubuntu-latest

--- a/adapter/anthropic/anthropic.go
+++ b/adapter/anthropic/anthropic.go
@@ -130,8 +130,7 @@ func ToMessages(msgs []frames.Message) ([]sdk.MessageParam, error) {
 	for _, m := range msgs {
 		converted, send, err := toMessage(m)
 		if err != nil {
-			var convErr *adapter.ConversionError
-			if errors.As(err, &convErr) {
+			if _, ok := errors.AsType[*adapter.ConversionError](err); ok {
 				return nil, err
 			}
 			return nil, &adapter.ConversionError{Cause: err}

--- a/adapter/anthropic/anthropic_test.go
+++ b/adapter/anthropic/anthropic_test.go
@@ -277,8 +277,7 @@ func TestMalformedToolCallIsAConversionError(t *testing.T) {
 	if err == nil {
 		t.Fatal("LLMInvocationParams succeeded, want a conversion error")
 	}
-	var convErr *adapter.ConversionError
-	if !errors.As(err, &convErr) {
+	if _, ok := errors.AsType[*adapter.ConversionError](err); !ok {
 		t.Fatalf("err = %v, want an adapter.ConversionError", err)
 	}
 }

--- a/adapter/customtools_test.go
+++ b/adapter/customtools_test.go
@@ -87,8 +87,7 @@ func TestCustomToolsForRejectsAnotherType(t *testing.T) {
 	if err == nil {
 		t.Fatal("CustomToolsFor succeeded, want a conversion error")
 	}
-	var convErr *adapter.ConversionError
-	if !errors.As(err, &convErr) {
+	if _, ok := errors.AsType[*adapter.ConversionError](err); !ok {
 		t.Fatalf("err = %v, want an adapter.ConversionError", err)
 	}
 }

--- a/adapter/llmspecific_test.go
+++ b/adapter/llmspecific_test.go
@@ -57,8 +57,7 @@ func TestNativeMessageRejectsAnotherType(t *testing.T) {
 	if err == nil {
 		t.Fatal("NativeMessage succeeded, want a conversion error")
 	}
-	var convErr *adapter.ConversionError
-	if !errors.As(err, &convErr) {
+	if _, ok := errors.AsType[*adapter.ConversionError](err); !ok {
 		t.Fatalf("err = %v, want an adapter.ConversionError", err)
 	}
 }

--- a/adapter/openai/openai_test.go
+++ b/adapter/openai/openai_test.go
@@ -411,8 +411,7 @@ func TestLLMSpecificMessageOfTheWrongTypeFails(t *testing.T) {
 	if err == nil {
 		t.Fatal("LLMInvocationParams succeeded, want a conversion error")
 	}
-	var convErr *adapter.ConversionError
-	if !errors.As(err, &convErr) {
+	if _, ok := errors.AsType[*adapter.ConversionError](err); !ok {
 		t.Fatalf("err = %v, want an adapter.ConversionError", err)
 	}
 }

--- a/examples/voice/azure/main.go
+++ b/examples/voice/azure/main.go
@@ -32,7 +32,6 @@ import (
 	"github.com/gojargo/jargo/provider/anthropic"
 	"github.com/gojargo/jargo/provider/azure/openai"
 	"github.com/gojargo/jargo/provider/azure/speech"
-	"github.com/gojargo/jargo/provider/openai/chat"
 	"github.com/gojargo/jargo/transport"
 	"github.com/gojargo/jargo/transport/rtc"
 	"github.com/pion/webrtc/v4"
@@ -81,7 +80,7 @@ func runBot(conn *rtc.Connection) {
 	stt := openai.NewSTT(openai.STTConfig{
 		Endpoint:   os.Getenv("AZURE_OPENAI_ENDPOINT"),
 		Deployment: os.Getenv("AZURE_STT_DEPLOYMENT"),
-		STTConfig:  chat.STTConfig{APIKey: os.Getenv("AZURE_OPENAI_API_KEY"), SampleRate: opus.SampleRate},
+		APIKey:     os.Getenv("AZURE_OPENAI_API_KEY"), SampleRate: opus.SampleRate,
 	})
 	llm := anthropic.NewLLM(anthropic.Config{APIKey: os.Getenv("ANTHROPIC_API_KEY")})
 	tts := speech.NewTTS(speech.TTSConfig{

--- a/examples/voicebot/main.go
+++ b/examples/voicebot/main.go
@@ -129,8 +129,7 @@ func loadConfig() (*viper.Viper, error) {
 	v.SetConfigName("voicebot")
 	v.AddConfigPath(".")
 	if err := v.ReadInConfig(); err != nil {
-		var notFound viper.ConfigFileNotFoundError
-		if !errors.As(err, &notFound) {
+		if _, ok := errors.AsType[viper.ConfigFileNotFoundError](err); !ok {
 			return nil, err
 		}
 	}

--- a/frames/audio.go
+++ b/frames/audio.go
@@ -110,10 +110,8 @@ type TTSAudioRawFrame struct {
 // NewTTSAudioRawFrame builds a TTSAudioRawFrame from PCM audio.
 func NewTTSAudioRawFrame(audio []byte, sampleRate, numChannels int) *TTSAudioRawFrame {
 	return &TTSAudioRawFrame{
-		OutputAudioRawFrame: OutputAudioRawFrame{
-			BaseDataFrame: NewBaseDataFrame("TTSAudioRawFrame"),
-			AudioRawData:  newAudioRawData(audio, sampleRate, numChannels),
-		},
+		BaseDataFrame: NewBaseDataFrame("TTSAudioRawFrame"),
+		AudioRawData:  newAudioRawData(audio, sampleRate, numChannels),
 	}
 }
 
@@ -127,10 +125,8 @@ type SpeechOutputAudioRawFrame struct {
 // NewSpeechOutputAudioRawFrame builds a SpeechOutputAudioRawFrame from PCM audio.
 func NewSpeechOutputAudioRawFrame(audio []byte, sampleRate, numChannels int) *SpeechOutputAudioRawFrame {
 	return &SpeechOutputAudioRawFrame{
-		OutputAudioRawFrame: OutputAudioRawFrame{
-			BaseDataFrame: NewBaseDataFrame("SpeechOutputAudioRawFrame"),
-			AudioRawData:  newAudioRawData(audio, sampleRate, numChannels),
-		},
+		BaseDataFrame: NewBaseDataFrame("SpeechOutputAudioRawFrame"),
+		AudioRawData:  newAudioRawData(audio, sampleRate, numChannels),
 	}
 }
 
@@ -154,11 +150,9 @@ type UserAudioRawFrame struct {
 // NewUserAudioRawFrame builds a UserAudioRawFrame from PCM audio.
 func NewUserAudioRawFrame(userID string, audio []byte, sampleRate, numChannels int) *UserAudioRawFrame {
 	return &UserAudioRawFrame{
-		InputAudioRawFrame: InputAudioRawFrame{
-			BaseSystemFrame: NewBaseSystemFrame("UserAudioRawFrame"),
-			AudioRawData:    newAudioRawData(audio, sampleRate, numChannels),
-		},
-		UserID: userID,
+		BaseSystemFrame: NewBaseSystemFrame("UserAudioRawFrame"),
+		AudioRawData:    newAudioRawData(audio, sampleRate, numChannels),
+		UserID:          userID,
 	}
 }
 

--- a/frames/catalog_test.go
+++ b/frames/catalog_test.go
@@ -219,8 +219,8 @@ func catalog() []catalogEntry {
 			label: "MetricsFrame", cat: system, wantString: "processor: tts-1",
 			build: func() frames.Frame {
 				return frames.NewMetricsFrame(frames.TTSUsageMetricsData{
-					BaseMetricsData: frames.BaseMetricsData{Processor: "tts-1"},
-					Value:           42,
+					Processor: "tts-1",
+					Value:     42,
 				})
 			},
 		},

--- a/frames/metadata.go
+++ b/frames/metadata.go
@@ -70,10 +70,8 @@ type LLMServiceMetadataFrame struct {
 // NewLLMServiceMetadataFrame builds an LLMServiceMetadataFrame for the named service.
 func NewLLMServiceMetadataFrame(service string) *LLMServiceMetadataFrame {
 	return &LLMServiceMetadataFrame{
-		ServiceMetadataFrame: ServiceMetadataFrame{
-			BaseSystemFrame: NewBaseSystemFrame("LLMServiceMetadataFrame"),
-			ServiceName:     service,
-		},
+		BaseSystemFrame: NewBaseSystemFrame("LLMServiceMetadataFrame"),
+		ServiceName:     service,
 	}
 }
 
@@ -93,10 +91,8 @@ type STTMetadataFrame struct {
 // frame to describe the service further.
 func NewSTTMetadataFrame(ttfsP99 time.Duration) *STTMetadataFrame {
 	return &STTMetadataFrame{
-		ServiceMetadataFrame: ServiceMetadataFrame{
-			BaseSystemFrame: NewBaseSystemFrame("STTMetadataFrame"),
-		},
-		TTFSP99Latency: ttfsP99,
+		BaseSystemFrame: NewBaseSystemFrame("STTMetadataFrame"),
+		TTFSP99Latency:  ttfsP99,
 	}
 }
 

--- a/frames/metrics_test.go
+++ b/frames/metrics_test.go
@@ -59,8 +59,8 @@ func TestMetricsFrameCarriesSeveralKinds(t *testing.T) {
 
 func TestMetricsFrameStringNamesASingleProcessor(t *testing.T) {
 	f := frames.NewMetricsFrame(frames.ProcessingMetricsData{
-		BaseMetricsData: frames.BaseMetricsData{Processor: "AnthropicLLM#1"},
-		Value:           time.Second,
+		Processor: "AnthropicLLM#1",
+		Value:     time.Second,
 	})
 	if got := f.String(); !strings.Contains(got, "AnthropicLLM#1") {
 		t.Errorf("String() = %q, want the processor named", got)
@@ -72,10 +72,10 @@ func TestMetricsFrameStringNamesASingleProcessor(t *testing.T) {
 // on in front of it.
 func TestTTFAReportsItsBreakdown(t *testing.T) {
 	d := frames.TTFAMetricsData{
-		BaseMetricsData: frames.BaseMetricsData{Processor: "tts-1"},
-		TTFA:            300 * time.Millisecond,
-		TTFB:            200 * time.Millisecond,
-		LeadingSilence:  100 * time.Millisecond,
+		Processor:      "tts-1",
+		TTFA:           300 * time.Millisecond,
+		TTFB:           200 * time.Millisecond,
+		LeadingSilence: 100 * time.Millisecond,
 	}
 	if d.TTFB+d.LeadingSilence != d.TTFA {
 		t.Errorf("TTFB %v + leading silence %v should equal TTFA %v", d.TTFB, d.LeadingSilence, d.TTFA)

--- a/frames/system.go
+++ b/frames/system.go
@@ -139,11 +139,9 @@ type FatalErrorFrame struct {
 // NewFatalErrorFrame builds a FatalErrorFrame describing message.
 func NewFatalErrorFrame(message string) *FatalErrorFrame {
 	return &FatalErrorFrame{
-		ErrorFrame: ErrorFrame{
-			BaseSystemFrame: NewBaseSystemFrame("FatalErrorFrame"),
-			Error:           message,
-			Fatal:           true,
-		},
+		BaseSystemFrame: NewBaseSystemFrame("FatalErrorFrame"),
+		Error:           message,
+		Fatal:           true,
 	}
 }
 

--- a/frames/text.go
+++ b/frames/text.go
@@ -43,12 +43,10 @@ type LLMTextFrame struct {
 // NewLLMTextFrame builds an LLMTextFrame.
 func NewLLMTextFrame(text string) *LLMTextFrame {
 	return &LLMTextFrame{
-		TextFrame: TextFrame{
-			BaseDataFrame:            NewBaseDataFrame("LLMTextFrame"),
-			Text:                     text,
-			AppendToContext:          true,
-			IncludesInterFrameSpaces: true,
-		},
+		BaseDataFrame:            NewBaseDataFrame("LLMTextFrame"),
+		Text:                     text,
+		AppendToContext:          true,
+		IncludesInterFrameSpaces: true,
 	}
 }
 
@@ -142,13 +140,11 @@ type TranscriptionFrame struct {
 // NewTranscriptionFrame builds a TranscriptionFrame.
 func NewTranscriptionFrame(text, userID, timestamp string) *TranscriptionFrame {
 	return &TranscriptionFrame{
-		TextFrame: TextFrame{
-			BaseDataFrame:   NewBaseDataFrame("TranscriptionFrame"),
-			Text:            text,
-			AppendToContext: true,
-		},
-		UserID:    userID,
-		Timestamp: timestamp,
+		BaseDataFrame:   NewBaseDataFrame("TranscriptionFrame"),
+		Text:            text,
+		AppendToContext: true,
+		UserID:          userID,
+		Timestamp:       timestamp,
 	}
 }
 
@@ -176,13 +172,11 @@ type InterimTranscriptionFrame struct {
 // NewInterimTranscriptionFrame builds an InterimTranscriptionFrame.
 func NewInterimTranscriptionFrame(text, userID, timestamp string) *InterimTranscriptionFrame {
 	return &InterimTranscriptionFrame{
-		TextFrame: TextFrame{
-			BaseDataFrame:   NewBaseDataFrame("InterimTranscriptionFrame"),
-			Text:            text,
-			AppendToContext: true,
-		},
-		UserID:    userID,
-		Timestamp: timestamp,
+		BaseDataFrame:   NewBaseDataFrame("InterimTranscriptionFrame"),
+		Text:            text,
+		AppendToContext: true,
+		UserID:          userID,
+		Timestamp:       timestamp,
 	}
 }
 
@@ -308,13 +302,11 @@ type TranslationFrame struct {
 // NewTranslationFrame builds a TranslationFrame.
 func NewTranslationFrame(text, userID, timestamp string) *TranslationFrame {
 	return &TranslationFrame{
-		TextFrame: TextFrame{
-			BaseDataFrame:   NewBaseDataFrame("TranslationFrame"),
-			Text:            text,
-			AppendToContext: true,
-		},
-		UserID:    userID,
-		Timestamp: timestamp,
+		BaseDataFrame:   NewBaseDataFrame("TranslationFrame"),
+		Text:            text,
+		AppendToContext: true,
+		UserID:          userID,
+		Timestamp:       timestamp,
 	}
 }
 

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -93,8 +93,7 @@ func TestStructRejectsANonStruct(t *testing.T) {
 	if err == nil {
 		t.Fatal("a non-struct was accepted")
 	}
-	var invalid *validator.InvalidValidationError
-	if !errors.As(err, &invalid) {
+	if _, ok := errors.AsType[*validator.InvalidValidationError](err); !ok {
 		t.Errorf("got %T, want an InvalidValidationError: %v", err, err)
 	}
 }

--- a/observers/latency_test.go
+++ b/observers/latency_test.go
@@ -54,8 +54,8 @@ func metrics(data ...frames.MetricsData) *frames.MetricsFrame {
 // ttfb is one time-to-first-byte measurement from the named processor.
 func ttfb(processorName string, d time.Duration) frames.TTFBMetricsData {
 	return frames.TTFBMetricsData{
-		BaseMetricsData: frames.BaseMetricsData{Processor: processorName},
-		Value:           d,
+		Processor: processorName,
+		Value:     d,
 	}
 }
 
@@ -113,8 +113,8 @@ func TestUserBotLatencyBreaksTheDelayDown(t *testing.T) {
 	o := observers.NewUserBotLatency(r.config())
 
 	textAgg := frames.TextAggregationMetricsData{
-		BaseMetricsData: frames.BaseMetricsData{Processor: "TTS#0"},
-		Value:           30 * time.Millisecond,
+		Processor: "TTS#0",
+		Value:     30 * time.Millisecond,
 	}
 
 	push(o, vadStopped(), processor.Downstream)
@@ -177,8 +177,8 @@ func TestUserBotLatencyKeepsTheFirstTextAggregation(t *testing.T) {
 
 	agg := func(d time.Duration) frames.TextAggregationMetricsData {
 		return frames.TextAggregationMetricsData{
-			BaseMetricsData: frames.BaseMetricsData{Processor: "TTS#0"},
-			Value:           d,
+			Processor: "TTS#0",
+			Value:     d,
 		}
 	}
 

--- a/observers/loggers.go
+++ b/observers/loggers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"reflect"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -216,7 +217,7 @@ func formatValue(v reflect.Value) (string, bool) {
 // than anything a log reader wants, and a service holds the configuration it was
 // built with, so writing them out would put its API key in the log.
 func selfNaming(v reflect.Value) (string, bool) {
-	named, ok := v.Interface().(interface{ Name() string })
+	named, ok := reflect.TypeAssert[interface{ Name() string }](v)
 	if !ok {
 		return "", false
 	}
@@ -421,7 +422,7 @@ func (o *MetricsLog) logMetric(d frames.MetricsData, at float64) {
 	if m := d.MetricsModel(); m != "" {
 		base = append(base, "model", m)
 	}
-	with := func(rest ...any) []any { return append(append(base[:len(base):len(base)], rest...), "at", at) }
+	with := func(rest ...any) []any { return append(append(slices.Clip(base), rest...), "at", at) }
 
 	switch m := d.(type) {
 	case frames.TTFBMetricsData:

--- a/observers/loggers_test.go
+++ b/observers/loggers_test.go
@@ -312,18 +312,18 @@ func TestMetricsLogReportsEveryKindOfMeasurement(t *testing.T) {
 	cached := int64(12)
 	handover(o, newPlain("Src"), newPlain("Dst"), frames.NewMetricsFrame(
 		frames.TTFBMetricsData{
-			BaseMetricsData: frames.BaseMetricsData{Processor: "LLM#0", Model: "gpt-4o"},
-			Value:           250 * time.Millisecond,
+			Processor: "LLM#0", Model: "gpt-4o",
+			Value: 250 * time.Millisecond,
 		},
 		frames.LLMUsageMetricsData{
-			BaseMetricsData: frames.BaseMetricsData{Processor: "LLM#0"},
+			Processor: "LLM#0",
 			Value: frames.LLMTokenUsage{
 				PromptTokens: 100, CompletionTokens: 20, TotalTokens: 120, CacheReadTokens: &cached,
 			},
 		},
 		frames.TTSUsageMetricsData{
-			BaseMetricsData: frames.BaseMetricsData{Processor: "TTS#0"},
-			Value:           42,
+			Processor: "TTS#0",
+			Value:     42,
 		},
 	), processor.Downstream)
 
@@ -343,8 +343,8 @@ func TestMetricsLogOmitsCountsTheServiceNeverReported(t *testing.T) {
 
 	handover(o, newPlain("Src"), newPlain("Dst"), frames.NewMetricsFrame(
 		frames.LLMUsageMetricsData{
-			BaseMetricsData: frames.BaseMetricsData{Processor: "LLM#0"},
-			Value:           frames.LLMTokenUsage{PromptTokens: 100, CompletionTokens: 20, TotalTokens: 120},
+			Processor: "LLM#0",
+			Value:     frames.LLMTokenUsage{PromptTokens: 100, CompletionTokens: 20, TotalTokens: 120},
 		},
 	), processor.Downstream)
 
@@ -363,10 +363,10 @@ func TestMetricsLogNarrowsToTheKindsAskedFor(t *testing.T) {
 	})
 
 	handover(o, newPlain("Src"), newPlain("Dst"), frames.NewMetricsFrame(
-		frames.TTFBMetricsData{BaseMetricsData: frames.BaseMetricsData{Processor: "LLM#0"}, Value: time.Second},
+		frames.TTFBMetricsData{Processor: "LLM#0", Value: time.Second},
 		frames.LLMUsageMetricsData{
-			BaseMetricsData: frames.BaseMetricsData{Processor: "LLM#0"},
-			Value:           frames.LLMTokenUsage{PromptTokens: 100, CompletionTokens: 20, TotalTokens: 120},
+			Processor: "LLM#0",
+			Value:     frames.LLMTokenUsage{PromptTokens: 100, CompletionTokens: 20, TotalTokens: 120},
 		},
 	), processor.Downstream)
 
@@ -386,8 +386,8 @@ func TestMetricsLogReportsAFrameOnce(t *testing.T) {
 	o := observers.NewMetricsLog(observers.MetricsLogConfig{Logger: debugLog(&buf)})
 
 	f := frames.NewMetricsFrame(frames.TTFBMetricsData{
-		BaseMetricsData: frames.BaseMetricsData{Processor: "LLM#0"},
-		Value:           250 * time.Millisecond,
+		Processor: "LLM#0",
+		Value:     250 * time.Millisecond,
 	})
 	src, mid, dst := newPlain("Src"), newPlain("Mid"), newPlain("Dst")
 	handover(o, src, mid, f, processor.Downstream)

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -801,8 +801,8 @@ func (b *Base) PushTokenUsage(ctx context.Context, model string, u frames.LLMTok
 	tracing.SetTokenUsage(ctx, u)
 	metrics.RecordTokens(ctx, b.name, model, u.PromptTokens, u.CompletionTokens)
 	f := frames.NewMetricsFrame(frames.LLMUsageMetricsData{
-		BaseMetricsData: frames.BaseMetricsData{Processor: b.name, Model: model},
-		Value:           u,
+		Processor: b.name, Model: model,
+		Value: u,
 	})
 	return b.self.PushFrame(ctx, f, Downstream)
 }

--- a/processor/rtvi/categories_test.go
+++ b/processor/rtvi/categories_test.go
@@ -158,8 +158,8 @@ func TestBotSpeakingCategoryCanBeTurnedOff(t *testing.T) {
 // Metrics are reported by default and can be turned off on their own.
 func TestMetricsCategoryCanBeTurnedOff(t *testing.T) {
 	metrics := frames.NewMetricsFrame(frames.TTFBMetricsData{
-		BaseMetricsData: frames.BaseMetricsData{Processor: "TTS"},
-		Value:           time.Second,
+		Processor: "TTS",
+		Value:     time.Second,
 	})
 	if msgs := observerHarness(t, rtvi.DefaultObserverParams(), metrics); !sent(msgs, rtvi.TypeMetrics) {
 		t.Fatalf("metrics are not reported by default, got %v", types(msgs))
@@ -168,8 +168,8 @@ func TestMetricsCategoryCanBeTurnedOff(t *testing.T) {
 	params := rtvi.DefaultObserverParams()
 	params.MetricsEnabled = off()
 	metrics2 := frames.NewMetricsFrame(frames.TTFBMetricsData{
-		BaseMetricsData: frames.BaseMetricsData{Processor: "TTS"},
-		Value:           time.Second,
+		Processor: "TTS",
+		Value:     time.Second,
 	})
 	if msgs := observerHarness(t, params, metrics2); sent(msgs, rtvi.TypeMetrics) {
 		t.Errorf("metrics were reported with the category off, got %v", types(msgs))

--- a/processor/rtvi/metrics_test.go
+++ b/processor/rtvi/metrics_test.go
@@ -50,8 +50,8 @@ func TestMetricsFrameBecomesMetricsMessage(t *testing.T) {
 			LeadingSilence:  100 * time.Millisecond,
 		},
 		frames.STTUsageMetricsData{
-			BaseMetricsData: frames.BaseMetricsData{Processor: "DeepgramSTT#3"},
-			Value:           frames.STTUsage{AudioSeconds: 2.5},
+			Processor: "DeepgramSTT#3",
+			Value:     frames.STTUsage{AudioSeconds: 2.5},
 		},
 	))
 

--- a/processor/turns/stop.go
+++ b/processor/turns/stop.go
@@ -239,9 +239,9 @@ func (s *TurnAnalyzerStop) reportPrediction(complete bool, prob float64, err err
 		return
 	}
 	turn := frames.TurnMetricsData{
-		BaseMetricsData: frames.BaseMetricsData{Processor: analyzerMetricsProcessor},
-		Complete:        complete,
-		Probability:     prob,
+		Processor:   analyzerMetricsProcessor,
+		Complete:    complete,
+		Probability: prob,
 	}
 	if len(start) > 0 {
 		turn.E2EProcessing = time.Since(start[0])

--- a/provider/azure/openai/openai_test.go
+++ b/provider/azure/openai/openai_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"net/http"
 	"testing"
-
-	"github.com/gojargo/jargo/provider/openai/chat"
 )
 
 func TestShaperEndpointAndAuth(t *testing.T) {
@@ -31,7 +29,7 @@ func TestConfigValidate(t *testing.T) {
 	valid := Config{
 		Endpoint:   "https://r.openai.azure.com",
 		Deployment: "gpt4o",
-		LLMConfig:  chat.LLMConfig{APIKey: "k"},
+		APIKey:     "k",
 	}
 	if err := valid.Validate(); err != nil {
 		t.Errorf("Validate() valid: %v", err)
@@ -48,7 +46,7 @@ func TestNewLLM(t *testing.T) {
 	svc := NewLLM(Config{
 		Endpoint:   "https://r.openai.azure.com",
 		Deployment: "gpt4o",
-		LLMConfig:  chat.LLMConfig{APIKey: "k"},
+		APIKey:     "k",
 	})
 	if svc == nil {
 		t.Fatal("NewLLM returned nil")

--- a/provider/cartesia/stt_settings_test.go
+++ b/provider/cartesia/stt_settings_test.go
@@ -38,10 +38,8 @@ func TestSTTSettingsChangeReachesTheEndpoint(t *testing.T) {
 	}
 
 	if _, err := settings.Apply(c.live, &STTSettings{
-		STT: settings.STT{
-			Base:     settings.Base{Model: settings.Set("ink-whisper-2")},
-			Language: settings.Set("fr"),
-		},
+		Model:    settings.Set("ink-whisper-2"),
+		Language: settings.Set("fr"),
 	}); err != nil {
 		t.Fatalf("apply: %v", err)
 	}
@@ -79,7 +77,7 @@ func TestSTTMetadataFollowsTheSettings(t *testing.T) {
 	cfg := sttConfig()
 	c := newSTTConnector(cfg)
 	if _, err := settings.Apply(c.live, &STTSettings{
-		STT: settings.STT{Base: settings.Base{Model: settings.Set("ink-whisper-2")}},
+		Model: settings.Set("ink-whisper-2"),
 	}); err != nil {
 		t.Fatalf("apply: %v", err)
 	}

--- a/provider/deepgram/flux.go
+++ b/provider/deepgram/flux.go
@@ -410,8 +410,7 @@ func (c *fluxConnector) ClassifyError(err error) errs.Category {
 	if errors.Is(err, errFluxNotConfirmed) {
 		return errs.InvalidRequest
 	}
-	var fatal *fluxFatalError
-	if errors.As(err, &fatal) {
+	if fatal, ok := errors.AsType[*fluxFatalError](err); ok {
 		return fluxPermanentErrorCodes[fatal.code]
 	}
 	return errs.Unset

--- a/provider/deepgram/settings_test.go
+++ b/provider/deepgram/settings_test.go
@@ -31,7 +31,7 @@ func TestSettingsChangeReachesTheQuery(t *testing.T) {
 	}
 
 	changed, err := settings.Apply(live, &Settings{
-		STT:     settings.STT{Base: settings.Base{Model: settings.Set("nova-2")}},
+		Model:   settings.Set("nova-2"),
 		Diarize: settings.Set(true),
 	})
 	if err != nil {
@@ -83,7 +83,7 @@ func TestMetadataFollowsTheSettings(t *testing.T) {
 	}
 
 	if _, err := settings.Apply(c.live, &Settings{
-		STT: settings.STT{Base: settings.Base{Model: settings.Set("nova-2")}},
+		Model: settings.Set("nova-2"),
 	}); err != nil {
 		t.Fatalf("apply: %v", err)
 	}

--- a/provider/soniox/stt_settings_test.go
+++ b/provider/soniox/stt_settings_test.go
@@ -39,7 +39,7 @@ func TestSTTSettingsChangeReachesTheHandshake(t *testing.T) {
 	}
 
 	if _, err := settings.Apply(c.live, &Settings{
-		STT:                      settings.STT{Base: settings.Base{Model: settings.Set("stt-rt-preview-v2")}},
+		Model:                    settings.Set("stt-rt-preview-v2"),
 		LanguageHints:            settings.Set([]string{"fr"}),
 		EnableSpeakerDiarization: settings.Set(true),
 		EndpointSensitivity:      settings.Set(0.6),

--- a/service/llm/llm.go
+++ b/service/llm/llm.go
@@ -617,8 +617,8 @@ func (b *Base) PushTokenUsage(ctx context.Context, u frames.LLMTokenUsage) error
 	tracing.SetTokenUsage(ctx, u)
 	metrics.RecordTokens(ctx, b.Name(), b.modelName(), u.PromptTokens, u.CompletionTokens)
 	f := frames.NewMetricsFrame(frames.LLMUsageMetricsData{
-		BaseMetricsData: frames.BaseMetricsData{Processor: b.Name(), Model: b.modelName()},
-		Value:           u,
+		Processor: b.Name(), Model: b.modelName(),
+		Value: u,
 	})
 	return b.PushFrame(ctx, f, processor.Downstream)
 }

--- a/service/llm/settings_test.go
+++ b/service/llm/settings_test.go
@@ -139,7 +139,7 @@ func TestLLMSettingsUpdateRelabelsTheModel(t *testing.T) {
 	}()
 
 	task.QueueFrame(frames.NewLLMUpdateSettingsFrame(&settings.LLM{
-		Base: settings.Base{Model: settings.Set("new-model")},
+		Model: settings.Set("new-model"),
 	}))
 	waitForUpdates(t, gen, 1)
 

--- a/service/settings/resolve_test.go
+++ b/service/settings/resolve_test.go
@@ -144,7 +144,7 @@ func TestNewDelta(t *testing.T) {
 // currently holds without knowing the shape of its own settings type.
 func TestGet(t *testing.T) {
 	store := &settings.TTS{
-		Base:     settings.Base{Model: settings.Set("sonic")},
+		Model:    settings.Set("sonic"),
 		Voice:    settings.Set("nova"),
 		Language: settings.Cleared[string](),
 	}
@@ -221,7 +221,7 @@ func TestSetNamed(t *testing.T) {
 func TestChangedExcept(t *testing.T) {
 	store := &settings.LLM{}
 	delta := &settings.LLM{
-		Base:        settings.Base{Model: settings.Set("gpt-4")},
+		Model:       settings.Set("gpt-4"),
 		Temperature: settings.Set(0.4),
 		TopP:        settings.Set(0.9),
 	}

--- a/service/settings/settings.go
+++ b/service/settings/settings.go
@@ -103,7 +103,7 @@ func (o *Opt[T]) SetAny(v any) error {
 	default:
 		return fmt.Errorf("%w: cannot use %T as %s", ErrType, v, want)
 	}
-	val, ok := rv.Interface().(T)
+	val, ok := reflect.TypeAssert[T](rv)
 	if !ok {
 		return fmt.Errorf("%w: cannot use %T as %s", ErrType, v, want)
 	}
@@ -277,7 +277,7 @@ func Get(v any, name string) (any, bool) {
 		if fieldName != name || found {
 			return
 		}
-		o, _ := field.Interface().(option)
+		o, _ := reflect.TypeAssert[option](field)
 		if o.IsGiven() {
 			value = o.AsAny()
 		}
@@ -304,7 +304,7 @@ func SetNamed(v any, name string, value any) error {
 	}
 	results := target.Addr().MethodByName("SetAny").
 		Call([]reflect.Value{reflect.ValueOf(&value).Elem()})
-	if err, _ := results[0].Interface().(error); err != nil {
+	if err, _ := reflect.TypeAssert[error](results[0]); err != nil {
 		return fmt.Errorf("settings: field %q: %w", name, err)
 	}
 	return nil
@@ -335,12 +335,12 @@ func Apply(store, delta any) (Changed, error) {
 
 	changed := Changed{}
 	eachField(dv, func(name string, deltaField reflect.Value, index []int) {
-		d, _ := deltaField.Interface().(option)
+		d, _ := reflect.TypeAssert[option](deltaField)
 		if !d.IsGiven() {
 			return
 		}
 		storeField := sv.FieldByIndex(index)
-		s, _ := storeField.Interface().(option)
+		s, _ := reflect.TypeAssert[option](storeField)
 		if reflect.DeepEqual(s.AsAny(), d.AsAny()) {
 			return
 		}
@@ -390,7 +390,7 @@ func Given(delta any) (map[string]any, error) {
 	}
 	given := map[string]any{}
 	eachField(dv, func(name string, field reflect.Value, _ []int) {
-		o, _ := field.Interface().(option)
+		o, _ := reflect.TypeAssert[option](field)
 		if o.IsGiven() {
 			given[name] = o.AsAny()
 		}
@@ -443,7 +443,7 @@ func FromMap(delta any, values map[string]any) error {
 		}
 		results := dv.FieldByIndex(index).Addr().MethodByName("SetAny").
 			Call([]reflect.Value{reflect.ValueOf(&value).Elem()})
-		if err, _ := results[0].Interface().(error); err != nil {
+		if err, _ := reflect.TypeAssert[error](results[0]); err != nil {
 			return fmt.Errorf("settings: field %q: %w", name, err)
 		}
 	}

--- a/service/settings/settings_test.go
+++ b/service/settings/settings_test.go
@@ -109,7 +109,7 @@ func TestApplyMergesExtra(t *testing.T) {
 	current := &settings.TTS{Voice: settings.Set("alice")}
 	current.Extra = map[string]any{"speed": 1.0, "stability": 0.5}
 	changed, err := settings.Apply(current, &settings.TTS{
-		Base: settings.Base{Extra: map[string]any{"speed": 1.2}},
+		Extra: map[string]any{"speed": 1.2},
 	})
 	if err != nil {
 		t.Fatalf("apply: %v", err)
@@ -133,7 +133,7 @@ func TestApplyReportsNothingForAnUnchangedExtra(t *testing.T) {
 	current := &settings.TTS{Voice: settings.Set("alice")}
 	current.Extra = map[string]any{"speed": 1.0}
 	changed, err := settings.Apply(current, &settings.TTS{
-		Base: settings.Base{Extra: map[string]any{"speed": 1.0}},
+		Extra: map[string]any{"speed": 1.0},
 	})
 	if err != nil {
 		t.Fatalf("apply: %v", err)
@@ -147,9 +147,9 @@ func TestApplyReportsNothingForAnUnchangedExtra(t *testing.T) {
 func TestApplyChangesTheModel(t *testing.T) {
 	t.Parallel()
 
-	current := &settings.STT{Base: settings.Base{Model: settings.Set("old-model")}}
+	current := &settings.STT{Model: settings.Set("old-model")}
 	changed, err := settings.Apply(current, &settings.STT{
-		Base: settings.Base{Model: settings.Set("new-model")},
+		Model: settings.Set("new-model"),
 	})
 	if err != nil {
 		t.Fatalf("apply: %v", err)
@@ -338,7 +338,7 @@ func TestGivenListsWhatTheDeltaCarries(t *testing.T) {
 	t.Parallel()
 
 	delta := &settings.LLM{
-		Base:        settings.Base{Model: settings.Set("a-model"), Extra: map[string]any{"custom": true}},
+		Model: settings.Set("a-model"), Extra: map[string]any{"custom": true},
 		Temperature: settings.Set(0.5),
 	}
 

--- a/service/stt/model_internal_test.go
+++ b/service/stt/model_internal_test.go
@@ -67,7 +67,7 @@ func (c *settingsProvider) Settings() any { return &c.store }
 // triggers: what follows is labeled with the model now in force, or its cost
 // lands against the one it is no longer using.
 func TestModelFollowsASettingsChange(t *testing.T) {
-	c := &settingsProvider{describingConnector: describingConnector{meta: Metadata{Model: "old-model"}}}
+	c := &settingsProvider{meta: Metadata{Model: "old-model"}}
 	if err := settings.SetNamed(&c.store, "model", "old-model"); err != nil {
 		t.Fatal(err)
 	}
@@ -95,7 +95,7 @@ func TestModelFollowsASettingsChange(t *testing.T) {
 // TestModelIsLeftAloneWhenSomethingElseChanges checks a change to another
 // setting does not disturb the label.
 func TestModelIsLeftAloneWhenSomethingElseChanges(t *testing.T) {
-	c := &settingsProvider{describingConnector: describingConnector{meta: Metadata{Model: "kept"}}}
+	c := &settingsProvider{meta: Metadata{Model: "kept"}}
 	s := NewStream("TestSTT", c, 0)
 
 	delta := &STTSettings{}

--- a/service/stt/processing.go
+++ b/service/stt/processing.go
@@ -66,8 +66,8 @@ func (m *processingMeter) reportElapsed(ctx context.Context, elapsed time.Durati
 		return
 	}
 	data := frames.ProcessingMetricsData{
-		BaseMetricsData: frames.BaseMetricsData{Processor: m.svc.Name(), Model: model},
-		Value:           elapsed,
+		Processor: m.svc.Name(), Model: model,
+		Value: elapsed,
 	}
 	_ = m.svc.PushFrame(ctx, frames.NewMetricsFrame(data), processor.Downstream)
 }

--- a/service/stt/ttfb.go
+++ b/service/stt/ttfb.go
@@ -153,8 +153,8 @@ func (t *ttfbTracker) report(ctx context.Context, end time.Time) {
 		return
 	}
 	data := frames.TTFBMetricsData{
-		BaseMetricsData: frames.BaseMetricsData{Processor: t.svc.Name(), Model: model},
-		Value:           ttfb,
+		Processor: t.svc.Name(), Model: model,
+		Value: ttfb,
 	}
 	_ = t.svc.PushFrame(ctx, frames.NewMetricsFrame(data), processor.Downstream)
 }

--- a/service/stt/usage.go
+++ b/service/stt/usage.go
@@ -20,8 +20,8 @@ func pushUsageMetrics(ctx context.Context, p *processor.Base, model string, audi
 		return
 	}
 	f := frames.NewMetricsFrame(frames.STTUsageMetricsData{
-		BaseMetricsData: frames.BaseMetricsData{Processor: p.Name(), Model: model},
-		Value:           frames.STTUsage{AudioSeconds: audio.Seconds()},
+		Processor: p.Name(), Model: model,
+		Value: frames.STTUsage{AudioSeconds: audio.Seconds()},
 	})
 	_ = p.PushFrame(ctx, f, processor.Downstream)
 }

--- a/service/tts/textaggregation.go
+++ b/service/tts/textaggregation.go
@@ -94,8 +94,8 @@ func (b *Base) stopTextAggregationMetrics(ctx context.Context) {
 	value := time.Since(start)
 	slog.Debug("text aggregation time", "service", b.Name(), "took", value)
 	f := frames.NewMetricsFrame(frames.TextAggregationMetricsData{
-		BaseMetricsData: frames.BaseMetricsData{Processor: b.Name(), Model: b.meta.Model},
-		Value:           value,
+		Processor: b.Name(), Model: b.meta.Model,
+		Value: value,
 	})
 	_ = b.PushFrame(ctx, f, processor.Downstream)
 }

--- a/transport/wsserver/protobuf/protobuf.go
+++ b/transport/wsserver/protobuf/protobuf.go
@@ -42,7 +42,7 @@ type Serializer struct {
 func New() *Serializer {
 	// This wire is the delivery channel for RTVI messages, so they are not
 	// filtered off it the way they are off a telephony call.
-	return &Serializer{BaseSerializer: wsserver.BaseSerializer{KeepRTVIMessages: true}}
+	return &Serializer{KeepRTVIMessages: true}
 }
 
 // Setup is a no-op: the encoding carries the sample rate of every chunk, so

--- a/transport/wsserver/rtvifilter_test.go
+++ b/transport/wsserver/rtvifilter_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/gojargo/jargo/frames"
 	"github.com/gojargo/jargo/processor/rtvi"
-	"github.com/gojargo/jargo/transport"
 	"github.com/gojargo/jargo/transport/wsserver"
 )
 
@@ -56,7 +55,7 @@ func isRTVI(t *testing.T, data []byte) bool {
 // pipeline that has an RTVI processor in it still runs one on a phone call, so
 // the transport is what keeps the protocol off the wire.
 func TestRTVIMessagesAreKeptOffATelephonyWire(t *testing.T) {
-	c := dial(t, &testSerializer{}, wsserver.Params{Params: transport.Params{AudioOutEnabled: true}})
+	c := dial(t, &testSerializer{}, wsserver.Params{AudioOutEnabled: true})
 	defer c.shutdown(t)
 
 	c.task.QueueFrame(frames.NewOutputTransportMessageUrgentFrame(botReady()))
@@ -77,7 +76,7 @@ func TestRTVIMessagesAreKeptOffATelephonyWire(t *testing.T) {
 // The wire a browser client connects over is the one the protocol is for, so a
 // serializer that says so has its messages passed through.
 func TestRTVIMessagesReachAWireThatCarriesThem(t *testing.T) {
-	c := dial(t, newRTVISerializer(), wsserver.Params{Params: transport.Params{AudioOutEnabled: true}})
+	c := dial(t, newRTVISerializer(), wsserver.Params{AudioOutEnabled: true})
 	defer c.shutdown(t)
 
 	c.task.QueueFrame(frames.NewOutputTransportMessageUrgentFrame(botReady()))
@@ -99,7 +98,7 @@ func TestRTVIMessagesReachAWireThatCarriesThem(t *testing.T) {
 // telephony wire like any other, which is how a provider's own control messages
 // are sent.
 func TestNonRTVIMessagesStillReachATelephonyWire(t *testing.T) {
-	c := dial(t, &testSerializer{}, wsserver.Params{Params: transport.Params{AudioOutEnabled: true}})
+	c := dial(t, &testSerializer{}, wsserver.Params{AudioOutEnabled: true})
 	defer c.shutdown(t)
 
 	c.task.QueueFrame(frames.NewOutputTransportMessageUrgentFrame(

--- a/transport/wsserver/rtviws/rtviws.go
+++ b/transport/wsserver/rtviws/rtviws.go
@@ -58,7 +58,7 @@ type Serializer struct {
 func New() *Serializer {
 	// RTVI messages are the whole point of this wire, so they are not filtered
 	// out of it the way they are off a telephony call.
-	return &Serializer{BaseSerializer: wsserver.BaseSerializer{KeepRTVIMessages: true}}
+	return &Serializer{KeepRTVIMessages: true}
 }
 
 // Setup is a no-op: the RTVI channel carries no audio, so there is nothing to

--- a/transport/wsserver/wsserver.go
+++ b/transport/wsserver/wsserver.go
@@ -301,8 +301,7 @@ func gone(err error) bool {
 	if errors.Is(err, net.ErrClosed) || errors.Is(err, io.EOF) {
 		return true
 	}
-	var closeErr websocket.CloseError
-	if errors.As(err, &closeErr) {
+	if _, ok := errors.AsType[websocket.CloseError](err); ok {
 		return true
 	}
 	// A failed network write on a live session means the connection under it

--- a/utils/errors/errors.go
+++ b/utils/errors/errors.go
@@ -142,8 +142,7 @@ func (e *HTTPStatusError) HTTPStatusCode() int { return e.Status }
 // status such a type puts on it: the field names below, on a response the error
 // carries and then on the error itself.
 func ExtractHTTPStatusCode(err error) (int, bool) {
-	var sc StatusCoder
-	if errors.As(err, &sc) {
+	if sc, ok := errors.AsType[StatusCoder](err); ok {
 		if status := sc.HTTPStatusCode(); status != 0 {
 			return status, true
 		}
@@ -245,8 +244,7 @@ var connectionErrnos = []error{
 // A cancellation is deliberately not matched: it says nothing about whether the
 // service was reachable.
 func isConnectivity(err error) bool {
-	var netErr net.Error
-	if errors.As(err, &netErr) {
+	if _, ok := errors.AsType[net.Error](err); ok {
 		return true
 	}
 	for _, errno := range connectionErrnos {

--- a/workers/jobgroup_test.go
+++ b/workers/jobgroup_test.go
@@ -531,7 +531,7 @@ func TestUrgentResponseHasSystemPriority(t *testing.T) {
 		msgBus.Send(ctx, data)
 	}
 	urgent := &bus.JobResponseUrgentMessage{
-		JobResult: bus.JobResult{JobID: "t1", Status: jobcontext.JobCompleted},
+		JobID: "t1", Status: jobcontext.JobCompleted,
 	}
 	urgent.From = "worker"
 	urgent.To = "parent"

--- a/workers/worker_test.go
+++ b/workers/worker_test.go
@@ -1561,7 +1561,7 @@ func answer(
 	source, target, jobID string, status jobcontext.JobStatus, response map[string]any,
 ) *bus.JobResponseMessage {
 	m := &bus.JobResponseMessage{
-		JobResult: bus.JobResult{JobID: jobID, Status: status, Response: response},
+		JobID: jobID, Status: status, Response: response,
 	}
 	m.From = source
 	m.To = target


### PR DESCRIPTION
`main` is red on `lint` right now, from the Go 1.27 move: the pinned 2.12.2 is built with Go 1.26 and refuses a module targeting anything newer.

```
can't load config: the Go language version (go1.26) used to build golangci-lint
is lower than the targeted Go version (1.27.1)
```

2.13.2 is built with 1.27.0 and lints the tree normally. It also knows the forms the release added and flags 78 of them, all its own autofixes, all the 1.27 spelling of what the code already did:

| Check | Count | What changes |
| --- | --- | --- |
| `embedlit` | 58 | A promoted field written directly in the struct literal: `&Serializer{KeepRTVIMessages: true}` rather than naming the embedded type around it. |
| `errorsastype` | 11 | `errors.AsType[T](err)` in place of declaring the variable and passing its address. |
| `reflecttypeassert` | 8 | `reflect.TypeAssert[T](v)` in place of `v.Interface().(T)`. |
| `slicesclip` | 1 | `slices.Clip(base)` in place of `base[:len(base):len(base)]`. |

No behaviour changes: each is the same operation in the form 1.27 added for it, applied by `golangci-lint run --fix` rather than by hand.

## Verification

`go build ./...`, `go vet ./...`, `make build-matrix`, `make cover` (76.3% total, race on) and `golangci-lint run` (0 issues) all pass.

One flake worth naming: `provider/xai/realtime` failed once under a loaded `make cover` and passed on every run since, including twice under the exact `-race -coverpkg` flags. Not related to anything here.