### PR TITLE
Do not filter in place the audio another processor pushed

### DIFF
--- a/audio/audio.go
+++ b/audio/audio.go
@@ -19,6 +19,12 @@ import (
 // was given; it returns an empty slice when it has nothing to emit yet.
 // ProcessFrame applies a runtime control frame, so the filter can be retuned or
 // switched off without being torn down.
+//
+// The pcm a filter is handed is read-only. The chunk it came in belongs to a
+// frame, and a frame that has been pushed is being read elsewhere, so a filter
+// that wrote into it would be writing under that reader. Return the filtered
+// audio in a slice of the filter's own, or return the one it was given
+// unchanged.
 type Filter interface {
 	Start(ctx context.Context, sampleRate int) error
 	Stop(ctx context.Context) error

--- a/transport/input.go
+++ b/transport/input.go
@@ -169,7 +169,14 @@ func (bi *BaseInput) ProcessFrame(ctx context.Context, f frames.Frame, dir proce
 		// Audio pushed in from upstream (by the RTVI processor, say) goes down
 		// the same filtering path as audio read from the transport itself,
 		// rather than being forwarded on as a plain frame.
-		bi.PushAudioFrame(ctx, fr)
+		//
+		// It travels as a copy. The filter writes its output back into the
+		// frame it is given, and this frame arrived by being pushed, so an
+		// observer was handed it and reads it on its own goroutine: the write
+		// and that read are the same field. Audio the transport read itself
+		// has never been pushed when it reaches the filter, so it needs none
+		// of this.
+		bi.PushAudioFrame(ctx, unshared(fr))
 		return nil
 	case *frames.EndFrame:
 		// Push EndFrame before stopping, because stopping waits for the audio
@@ -319,6 +326,17 @@ func (bi *BaseInput) applyFilter(ctx context.Context, f *frames.InputAudioRawFra
 	}
 	f.Audio = filtered
 	return len(filtered) > 0
+}
+
+// unshared returns a frame the filtering path may write into, for one that
+// something else is already holding.
+//
+// It keeps the frame's identity, so what travels on is still the frame that was
+// pushed in rather than a new one appearing mid-pipeline, and it shares the
+// audio rather than duplicating it, which a filter only ever reads.
+func unshared(f *frames.InputAudioRawFrame) *frames.InputAudioRawFrame {
+	cp := *f
+	return &cp
 }
 
 func pick(a, b int) int {

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -1712,6 +1712,45 @@ func TestBaseInputFiltersWithPassthroughOff(t *testing.T) {
 	<-runDone
 }
 
+// TestBaseInputDoesNotWriteIntoAPushedFrame covers who owns audio that arrived
+// by being pushed. The filter writes its output back into the frame it is given,
+// and a frame that has been pushed has been handed to the observers too, which
+// read it on their own goroutines. So the filtering path takes a copy, and the
+// frame the caller pushed is left as it was.
+func TestBaseInputDoesNotWriteIntoAPushedFrame(t *testing.T) {
+	params := transport.DefaultParams()
+	params.AudioInSampleRate = 48000
+	params.AudioInPassthrough = false
+	filter := &fakeFilter{}
+	params.AudioInFilter = filter
+
+	in := newFakeInput(params, 0)
+	task := pipeline.NewWorker(pipeline.New(in), pipeline.WorkerConfig{})
+	runDone := make(chan error, 1)
+	go func() { runDone <- task.Run(context.Background()) }()
+
+	audio := []byte{1, 2, 3, 4}
+	f := frames.NewInputAudioRawFrame(audio, 48000, 1)
+	task.QueueFrame(f)
+
+	deadline := time.Now().Add(3 * time.Second)
+	for filter.filtered.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if filter.filtered.Load() == 0 {
+		t.Fatal("the input filter never saw the audio")
+	}
+
+	task.StopWhenDone()
+	<-runDone
+
+	// The fake filter adds one to every byte, so the frame would carry 2,3,4,5
+	// if the filtering path had written into it.
+	if got := f.Audio; !bytes.Equal(got, []byte{1, 2, 3, 4}) {
+		t.Errorf("the pushed frame's audio = %v, want it left at 1,2,3,4", got)
+	}
+}
+
 // wedgedOutput never returns from a write, which is what a peer that has stopped
 // reading looks like: the connection is up and nothing fails, so the only signal
 // available is that the write does not come back.


### PR DESCRIPTION
Fixes the data race that has `test` red on `main`. It predates the Go 1.27 move: it reproduces at `4333387` on Go 1.26, and CI run `33876692929` on that commit already failed the same way.

```
Read  at 0x00c0000b8058  rtvi.(*Observer).audioLevelMessageFor   processor/rtvi/observer.go:400
Write at 0x00c0000b8058  transport.(*BaseInput).applyFilter      transport/input.go:320
```

## What happens

`applyFilter` writes its output back into the frame it is given (`f.Audio = filtered`). An `InputAudioRawFrame` that arrives through `ProcessFrame` got there by being pushed, and a push hands the frame to every observer, each of which reads it on its own goroutine. The RTVI observer reads `fr.AudioRawData` to compute audio levels. Same field, two goroutines.

Audio the transport reads itself goes straight to `PushAudioFrame` and has never been pushed when it reaches the filter, so only the frame arriving from upstream is affected.

## Checked against the reference implementation first

Both halves are faithful ports, which is why the fix goes where it does rather than into either of them:

- `_audio_task_handler` does `frame.audio = await self._params.audio_in_filter.filter(frame.audio)`, mutating the frame in place, exactly as `applyFilter` does. And `process_frame` routes an incoming `InputAudioRawFrame` to `push_audio_frame(frame)`, the same aliasing.
- Observer delivery is asynchronous upstream too: `push_frame` awaits the observer inline, but that observer is a proxy that gives each real observer its own queue and task, which is what `pipeline/observerproxy.go` ports.

So the same aliasing exists upstream. It cannot corrupt anything there: the runtime is single-threaded, and `frame.audio` is `bytes`, which is immutable, so the filter always returns a new object and the attribute is merely rebound. Neither guarantee holds in Go, where the field is a slice header written non-atomically while another goroutine reads it. This is the usual shape of a jargo-specific mechanism: the same design, plus the synchronization a parallel runtime needs.

## The fix

The frame arriving through `ProcessFrame` goes down the filtering path as a copy. The copy keeps the frame's identity, so what travels on is still the frame that was pushed in rather than a new one appearing mid-pipeline, and it shares the audio rather than duplicating it, since a filter only reads it.

`audio.Filter` now says that the pcm a filter is handed is read-only, which is what Python's immutable `bytes` gives upstream for free. Both shipped filters already comply: `noise/gate` returns either the slice it was given or a fresh one, and `noise/rnnoise` copies into its own buffer.

## Verification

The new test pins the ownership rule without depending on the race detector's timing: the fake filter adds one to every byte, and the frame the caller pushed must still read `1,2,3,4` afterwards. Without the fix it fails deterministically with `[2 3 4 5]`.

`make cover` (race on) passes at 76.3%, `golangci-lint run` reports 0 issues, and `go vet` is clean.